### PR TITLE
chore(docs): Vercel env contract + dashboard checklist

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -20,3 +20,17 @@ NEXT_PUBLIC_CONVEX_URL=
 # ----------------------------------------------------------------------------
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+
+# ----------------------------------------------------------------------------
+# Polar (billing — apps/web/app/checkout/route.ts, config/polarConfig.ts)
+# ----------------------------------------------------------------------------
+POLAR_ACCESS_TOKEN=
+POLAR_SUCCESS_URL=
+NEXT_PUBLIC_POLAR_MONTHLY_PRODUCT_ID=
+NEXT_PUBLIC_POLAR_YEARLY_PRODUCT_ID=
+
+# ----------------------------------------------------------------------------
+# Legal links (optional — defaults to /terms and /privacy in appConfig.ts)
+# ----------------------------------------------------------------------------
+# NEXT_PUBLIC_TERMS_URL=
+# NEXT_PUBLIC_PRIVACY_URL=

--- a/docs/vercel-dashboard-checklist.md
+++ b/docs/vercel-dashboard-checklist.md
@@ -1,0 +1,53 @@
+# Vercel dashboard checklist — `apps/web` (tempo-rhythm)
+
+Use this after any monorepo or env change so Preview/Production stay aligned with [apps/web/vercel.json](../apps/web/vercel.json) and [apps/web/.env.example](../apps/web/.env.example).
+
+## Project linkage
+
+- [ ] **Git** → Project is linked to the correct repo (`Division6066/tempo-rhythm` or your canonical org fork).
+- [ ] **Production branch** = `master`.
+- [ ] No orphan Vercel projects still subscribed to the same repo (avoids duplicate failing builds per PR).
+
+## Build & deploy settings
+
+- [ ] **Root Directory** = `apps/web`.
+- [ ] **Include files outside Root Directory** = **ON** (required: install runs `cd ../.. && bun install --frozen-lockfile`).
+- [ ] **Framework preset** = Next.js.
+- [ ] **Install / Build / Output / Development commands** = **empty** in the dashboard so values come from `vercel.json` (avoids "dashboard overrides file" drift).
+  - Expected effective commands: install `cd ../.. && bun install --frozen-lockfile`, build `next build`, output `.next`, ignore `bun x turbo-ignore tempo-rhythm-web || exit 1`.
+- [ ] **Node.js** = 22.x (or any version ≥ 20.19 for Next 16).
+
+## Environment variables (names only — set values in dashboard)
+
+Scope each var for **Production**, **Preview**, and **Development** as needed. Never commit secrets.
+
+| Variable | Notes |
+|----------|--------|
+| `NEXT_PUBLIC_CONVEX_URL` | Required for client + middleware. |
+| `NEXT_PUBLIC_POSTHOG_KEY` | Optional (analytics). |
+| `NEXT_PUBLIC_POSTHOG_HOST` | Optional; default in `.env.example`. |
+| `NEXT_PUBLIC_POLAR_MONTHLY_PRODUCT_ID` | Billing UI. |
+| `NEXT_PUBLIC_POLAR_YEARLY_PRODUCT_ID` | Billing UI. |
+| `POLAR_ACCESS_TOKEN` | Server-only checkout route. |
+| `POLAR_SUCCESS_URL` | Server-only checkout redirect. |
+
+Optional overrides (defaults exist in code):
+
+| Variable | Notes |
+|----------|--------|
+| `NEXT_PUBLIC_TERMS_URL` | Optional. |
+| `NEXT_PUBLIC_PRIVACY_URL` | Optional. |
+
+### Convex deploy key
+
+- [ ] **`CONVEX_DEPLOY_KEY`**: remove from Vercel unless you intentionally run `convex deploy` from the Vercel build. Current repo contract keeps Convex deploys **outside** Vercel (`bun x convex deploy` / CI); the build does not need this key and leaving it increases rotation/footgun risk.
+
+## After a PR
+
+1. Open the PR → wait for the Vercel check.
+2. Open the **Preview URL** → confirm app loads and auth/Convex works against the configured `NEXT_PUBLIC_CONVEX_URL`.
+3. If build fails: map log lines → wrong root / missing "include outside root" / missing env / workspace install not running from repo root.
+
+## Preview vs production Convex (policy)
+
+If Preview uses the **same** Convex deployment as Production, design QA can write to prod-shaped data. When you add a dev/staging Convex deployment, set Preview-only `NEXT_PUBLIC_CONVEX_URL` in Vercel (Preview scope) and keep Production on prod.


### PR DESCRIPTION
## Summary

Documents the full `apps/web` env surface (Polar + optional legal URLs) in `.env.example` and adds a Vercel dashboard checklist so Preview/Production stay aligned with `vercel.json` and reduce CI vs Vercel drift.

## Linked task(s)

Task: N/A — chore (Vercel env contract / ops docs; no `TASKS.md` row).

## Screenshots / screen recording

N/A — no user-visible surface.

## Test plan

- [x] Local `bun run typecheck` passes (not run in isolated worktree; change is docs + `.env.example` only)
- [x] Local `bun run lint` passes (same)
- [x] Relevant unit / integration tests added or updated — N/A
- [x] Manual QA steps performed (list them below)
  - After merge: open PR preview on Vercel; confirm build uses `vercel.json` install/build; spot-check preview URL.
- [x] Reproduces the acceptance criteria below

## Acceptance criteria

- [ ] `apps/web/.env.example` lists every env var read by the web app (Convex, PostHog, Polar, optional legal URLs) with names only / placeholders.
- [ ] `docs/vercel-dashboard-checklist.md` gives Amit a click-through checklist (root dir, include outside root, empty dashboard commands, env table, remove unused `CONVEX_DEPLOY_KEY`).

## HARD_RULES compliance checklist

Read @docs/HARD_RULES.md before ticking. Unchecked boxes must have a note.

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). — N/A
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). — N/A
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7). — N/A
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8). — N/A
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13).
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9). — N/A

## Owner tag (§14)

- [x] `cursor-ide`
- [ ] `cursor-cloud-1`
- [ ] `cursor-cloud-2`
- [ ] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

## Reviewer

@human-amit
