### PR TITLE
feat(T-F000): full frontend port — web + mobile mock screens

### DIFF
--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -1,23 +1,55 @@
 /**
- * @generated-by: T-F008 scaffold — replace with T-F009* port.
  * @screen: onboarding
  * @platform: mobile
  * @source: docs/design/claude-export/design-system/mobile/mobile-screens-b.jsx
- * @summary: Mobile onboarding flow.
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @mutations: users.completeOnboarding
+ * @auth: public
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { Text, View } from "react-native";
+import { useRouter } from "expo-router";
+import { useState } from "react";
+import { Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+const steps = ["Welcome", "Pick theme", "First capture", "Done"] as const;
+
 export default function Screen() {
+  const router = useRouter();
+  const [i, setI] = useState(0);
+
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Onboarding</Text>
-        <Text className="text-sm text-muted-foreground">Mobile onboarding flow.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-b.jsx
+      <View className="flex-1 justify-center gap-4 p-6">
+        <Text className="text-center text-xs text-muted-foreground">
+          Step {i + 1} of {steps.length}
         </Text>
+        <Text className="text-center text-2xl font-semibold text-foreground">{steps[i]}</Text>
+        <Text className="text-center text-sm text-muted-foreground">
+          Tempo meets you where you are. Tap through when ready.
+        </Text>
+        {i < steps.length - 1 ? (
+          <Pressable
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel="Continue onboarding"
+            hitSlop={8}
+            onPress={() => setI((x) => x + 1)}
+            className="rounded-lg bg-primary py-3"
+          >
+            <Text className="text-center text-sm font-medium text-primary-foreground">Continue</Text>
+          </Pressable>
+        ) : (
+          <Pressable
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel="Finish onboarding"
+            hitSlop={8}
+            onPress={() => router.replace("/(tempo)/(tabs)/today" as never)}
+            className="rounded-lg bg-primary py-3"
+          >
+            <Text className="text-center text-sm font-medium text-primary-foreground">Enter app</Text>
+          </Pressable>
+        )}
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tempo)/(tabs)/coach.tsx
+++ b/apps/mobile/app/(tempo)/(tabs)/coach.tsx
@@ -1,23 +1,62 @@
 /**
- * @generated-by: T-F008 scaffold — replace with T-F009* port.
  * @screen: coach
  * @platform: mobile
  * @source: docs/design/claude-export/design-system/mobile/mobile-screens-a.jsx
- * @summary: Coach conversation.
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @queries: messages.listByConversation @index by_conversationId_createdAt
+ * @mutations: messages.appendUser
+ * @auth: required
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { Text, View } from "react-native";
+import { mockCoachMessages, mockCoachScopeSummary } from "@tempo/mock-data";
+import { useState } from "react";
+import { FlatList, Pressable, Text, TextInput, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Screen() {
+  const [draft, setDraft] = useState("");
+
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Coach</Text>
-        <Text className="text-sm text-muted-foreground">Coach conversation.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-a.jsx
-        </Text>
+      <View className="flex-1 gap-2 p-4">
+        <Text className="text-xl font-semibold text-foreground">Coach</Text>
+        <Text className="text-xs text-muted-foreground">{mockCoachScopeSummary}</Text>
+        <FlatList
+          className="flex-1"
+          data={mockCoachMessages}
+          keyExtractor={(m) => m.id}
+          renderItem={({ item }) => (
+            <View
+              className={`mb-2 max-w-[90%] rounded-xl border border-border p-3 ${
+                item.role === "user" ? "self-end bg-surface-inverse" : "self-start bg-card"
+              }`}
+            >
+              <Text className={item.role === "user" ? "text-cream" : "text-foreground"}>{item.body}</Text>
+            </View>
+          )}
+        />
+        <TextInput
+          accessibilityLabel="Message to coach"
+          value={draft}
+          onChangeText={setDraft}
+          placeholder="Reply…"
+          className="rounded-lg border border-border bg-card p-3 text-base text-foreground"
+        />
+        {/*
+          @action sendCoachMessageMobile
+          @mutation: messages.appendUser
+          @auth: required
+          @env: NEXT_PUBLIC_CONVEX_URL
+        */}
+        <Pressable
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Send message"
+          hitSlop={8}
+          onPress={() => setDraft("")}
+          className="rounded-lg bg-primary py-3"
+        >
+          <Text className="text-center text-sm font-medium text-primary-foreground">Send</Text>
+        </Pressable>
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tempo)/(tabs)/notes.tsx
+++ b/apps/mobile/app/(tempo)/(tabs)/notes.tsx
@@ -1,23 +1,39 @@
 /**
- * @generated-by: T-F008 scaffold — replace with T-F009* port.
  * @screen: notes
  * @platform: mobile
  * @source: docs/design/claude-export/design-system/mobile/mobile-screens-a.jsx
- * @summary: Notes list.
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @queries: notes.listByUser @index by_userId_deletedAt
+ * @navigate: note detail (Long Run 2 stack)
+ * @auth: required
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { Text, View } from "react-native";
+import { mockNotes } from "@tempo/mock-data";
+import { FlatList, Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Screen() {
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Notes</Text>
-        <Text className="text-sm text-muted-foreground">Notes list.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-a.jsx
-        </Text>
+      <View className="flex-1 gap-2 p-4">
+        <Text className="text-xl font-semibold text-foreground">Notes</Text>
+        <FlatList
+          data={mockNotes}
+          keyExtractor={(n) => n.id}
+          renderItem={({ item }) => (
+            <Pressable
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel={`Open note ${item.title}`}
+              hitSlop={6}
+              className="rounded-lg border border-border bg-card p-3"
+            >
+              <Text className="font-medium text-foreground">{item.title}</Text>
+              <Text className="mt-1 text-xs text-muted-foreground" numberOfLines={2}>
+                {item.body}
+              </Text>
+            </Pressable>
+          )}
+        />
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tempo)/(tabs)/tasks.tsx
+++ b/apps/mobile/app/(tempo)/(tabs)/tasks.tsx
@@ -1,23 +1,48 @@
 /**
- * @generated-by: T-F008 scaffold — replace with T-F009* port.
  * @screen: tasks
  * @platform: mobile
  * @source: docs/design/claude-export/design-system/mobile/mobile-screens-a.jsx
- * @summary: Tasks list with quick-check.
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @queries: tasks.listByUser @index by_userId_deletedAt
+ * @mutations: tasks.complete
+ * @auth: required
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { Text, View } from "react-native";
+import { mockLibraryTasks } from "@tempo/mock-data";
+import { useState } from "react";
+import { FlatList, Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Screen() {
+  const [tasks, setTasks] = useState(() => mockLibraryTasks.map((t) => ({ ...t, done: t.status === "done" })));
+
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Tasks</Text>
-        <Text className="text-sm text-muted-foreground">Tasks list with quick-check.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-a.jsx
-        </Text>
+      <View className="flex-1 gap-2 p-4">
+        <Text className="text-xl font-semibold text-foreground">Tasks</Text>
+        <FlatList
+          data={tasks}
+          keyExtractor={(t) => t.id}
+          renderItem={({ item }) => (
+            <Pressable
+              accessible
+              accessibilityRole="checkbox"
+              accessibilityState={{ checked: item.done }}
+              accessibilityLabel={item.title}
+              hitSlop={6}
+              onPress={() =>
+                setTasks((prev) =>
+                  prev.map((t) => (t.id === item.id ? { ...t, done: !t.done } : t)),
+                )
+              }
+              className="border-b border-border py-3"
+            >
+              <Text className={item.done ? "text-muted-foreground line-through" : "text-foreground"}>
+                {item.title}
+              </Text>
+              <Text className="text-xs text-muted-foreground">{item.dueLabel}</Text>
+            </Pressable>
+          )}
+        />
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tempo)/(tabs)/today.tsx
+++ b/apps/mobile/app/(tempo)/(tabs)/today.tsx
@@ -1,23 +1,77 @@
 /**
- * @generated-by: T-F008 scaffold — replace with T-F009* port.
  * @screen: today
  * @platform: mobile
  * @source: docs/design/claude-export/design-system/mobile/mobile-screens-a.jsx
- * @summary: Tab home: today capsule + coach suggestion.
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @queries: tasks.listToday @index by_userId_deletedAt (Convex)
+ * @mutations: tasks.complete
+ * @auth: required
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { Text, View } from "react-native";
+import { mockCoachTodayBubble, mockTodayPage, mockTodayTasks } from "@tempo/mock-data";
+import { useRouter } from "expo-router";
+import { useMemo, useState } from "react";
+import { FlatList, Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Screen() {
+  const router = useRouter();
+  const [tasks, setTasks] = useState(() => mockTodayTasks.map((t) => ({ ...t, done: t.status === "done" })));
+  const done = useMemo(() => tasks.filter((t) => t.done).length, [tasks]);
+
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Today</Text>
-        <Text className="text-sm text-muted-foreground">Tab home: today capsule + coach suggestion.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-a.jsx
+      <View className="flex-1 gap-4 p-4">
+        <Text className="font-mono text-xs uppercase text-muted-foreground">{mockTodayPage.dateLabel}</Text>
+        <Text className="text-2xl font-semibold text-foreground">{mockTodayPage.greeting}</Text>
+        <Text className="text-sm leading-relaxed text-muted-foreground">{mockTodayPage.lede}</Text>
+        {/*
+          @action openPlanFromToday
+          @navigate: /plan (stack)
+          @query: planBlocks.listForDay
+          @auth: required
+          @env: NEXT_PUBLIC_CONVEX_URL
+        */}
+        <Pressable
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Plan with Coach"
+          hitSlop={8}
+          onPress={() => router.push("/plan")}
+          className="self-start rounded-lg bg-primary px-4 py-3"
+        >
+          <Text className="text-sm font-medium text-primary-foreground">Plan with Coach</Text>
+        </Pressable>
+        <Text className="text-xs text-muted-foreground">
+          {done} of {tasks.length} things
         </Text>
+        <FlatList
+          data={tasks}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <Pressable
+              accessible
+              accessibilityRole="checkbox"
+              accessibilityState={{ checked: item.done }}
+              accessibilityLabel={`Toggle ${item.title}`}
+              hitSlop={6}
+              onPress={() =>
+                setTasks((prev) =>
+                  prev.map((t) =>
+                    t.id === item.id ? { ...t, done: !t.done } : t,
+                  ),
+                )
+              }
+              className="border-b border-border py-3"
+            >
+              <Text className={item.done ? "text-muted-foreground line-through" : "text-foreground"}>
+                {item.title}
+              </Text>
+            </Pressable>
+          )}
+        />
+        <View className="rounded-xl border border-border bg-card p-3">
+          <Text className="text-sm text-foreground">{mockCoachTodayBubble}</Text>
+        </View>
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tempo)/_layout.tsx
+++ b/apps/mobile/app/(tempo)/_layout.tsx
@@ -9,6 +9,13 @@ export default function TempoLayout() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="(tabs)" />
       <Stack.Screen name="capture" options={{ presentation: "modal" }} />
+      <Stack.Screen name="plan" />
+      <Stack.Screen name="journal" />
+      <Stack.Screen name="habits" />
+      <Stack.Screen name="calendar" />
+      <Stack.Screen name="routines" />
+      <Stack.Screen name="templates" />
+      <Stack.Screen name="settings" />
     </Stack>
   );
 }

--- a/apps/mobile/app/(tempo)/calendar.tsx
+++ b/apps/mobile/app/(tempo)/calendar.tsx
@@ -1,23 +1,37 @@
 /**
- * @generated-by: T-F008 scaffold — replace with T-F009* port.
  * @screen: calendar
  * @platform: mobile
  * @source: docs/design/claude-export/design-system/mobile/mobile-screens-b.jsx
- * @summary: Mobile calendar week view.
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @queries: calendarEvents (Long Run 2)
+ * @auth: required
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { Text, View } from "react-native";
+import { mockCalendarEvents, mockCalendarWeekLabel } from "@tempo/mock-data";
+import { FlatList, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+
+function fmt(ms: number) {
+  return new Date(ms).toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+}
 
 export default function Screen() {
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Calendar</Text>
-        <Text className="text-sm text-muted-foreground">Mobile calendar week view.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-b.jsx
-        </Text>
+      <View className="flex-1 gap-2 p-4">
+        <Text className="text-xl font-semibold text-foreground">Calendar</Text>
+        <Text className="text-xs text-muted-foreground">{mockCalendarWeekLabel}</Text>
+        <FlatList
+          data={mockCalendarEvents}
+          keyExtractor={(e) => e.id}
+          renderItem={({ item }) => (
+            <View className="mb-2 rounded-lg border border-border bg-card p-3">
+              <Text className="font-medium text-foreground">{item.title}</Text>
+              <Text className="text-xs text-muted-foreground">
+                {fmt(item.startAt)} – {fmt(item.endAt)}
+              </Text>
+            </View>
+          )}
+        />
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tempo)/capture.tsx
+++ b/apps/mobile/app/(tempo)/capture.tsx
@@ -1,23 +1,61 @@
 /**
- * @generated-by: T-F008 scaffold — replace with T-F009* port.
  * @screen: capture
  * @platform: mobile
  * @source: docs/design/claude-export/design-system/mobile/mobile-screens-a.jsx
- * @summary: Modal capture composer with voice + text.
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @mutations: tasks.captureQuick (Convex Long Run 2)
+ * @auth: required
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { Text, View } from "react-native";
+import { useRouter } from "expo-router";
+import { useState } from "react";
+import { Pressable, Text, TextInput, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Screen() {
+  const router = useRouter();
+  const [text, setText] = useState("");
+
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Capture</Text>
-        <Text className="text-sm text-muted-foreground">Modal capture composer with voice + text.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-a.jsx
-        </Text>
+      <View className="flex-1 gap-4 p-4">
+        <Text className="text-xl font-semibold text-foreground">Capture</Text>
+        <TextInput
+          accessibilityLabel="Capture text"
+          multiline
+          value={text}
+          onChangeText={setText}
+          placeholder="Type a thought…"
+          className="min-h-32 rounded-lg border border-border bg-card p-3 text-base text-foreground"
+        />
+        {/*
+          @action saveCapture
+          @mutation: tasks.createFromCapture
+          @auth: required
+          @env: NEXT_PUBLIC_CONVEX_URL
+        */}
+        <Pressable
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Save capture"
+          hitSlop={8}
+          onPress={() => router.back()}
+          className="rounded-lg bg-primary px-4 py-3"
+        >
+          <Text className="text-center text-sm font-medium text-primary-foreground">Save</Text>
+        </Pressable>
+        {/*
+          @action dismissCapture
+          @navigate: back
+        */}
+        <Pressable
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Cancel capture"
+          hitSlop={8}
+          onPress={() => router.back()}
+        >
+          <Text className="text-center text-sm text-muted-foreground">Cancel</Text>
+        </Pressable>
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tempo)/habits.tsx
+++ b/apps/mobile/app/(tempo)/habits.tsx
@@ -1,23 +1,37 @@
 /**
- * @generated-by: T-F008 scaffold — replace with T-F009* port.
  * @screen: habits
  * @platform: mobile
  * @source: docs/design/claude-export/design-system/mobile/mobile-screens-b.jsx
- * @summary: Mobile habits with ring rows.
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @queries: habits.listByUser @index by_userId_deletedAt
+ * @mutations: habits.logCompletion
+ * @auth: required
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { Text, View } from "react-native";
+import { mockHabits } from "@tempo/mock-data";
+import { FlatList, Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Screen() {
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Habits</Text>
-        <Text className="text-sm text-muted-foreground">Mobile habits with ring rows.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-b.jsx
-        </Text>
+      <View className="flex-1 gap-2 p-4">
+        <Text className="text-xl font-semibold text-foreground">Habits</Text>
+        <FlatList
+          data={mockHabits}
+          keyExtractor={(h) => h.id}
+          renderItem={({ item }) => (
+            <Pressable
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel={`Log habit ${item.name}`}
+              hitSlop={6}
+              className="flex-row items-center justify-between border-b border-border py-3"
+            >
+              <Text className="text-foreground">{item.name}</Text>
+              <Text className="text-xs text-muted-foreground">{item.streak}d</Text>
+            </Pressable>
+          )}
+        />
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tempo)/journal.tsx
+++ b/apps/mobile/app/(tempo)/journal.tsx
@@ -1,23 +1,60 @@
 /**
- * @generated-by: T-F008 scaffold — replace with T-F009* port.
  * @screen: journal
  * @platform: mobile
  * @source: docs/design/claude-export/design-system/mobile/mobile-screens-b.jsx
- * @summary: Mobile journal.
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @queries: journalEntries (Long Run 2)
+ * @mutations: journalEntries.upsertDay
+ * @auth: required
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { Text, View } from "react-native";
+import { mockJournalEntries, mockJournalPromptTitle, mockJournalTodayDraft } from "@tempo/mock-data";
+import { useState } from "react";
+import { FlatList, Pressable, Text, TextInput, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Screen() {
+  const [draft, setDraft] = useState(mockJournalTodayDraft);
+
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Journal</Text>
-        <Text className="text-sm text-muted-foreground">Mobile journal.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-b.jsx
-        </Text>
+      <View className="flex-1 gap-3 p-4">
+        <Text className="text-xl font-semibold text-foreground">Journal</Text>
+        <Text className="text-xs text-muted-foreground">{mockJournalPromptTitle}</Text>
+        <TextInput
+          accessibilityLabel="Journal draft"
+          multiline
+          value={draft}
+          onChangeText={setDraft}
+          className="min-h-40 rounded-lg border border-border bg-card p-3 text-base text-foreground"
+        />
+        {/*
+          @action saveJournalMobile
+          @mutation: journalEntries.upsertDay
+          @auth: required
+          @env: NEXT_PUBLIC_CONVEX_URL
+        */}
+        <Pressable
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Save journal entry"
+          hitSlop={8}
+          className="rounded-lg bg-primary py-3"
+        >
+          <Text className="text-center text-sm font-medium text-primary-foreground">Save</Text>
+        </Pressable>
+        <Text className="text-sm font-medium text-foreground">Past</Text>
+        <FlatList
+          data={[...mockJournalEntries]}
+          keyExtractor={(e) => e.id}
+          renderItem={({ item }) => (
+            <View className="mb-2 rounded-lg border border-border p-2">
+              <Text className="text-xs text-muted-foreground">{item.date}</Text>
+              <Text className="text-sm text-foreground" numberOfLines={2}>
+                {item.body}
+              </Text>
+            </View>
+          )}
+        />
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tempo)/plan.tsx
+++ b/apps/mobile/app/(tempo)/plan.tsx
@@ -1,0 +1,50 @@
+/**
+ * @screen: plan
+ * @platform: mobile
+ * @source: docs/design/claude-export/design-system/screens-1.jsx
+ * @queries: planBlocks (Long Run 2)
+ * @auth: required
+ * @env: NEXT_PUBLIC_CONVEX_URL
+ */
+import { mockPlanBlocks, mockPlanSummary } from "@tempo/mock-data";
+import { useRouter } from "expo-router";
+import { FlatList, Pressable, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+export default function PlanScreen() {
+  const router = useRouter();
+
+  return (
+    <SafeAreaView className="flex-1 bg-background">
+      <View className="flex-1 gap-3 p-4">
+        {/*
+          @action closePlan
+          @navigate: back to tabs
+        */}
+        <Pressable
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          hitSlop={8}
+          onPress={() => router.back()}
+        >
+          <Text className="text-sm text-primary">← Back</Text>
+        </Pressable>
+        <Text className="text-xl font-semibold text-foreground">Planning</Text>
+        <Text className="text-xs text-muted-foreground">{mockPlanSummary}</Text>
+        <FlatList
+          data={[...mockPlanBlocks]}
+          keyExtractor={(b) => b.id}
+          renderItem={({ item }) => (
+            <View className="mb-2 rounded-lg border border-border bg-card p-3">
+              <Text className="font-medium text-foreground">{item.title}</Text>
+              <Text className="text-xs text-muted-foreground">
+                {item.startLabel}–{item.endLabel}
+              </Text>
+            </View>
+          )}
+        />
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/apps/mobile/app/(tempo)/routines.tsx
+++ b/apps/mobile/app/(tempo)/routines.tsx
@@ -1,23 +1,36 @@
 /**
- * @generated-by: T-F008 scaffold — replace with T-F009* port.
  * @screen: routines
  * @platform: mobile
  * @source: docs/design/claude-export/design-system/mobile/mobile-screens-b.jsx
- * @summary: Mobile routines.
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @queries: routines (Long Run 2)
+ * @auth: required
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { Text, View } from "react-native";
+import { mockRoutines } from "@tempo/mock-data";
+import { FlatList, Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Screen() {
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Routines</Text>
-        <Text className="text-sm text-muted-foreground">Mobile routines.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-b.jsx
-        </Text>
+      <View className="flex-1 gap-2 p-4">
+        <Text className="text-xl font-semibold text-foreground">Routines</Text>
+        <FlatList
+          data={mockRoutines}
+          keyExtractor={(r) => r.id}
+          renderItem={({ item }) => (
+            <Pressable
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel={`Open routine ${item.name}`}
+              hitSlop={6}
+              className="rounded-lg border border-border bg-card p-3"
+            >
+              <Text className="font-medium text-foreground">{item.name}</Text>
+              <Text className="text-xs text-muted-foreground">{item.description}</Text>
+            </Pressable>
+          )}
+        />
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tempo)/settings.tsx
+++ b/apps/mobile/app/(tempo)/settings.tsx
@@ -1,23 +1,38 @@
 /**
- * @generated-by: T-F008 scaffold — replace with T-F009* port.
  * @screen: settings
  * @platform: mobile
  * @source: docs/design/claude-export/design-system/mobile/mobile-screens-b.jsx
- * @summary: Mobile settings.
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @queries: users.getMe
+ * @mutations: users.setPreferences
+ * @auth: required
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { Text, View } from "react-native";
+import { mockUser } from "@tempo/mock-data";
+import { Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Screen() {
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Settings</Text>
-        <Text className="text-sm text-muted-foreground">Mobile settings.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-b.jsx
-        </Text>
+      <View className="flex-1 gap-4 p-4">
+        <Text className="text-xl font-semibold text-foreground">Settings</Text>
+        <Text className="text-sm text-muted-foreground">{mockUser.name}</Text>
+        <Text className="text-xs text-muted-foreground">{mockUser.email}</Text>
+        {/*
+          @action openThemeSettings
+          @mutation: users.setPreferences
+          @auth: required
+          @env: NEXT_PUBLIC_CONVEX_URL
+        */}
+        <Pressable
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel="Theme"
+          hitSlop={8}
+          className="rounded-lg border border-border bg-card p-4"
+        >
+          <Text className="text-foreground">Theme: {mockUser.preferences.theme}</Text>
+        </Pressable>
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tempo)/templates.tsx
+++ b/apps/mobile/app/(tempo)/templates.tsx
@@ -1,23 +1,37 @@
 /**
- * @generated-by: T-F008 scaffold — replace with T-F009* port.
  * @screen: templates
  * @platform: mobile
  * @source: docs/design/claude-export/design-system/mobile/mobile-screens-b.jsx
- * @summary: Mobile templates.
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @queries: templates.listStarters (Long Run 2)
+ * @auth: required
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { Text, View } from "react-native";
+import { mockTemplateStarters } from "@tempo/mock-data";
+import { FlatList, Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Screen() {
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Templates</Text>
-        <Text className="text-sm text-muted-foreground">Mobile templates.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-b.jsx
-        </Text>
+      <View className="flex-1 gap-2 p-4">
+        <Text className="text-xl font-semibold text-foreground">Templates</Text>
+        <FlatList
+          data={[...mockTemplateStarters]}
+          keyExtractor={(t) => t.id}
+          renderItem={({ item }) => (
+            <Pressable
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel={`Run template ${item.name}`}
+              hitSlop={6}
+              className="mb-2 rounded-lg border border-border bg-card p-3"
+            >
+              <Text className="text-lg">{item.emoji}</Text>
+              <Text className="font-medium text-foreground">{item.name}</Text>
+              <Text className="text-xs text-muted-foreground">{item.kicker}</Text>
+            </Pressable>
+          )}
+        />
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -31,6 +31,7 @@
     "@react-navigation/native": "^7.1.8",
     "@rn-primitives/slot": "^1.2.0",
     "@rn-primitives/types": "^1.2.0",
+    "@tempo/mock-data": "workspace:*",
     "@tempo/ui": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/app/(bare)/billing/trial-end/page.tsx
+++ b/apps/web/app/(bare)/billing/trial-end/page.tsx
@@ -1,23 +1,55 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: trial-end
  * @category: Settings
  * @source: docs/design/claude-export/design-system/screens-6.jsx
- * @summary: Anti-shame trial-ended screen (continue / pause / walk-away).
- * @queries: (none)
- * @mutations: (none)
+ * @queries: billing.getSubscriptionState
+ * @mutations: billing.openCheckout
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL, POLAR_ACCESS_TOKEN
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Trial ended"
-      category="Settings"
-      source="screens-6.jsx"
-      summary="Anti-shame trial-ended screen (continue / pause / walk-away)."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-lg space-y-8 p-6 pb-24 md:p-8">
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Trial</p>
+          <h1 className="text-h1 font-serif text-foreground">Your walk paused here.</h1>
+          <p className="mt-2 text-body text-muted-foreground">
+            No shame — pick up when you are ready, or keep a lighter free tier.
+          </p>
+        </header>
+        <SoftCard padding="md" className="space-y-4">
+          {/*
+            @action resumeSubscription
+            @mutation: billing.resume (Long Run 2)
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="primary" className="w-full">
+            Continue with Plus
+          </Button>
+          {/*
+            @action downgradeToFree
+            @mutation: billing.setPlanFree
+            @confirm: undoable 5s
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="ghost" className="w-full">
+            Stay on free
+          </Button>
+        </SoftCard>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(bare)/daily-note/page.tsx
+++ b/apps/web/app/(bare)/daily-note/page.tsx
@@ -1,23 +1,100 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: daily-note
  * @category: Flow
- * @source: docs/design/claude-export/design-system/screens-1.jsx
- * @summary: Distraction-free daily note surface.
- * @queries: journal.getDaily
- * @mutations: journal.updateDaily
+ * @source: docs/design/claude-export/design-system/screens-7.jsx (daily note cues) + mockDailyNote
+ * @queries:
+ *   - notes.getDailyByDate withIndex("by_userId_updatedAt") (Long Run 2; periodType daily)
+ * @mutations:
+ *   - notes.updateBody ({ noteId }) @index by_userId_deletedAt
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { mockDailyNote } from "@tempo/mock-data";
+import { Button, Pill, SoftCard, TaskRow } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [topTasks, setTopTasks] = useState(() =>
+    mockDailyNote.topTasks.map((t) => ({ ...t, done: t.done })),
+  );
+  const [laterTasks, setLaterTasks] = useState(() =>
+    mockDailyNote.laterTasks.map((t) => ({ ...t, done: t.done })),
+  );
+
+  const toggleTop = (id: string, next: boolean) => {
+    setTopTasks((prev) => prev.map((t) => (t.id === id ? { ...t, done: next } : t)));
+  };
+  const toggleLater = (id: string, next: boolean) => {
+    setLaterTasks((prev) => prev.map((t) => (t.id === id ? { ...t, done: next } : t)));
+  };
+
   return (
-    <ScaffoldScreen
-      title="Daily note"
-      category="Flow"
-      source="screens-1.jsx"
-      summary="Distraction-free daily note surface."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-3xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="space-y-2">
+          <p className="font-eyebrow text-muted-foreground">{mockDailyNote.fileName}</p>
+          <h1 className="text-h1 font-serif text-foreground">{mockDailyNote.headline}</h1>
+          <p className="text-caption text-muted-foreground">{mockDailyNote.streakLabel}</p>
+        </header>
+
+        <SoftCard tone="sunken" padding="md">
+          <p className="text-body leading-relaxed text-foreground">{mockDailyNote.coachGreeting}</p>
+        </SoftCard>
+
+        <section aria-labelledby="dn-top-label">
+          <h2 id="dn-top-label" className="mb-3 font-eyebrow text-muted-foreground">
+            Top of mind
+          </h2>
+          <SoftCard padding="none" className="divide-y divide-border-soft border-border-soft">
+            {topTasks.map((t) => (
+              <TaskRow
+                key={t.id}
+                taskId={t.id}
+                title={t.title}
+                done={t.done}
+                meta={[t.time, t.tag, t.energy].filter(Boolean).join(" · ")}
+                onToggle={(id, next) => toggleTop(id, next)}
+                trailing={t.tag ? <Pill tone="slate">{t.tag}</Pill> : null}
+              />
+            ))}
+          </SoftCard>
+        </section>
+
+        <section aria-labelledby="dn-later-label">
+          <h2 id="dn-later-label" className="mb-3 font-eyebrow text-muted-foreground">
+            Later
+          </h2>
+          <SoftCard padding="none" className="divide-y divide-border-soft border-border-soft">
+            {laterTasks.map((t) => (
+              <TaskRow
+                key={t.id}
+                taskId={t.id}
+                title={t.title}
+                done={t.done}
+                meta={t.tag ?? ""}
+                onToggle={(id, next) => toggleLater(id, next)}
+                trailing={t.tag ? <Pill tone="neutral">{t.tag}</Pill> : null}
+              />
+            ))}
+          </SoftCard>
+        </section>
+
+        {/*
+          @action saveDailyNote
+          @mutation: notes.upsertDaily ({ date, bodyMarkdown }) @index by_userId_updatedAt
+          @soft-delete: no
+          @auth: required
+          @errors: toast
+          @env: NEXT_PUBLIC_CONVEX_URL
+        */}
+        <Button type="button" variant="primary" className="w-full sm:w-auto">
+          Save note
+        </Button>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(bare)/onboarding/page.tsx
+++ b/apps/web/app/(bare)/onboarding/page.tsx
@@ -1,24 +1,92 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: onboarding
  * @category: Onboarding
- * @source: docs/design/claude-export/design-system/screens-7.jsx
- * @summary: 5-step onboarding (welcome → personalization → template → first brain dump → first plan).
- * @queries: (none)
- * @mutations: users.completeOnboarding
+ * @source: docs/design/claude-export/design-system/screens-7.jsx (flow cues)
+ * @summary: Five-step onboarding — welcome, personalization, template pick, first brain dump, first plan.
+ * @mutations: users.completeOnboarding @table users @index by_deletedAt
  * @routes-to: /today
- * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @auth: public (pre-account) or required (resume) — Convex Auth resolves in Long Run 2
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
+
+const steps = [
+  {
+    title: "Welcome",
+    body: "Tempo is a quiet place for messy brains. No streak shame, no hustle language — just the next small thing.",
+  },
+  {
+    title: "Personalization",
+    body: "Pick a warmth dial and theme. You can change this anytime in settings.",
+  },
+  {
+    title: "Pick a template",
+    body: "Start with Weekly Review or Morning Pages — both are gentle on-rails.",
+  },
+  {
+    title: "First brain dump",
+    body: "Type everything on your mind. Sorting comes after you breathe.",
+  },
+  {
+    title: "First plan",
+    body: "Coach suggests a light day — you approve every block.",
+  },
+] as const;
 
 export default function Page() {
+  const router = useRouter();
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [step, setStep] = useState(0);
+
+  const isLast = step === steps.length - 1;
+
   return (
-    <ScaffoldScreen
-      title="Onboarding"
-      category="Onboarding"
-      source="screens-7.jsx"
-      summary="5-step onboarding (welcome → personalization → template → first brain dump → first plan)."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto flex min-h-[70vh] max-w-lg flex-col justify-center p-6 pb-24 md:p-8">
+        <p className="mb-2 font-eyebrow text-muted-foreground">
+          Step {step + 1} of {steps.length}
+        </p>
+        <SoftCard padding="lg" className="space-y-4">
+          <h1 className="text-h1 font-serif text-foreground">{steps[step].title}</h1>
+          <p className="text-body leading-relaxed text-muted-foreground">{steps[step].body}</p>
+          <div className="flex flex-wrap gap-2 pt-4">
+            {/*
+              @action onboardingBack
+              @mutation: none
+              @navigate: none
+              @auth: public
+              @env: NEXT_PUBLIC_CONVEX_URL
+            */}
+            <Button type="button" variant="ghost" disabled={step === 0} onClick={() => setStep((s) => Math.max(0, s - 1))}>
+              Back
+            </Button>
+            {!isLast ? (
+              <Button type="button" variant="primary" onClick={() => setStep((s) => s + 1)}>
+                Continue
+              </Button>
+            ) : (
+              <>
+                {/*
+                  @action completeOnboarding
+                  @mutation: users.completeOnboarding @index by_email
+                  @navigate: /today
+                  @auth: required
+                  @errors: toast
+                  @env: NEXT_PUBLIC_CONVEX_URL
+                */}
+                <Button type="button" variant="primary" onClick={() => router.push("/today")}>
+                  Enter Tempo
+                </Button>
+              </>
+            )}
+          </div>
+        </SoftCard>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(bare)/templates/builder/page.tsx
+++ b/apps/web/app/(bare)/templates/builder/page.tsx
@@ -1,23 +1,51 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: template-builder
- * @category: You
- * @source: docs/design/claude-export/design-system/screens-template-builder.jsx + -ui.jsx + -slash.jsx
- * @summary: Full-screen template builder with slash command DSL.
- * @queries: templates.get
- * @mutations: templates.save
+ * @category: You (bare shell)
+ * @source: docs/design/claude-export/design-system/screens-template-builder.jsx
+ * @queries: templates.getDraft (Long Run 2)
+ * @mutations: templates.saveDraft
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button, Field, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const router = useRouter();
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [name, setName] = useState("Untitled template");
+
   return (
-    <ScaffoldScreen
-      title="Template builder"
-      category="You"
-      source="screens-template-builder.jsx + -ui.jsx + -slash.jsx"
-      summary="Full-screen template builder with slash command DSL."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-3xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="flex items-center justify-between gap-4">
+          <h1 className="text-h1 font-serif text-foreground">Template builder</h1>
+          <Button type="button" variant="ghost" size="sm" onClick={() => router.push("/templates")}>
+            Close
+          </Button>
+        </header>
+        <SoftCard padding="md" className="space-y-4">
+          <Field label="Name" name="name" value={name} onChange={(e) => setName(e.target.value)} />
+          <p className="text-small text-muted-foreground">
+            Add steps on the left, preview on the right — Long Run 2 persists templateItems in Convex.
+          </p>
+          {/*
+            @action saveTemplateDraft
+            @mutation: templates.saveDraft (Long Run 2)
+            @index: n/a until schema
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="primary">
+            Save draft
+          </Button>
+        </SoftCard>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(bare)/templates/run/[id]/page.tsx
+++ b/apps/web/app/(bare)/templates/run/[id]/page.tsx
@@ -1,30 +1,100 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: template-run
- * @category: You
+ * @category: You (bare shell)
  * @source: docs/design/claude-export/design-system/screens-template-run.jsx
- * @summary: Runs a template step by step.
- * @queries: templates.get
- * @mutations: templates.logRun
+ * @queries: templates.getById, templateRuns.getActive (Long Run 2)
+ * @mutations: templateRuns.completeStep, templateRuns.finish
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
 
-type Params = { id: string };
+import { useParams, useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { mockMyTemplates, mockRoutines, mockTemplateStarters } from "@tempo/mock-data";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<Params>;
-}) {
-  const { id } = await params;
+function resolveTemplate(id: string) {
+  const starter = mockTemplateStarters.find((t) => t.id === id);
+  if (starter) {
+    return { title: starter.name, steps: mockRoutines.find((r) => r.id === "routine-weekly")?.steps ?? [] };
+  }
+  const mine = mockMyTemplates.find((t) => t.id === id);
+  if (mine) {
+    return {
+      title: mine.name,
+      steps: mockRoutines.find((r) => r.id === "routine-morning")?.steps ?? [],
+    };
+  }
+  return { title: "Template", steps: mockRoutines[0]?.steps ?? [] };
+}
+
+export default function Page() {
+  const params = useParams();
+  const router = useRouter();
+  const id = typeof params.id === "string" ? params.id : "";
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [idx, setIdx] = useState(0);
+
+  const { title, steps } = useMemo(() => resolveTemplate(id), [id]);
+  const step = steps[idx];
+  const total = steps.length;
+
   return (
-    <ScaffoldScreen
-      title="Template run"
-      category="You"
-      source="screens-template-run.jsx"
-      summary={`Runs a template step by step. (id: ${id})`}
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-lg space-y-8 p-6 pb-24 md:p-8">
+        <div className="flex items-center justify-between gap-2">
+          <h1 className="font-serif text-2xl text-foreground">{title}</h1>
+          <Button type="button" variant="ghost" size="sm" onClick={() => router.push("/templates")}>
+            Exit
+          </Button>
+        </div>
+        <p className="text-caption text-muted-foreground">
+          Step {Math.min(idx + 1, Math.max(total, 1))} of {Math.max(total, 1)}
+        </p>
+        {step ? (
+          <SoftCard padding="lg">
+            <p className="font-medium text-foreground">{step.title}</p>
+            <p className="mt-2 text-caption text-muted-foreground">{step.durationMin} min</p>
+          </SoftCard>
+        ) : (
+          <SoftCard padding="md">
+            <p className="text-muted-foreground">No steps in mock for this id.</p>
+          </SoftCard>
+        )}
+        <div className="flex gap-2">
+          {/*
+            @action templateRunPrevious
+            @mutation: templateRuns.seek (Long Run 2)
+            @auth: required
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="soft" disabled={idx === 0} onClick={() => setIdx((i) => Math.max(0, i - 1))}>
+            Back
+          </Button>
+          {/*
+            @action templateRunNext
+            @mutation: templateRuns.advanceStep
+            @auth: required
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button
+            type="button"
+            variant="primary"
+            className="flex-1"
+            onClick={() => {
+              if (idx < total - 1) {
+                setIdx((i) => i + 1);
+              } else {
+                router.push("/templates");
+              }
+            }}
+          >
+            {idx < total - 1 ? "Next" : "Done"}
+          </Button>
+        </div>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/activity/page.tsx
+++ b/apps/web/app/(tempo)/activity/page.tsx
@@ -1,23 +1,38 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: activity
  * @category: You
  * @source: docs/design/claude-export/design-system/screens-5.jsx
- * @summary: Activity feed of changes.
- * @queries: activity.list
- * @mutations: (none)
+ * @queries: auditEvents.listRecent (Long Run 2; @todo: requires schema add auditEvents)
+ * @mutations: none
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { mockActivityLines } from "@tempo/mock-data";
+import { SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Recent activity"
-      category="You"
-      source="screens-5.jsx"
-      summary="Activity feed of changes."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-3xl space-y-8 p-6 pb-24 md:p-8">
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Recent activity</p>
+          <h1 className="text-h1 font-serif text-foreground">What changed recently.</h1>
+        </header>
+        <SoftCard padding="none" className="divide-y divide-border-soft">
+          {mockActivityLines.map((a) => (
+            <div key={a.id} className="flex items-center justify-between gap-4 px-4 py-3">
+              <p className="text-small text-foreground">{a.text}</p>
+              <span className="shrink-0 font-tabular text-caption text-muted-foreground">{a.at}</span>
+            </div>
+          ))}
+        </SoftCard>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/ask-founder/page.tsx
+++ b/apps/web/app/(tempo)/ask-founder/page.tsx
@@ -1,23 +1,53 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: ask-founder
  * @category: Settings
  * @source: docs/design/claude-export/design-system/screens-6.jsx
- * @summary: Direct channel to send feedback.
- * @queries: (none)
- * @mutations: feedback.send
+ * @queries: none
+ * @mutations: feedback.submitToFounder (Long Run 2; @todo: requires schema add feedback)
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [message, setMessage] = useState("");
+
   return (
-    <ScaffoldScreen
-      title="Ask the founder"
-      category="Settings"
-      source="screens-6.jsx"
-      summary="Direct channel to send feedback."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-xl space-y-8 p-6 pb-24 md:p-8">
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Ask the founder</p>
+          <h1 className="text-h1 font-serif text-foreground">One honest note.</h1>
+        </header>
+        <SoftCard padding="md">
+          <label htmlFor="founder-msg" className="sr-only">
+            Message
+          </label>
+          <textarea
+            id="founder-msg"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            rows={8}
+            placeholder="What would make Tempo kinder for your Tuesdays?"
+            className="w-full resize-y rounded-lg border border-border bg-transparent p-3 font-serif text-body text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+          {/*
+            @action sendFounderMessage
+            @mutation: feedback.submit ({ body }) (Long Run 2)
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="primary" className="mt-4">
+            Send
+          </Button>
+        </SoftCard>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/billing/page.tsx
+++ b/apps/web/app/(tempo)/billing/page.tsx
@@ -1,23 +1,59 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: billing
  * @category: Settings
  * @source: docs/design/claude-export/design-system/screens-6.jsx
- * @summary: Trial countdown + RevenueCat entitlement status.
- * @queries: billing.status
- * @mutations: (none)
+ * @queries: billing.getSubscriptionState (Long Run 2; RevenueCat webhook → Convex)
+ * @mutations: billing.openCheckout (Polar server route; POLAR_ACCESS_TOKEN server-only on Vercel)
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL, POLAR_ACCESS_TOKEN (server), NEXT_PUBLIC_POLAR_MONTHLY_PRODUCT_ID
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { mockBillingCopy, mockUser } from "@tempo/mock-data";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Trial & billing"
-      category="Settings"
-      source="screens-6.jsx"
-      summary="Trial countdown + RevenueCat entitlement status."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-xl space-y-8 p-6 pb-24 md:p-8">
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Billing</p>
+          <h1 className="text-h1 font-serif text-foreground">{mockBillingCopy.headline}</h1>
+          <p className="mt-2 text-body text-muted-foreground">{mockBillingCopy.lede}</p>
+        </header>
+        <SoftCard padding="md" className="space-y-3">
+          <p className="text-small text-muted-foreground">
+            Trial day {mockBillingCopy.trialDay} of {mockBillingCopy.trialTotalDays} · {mockBillingCopy.daysLeft}{" "}
+            days left
+          </p>
+          <div
+            className="h-2 w-full overflow-hidden rounded-full bg-surface-sunken"
+            role="progressbar"
+            aria-valuenow={mockBillingCopy.progressPct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <div className="h-full bg-primary" style={{ width: `${mockBillingCopy.progressPct}%` }} />
+          </div>
+          <p className="text-caption text-muted-foreground">
+            Logged in as {mockUser.email} · plan flag (mock): {mockUser.isPremium ? "Plus" : "Free"}
+          </p>
+          {/*
+            @action openPolarCheckout
+            @mutation: none (redirect to Polar checkout via Next route; server uses POLAR_ACCESS_TOKEN)
+            @auth: required
+            @errors: toast
+            @env: POLAR_ACCESS_TOKEN, NEXT_PUBLIC_POLAR_MONTHLY_PRODUCT_ID
+          */}
+          <Button type="button" variant="primary">
+            Continue with Tempo Plus
+          </Button>
+        </SoftCard>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/brain-dump/page.tsx
+++ b/apps/web/app/(tempo)/brain-dump/page.tsx
@@ -1,23 +1,213 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: brain-dump
  * @category: Flow
- * @source: docs/design/claude-export/design-system/screens-1.jsx
- * @summary: Rapid capture with auto-sort suggestions.
- * @queries: inbox.list
- * @mutations: inbox.capture, inbox.sort
+ * @source: docs/design/claude-export/design-system/screens-1.jsx:L113-L205
+ * @queries: none (RAM-only scan in Long Run 2; never persist raw dump per HARD_RULES)
+ * @mutations:
+ *   - brainDump.sortInMemory then tasks.create proposals (@todo: requires schema add brainDumpItems + proposal flow)
+ * @routes-to: /tasks (after accept)
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  mockBrainDumpDefaultText,
+  mockBrainDumpPrompts,
+  mockBrainDumpSortedItems,
+} from "@tempo/mock-data";
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
+import { Mic, Sparkles } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
+
+function toneFor(t: (typeof mockBrainDumpSortedItems)[0]["type"]) {
+  const map = {
+    task: "orange" as const,
+    reminder: "slate" as const,
+    idea: "moss" as const,
+    worry: "amber" as const,
+    note: "neutral" as const,
+  };
+  return map[t];
+}
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [text, setText] = useState(mockBrainDumpDefaultText);
+  const [processed, setProcessed] = useState(true);
+
+  const wordCount = useMemo(() => {
+    const w = text.trim().split(/\s+/).filter(Boolean);
+    return w.length;
+  }, [text]);
+
   return (
-    <ScaffoldScreen
-      title="Brain dump"
-      category="Flow"
-      source="screens-1.jsx"
-      summary="Rapid capture with auto-sort suggestions."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-6xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="space-y-2">
+          <p className="font-eyebrow text-muted-foreground">Brain Dump</p>
+          <h1 className="text-h1 font-serif text-foreground">Everything on your mind.</h1>
+          <p className="max-w-2xl text-body leading-relaxed text-muted-foreground">
+            Don&apos;t organize it. Just type. I&apos;ll sort it into tasks, reminders, ideas, and worries
+            — then you approve what sticks.
+          </p>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+          <SoftCard padding="md">
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <h2 className="text-h3 font-serif text-foreground">Dump</h2>
+              <div className="flex items-center gap-2">
+                {/*
+                  @action startVoiceDictation
+                  @action-call: voice.startDictation (RAM-only pipeline; no raw persist)
+                  @auth: required
+                  @errors: toast mic permission
+                  @env: NEXT_PUBLIC_CONVEX_URL
+                  @source: screens-1.jsx:L143
+                */}
+                <Button type="button" variant="ghost" size="sm" aria-label="Dictate" title="Dictate">
+                  <Mic size={16} />
+                </Button>
+                <span className="text-caption font-tabular text-muted-foreground">
+                  {text.length} chars · {wordCount} words
+                </span>
+              </div>
+            </div>
+            <label htmlFor="brain-dump-text" className="sr-only">
+              Brain dump text
+            </label>
+            <textarea
+              id="brain-dump-text"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={12}
+              className="min-h-[280px] w-full resize-y rounded-lg border border-border bg-transparent px-0 py-2 font-serif text-lg leading-relaxed text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+            <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <span className="text-caption text-muted-foreground">
+                End-to-end encrypted. Only you see this.
+              </span>
+              {/*
+                @action sortBrainDump
+                @mutation: brainDump.proposeSortedItems (RAM-only input; proposals only to tasks table after confirm)
+                @index: n/a until schema
+                @soft-delete: n/a
+                @auth: required
+                @errors: toast
+                @env: NEXT_PUBLIC_CONVEX_URL
+                @source: screens-1.jsx:L153
+              */}
+              <Button
+                type="button"
+                variant="primary"
+                leadingIcon={<Sparkles size={14} />}
+                onClick={() => setProcessed(true)}
+              >
+                Sort it
+              </Button>
+            </div>
+          </SoftCard>
+
+          <div className="space-y-6">
+            <SoftCard padding="md">
+              <p className="mb-3 font-eyebrow text-muted-foreground">Gentle prompts</p>
+              <div className="space-y-2">
+                {mockBrainDumpPrompts.map((q) => (
+                  <div
+                    key={q}
+                    className="rounded-lg bg-surface-sunken px-3 py-2.5 font-serif text-small leading-relaxed text-foreground"
+                  >
+                    {q}
+                  </div>
+                ))}
+              </div>
+            </SoftCard>
+            <SoftCard tone="sunken" padding="md">
+              <p className="font-eyebrow text-muted-foreground">Privacy</p>
+              <p className="mt-2 text-small text-muted-foreground">
+                Raw dumps never leave Convex. Only sorted items are written to your library — and only after
+                you approve them.
+              </p>
+            </SoftCard>
+          </div>
+        </div>
+
+        {processed ? (
+          <SoftCard padding="md">
+            <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="font-eyebrow text-muted-foreground">Sorted — 7 items</p>
+                <h3 className="text-h3 font-serif text-foreground">Review and approve</h3>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {/*
+                  @action approveAllSorted
+                  @mutation: tasks.bulkCreateFromBrainDump (Long Run 2; @todo: requires schema add)
+                  @confirm: undoable 5s
+                  @auth: required
+                  @errors: toast
+                  @env: NEXT_PUBLIC_CONVEX_URL
+                  @source: screens-1.jsx:L181
+                */}
+                <Button type="button" variant="soft" size="sm">
+                  Approve all
+                </Button>
+                {/*
+                  @action skipAllSorted
+                  @mutation: none
+                  @auth: required
+                  @source: screens-1.jsx:L182
+                */}
+                <Button type="button" variant="ghost" size="sm">
+                  Skip all
+                </Button>
+              </div>
+            </div>
+            <ul className="space-y-2">
+              {mockBrainDumpSortedItems.map((it, i) => (
+                <li
+                  key={`${it.text}-${i}`}
+                  className="flex flex-col gap-3 rounded-lg bg-surface-sunken p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <Pill tone={toneFor(it.type)}>{it.type}</Pill>
+                    <span className="text-small text-foreground">{it.text}</span>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-caption font-tabular text-muted-foreground">
+                      {Math.round(it.confidence * 100)}%
+                    </span>
+                    {/*
+                      @action acceptSortedItem
+                      @mutation: tasks.create({ title, source: brain_dump }) @index by_userId_deletedAt
+                      @soft-delete: no
+                      @confirm: undoable 5s
+                      @auth: required
+                      @errors: toast
+                      @env: NEXT_PUBLIC_CONVEX_URL
+                      @source: screens-1.jsx:L194
+                    */}
+                    <Button type="button" size="sm" variant="primary">
+                      Accept
+                    </Button>
+                    {/*
+                      @action skipSortedItem
+                      @mutation: none
+                      @auth: required
+                      @source: screens-1.jsx:L195
+                    */}
+                    <Button type="button" size="sm" variant="ghost">
+                      Skip
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </SoftCard>
+        ) : null}
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/calendar/page.tsx
+++ b/apps/web/app/(tempo)/calendar/page.tsx
@@ -1,23 +1,87 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: calendar
  * @category: Library
- * @source: docs/design/claude-export/design-system/screens-3.jsx
- * @summary: Week + month calendar with task overlay.
- * @queries: calendar.list
- * @mutations: calendar.schedule
+ * @source: docs/design/claude-export/design-system/screens-2.jsx / screens-3.jsx
+ * @queries: calendarEvents.listRange (Long Run 2; @todo: requires schema add calendarEvents)
+ * @mutations: calendarEvents.createExternalLink (Long Run 2)
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useMemo, useState } from "react";
+import { mockCalendarEvents, mockCalendarWeekLabel } from "@tempo/mock-data";
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
+
+function formatTime(ms: number): string {
+  const d = new Date(ms);
+  return d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+}
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, typeof mockCalendarEvents>();
+    for (const ev of mockCalendarEvents) {
+      const day = new Date(ev.startAt).toLocaleDateString(undefined, {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+      });
+      const list = map.get(day) ?? [];
+      list.push(ev);
+      map.set(day, list);
+    }
+    return [...map.entries()];
+  }, []);
+
   return (
-    <ScaffoldScreen
-      title="Calendar"
-      category="Library"
-      source="screens-3.jsx"
-      summary="Week + month calendar with task overlay."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-4xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-eyebrow text-muted-foreground">Library · Calendar</p>
+            <h1 className="text-h1 font-serif text-foreground">Your week at a glance.</h1>
+            <p className="mt-1 text-body text-muted-foreground">{mockCalendarWeekLabel}</p>
+          </div>
+          {/*
+            @action createCalendarBlock
+            @mutation: calendarEvents.create (Long Run 2)
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="primary">
+            Add block
+          </Button>
+        </header>
+
+        <div className="space-y-6">
+          {grouped.map(([day, events]) => (
+            <SoftCard key={day} padding="md">
+              <h2 className="font-serif text-lg text-foreground">{day}</h2>
+              <ul className="mt-3 space-y-2">
+                {events.map((ev) => (
+                  <li
+                    key={ev.id}
+                    className="flex flex-col gap-1 rounded-lg border border-border-soft bg-surface-sunken/50 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div>
+                      <span className="font-medium text-foreground">{ev.title}</span>
+                      <span className="ml-2 text-caption font-tabular text-muted-foreground">
+                        {formatTime(ev.startAt)} – {formatTime(ev.endAt)}
+                      </span>
+                    </div>
+                    <Pill tone={ev.source === "tempo" ? "orange" : "slate"}>{ev.source}</Pill>
+                  </li>
+                ))}
+              </ul>
+            </SoftCard>
+          ))}
+        </div>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/coach/page.tsx
+++ b/apps/web/app/(tempo)/coach/page.tsx
@@ -1,23 +1,202 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: coach
  * @category: Flow
- * @source: docs/design/claude-export/design-system/screens-1.jsx + coach-dock.jsx
- * @summary: Conversational AI coach surface. Accept / tweak / skip suggestions.
- * @queries: coach.thread
- * @mutations: coach.accept, coach.tweak, coach.skip
+ * @source: docs/design/claude-export/design-system/screens-1.jsx:L207-L299
+ * @queries:
+ *   - conversations.listByUser withIndex("by_userId_deletedAt")
+ *   - messages.listByConversation withIndex("by_conversationId_createdAt")
+ * @mutations:
+ *   - messages.appendUser / messages.appendAssistant (insert into messages)
+ *   - conversations.updateTitle
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL, NEXT_PUBLIC_POSTHOG_KEY (opt-in @analytics: coach_message_sent)
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import {
+  mockCoachMessages,
+  mockCoachPastThreads,
+  mockCoachPersonalityLabel,
+  mockCoachQuickPills,
+  mockCoachScopeItems,
+  mockCoachScopeSummary,
+  mockCoachWarmthLevel,
+} from "@tempo/mock-data";
+import { Button, CoachBubble, Pill, SoftCard } from "@tempo/ui/primitives";
+import { Folder, Mic, Notebook, Plus, Send, Volume } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [draft, setDraft] = useState("");
+
+  const dialPct = Math.min(100, Math.max(0, (mockCoachWarmthLevel / 10) * 100));
+
   return (
-    <ScaffoldScreen
-      title="Coach"
-      category="Flow"
-      source="screens-1.jsx + coach-dock.jsx"
-      summary="Conversational AI coach surface. Accept / tweak / skip suggestions."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-6xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="space-y-2">
+          <p className="font-eyebrow text-muted-foreground">Coach</p>
+          <h1 className="text-h1 font-serif text-foreground">A quiet second brain.</h1>
+          <p className="max-w-2xl text-body leading-relaxed text-muted-foreground">
+            Warmth dial at <strong>{mockCoachWarmthLevel}/10</strong> — gently offering, not saccharine. Coach sees
+            only the notes and projects you share.
+          </p>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+          <SoftCard padding="none" className="flex min-h-[560px] flex-col overflow-hidden">
+            <div className="flex items-center gap-3 border-b border-border px-5 py-3">
+              <div
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary font-serif text-[13px] font-semibold text-primary-foreground"
+                aria-hidden
+              >
+                T
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="text-small font-medium text-foreground">Tempo Coach</div>
+                <div className="text-caption text-muted-foreground">{mockCoachScopeSummary}</div>
+              </div>
+              <Pill tone="moss">Online</Pill>
+            </div>
+
+            <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-6">
+              <p className="text-center text-caption text-muted-foreground">Thursday, 9:12 AM</p>
+              {mockCoachMessages.map((m) => {
+                const bubble =
+                  m.role === "user" ? (
+                    <CoachBubble key={m.id} bubbleRole="user">
+                      {m.body}
+                    </CoachBubble>
+                  ) : (
+                    <CoachBubble key={m.id} bubbleRole="coach">
+                      {m.body}
+                    </CoachBubble>
+                  );
+                return bubble;
+              })}
+            </div>
+
+            <div className="border-t border-border p-4 sm:p-5">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+                <label htmlFor="coach-input" className="sr-only">
+                  Message coach
+                </label>
+                <textarea
+                  id="coach-input"
+                  placeholder="Type, or hold to dictate…"
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  rows={2}
+                  className="min-h-[44px] flex-1 resize-none rounded-lg border border-border bg-card px-3 py-2 text-body text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+                {/*
+                  @action openWalkieTalkie
+                  @action-call: voice.openSession({ mode: walkie })
+                  @auth: required
+                  @errors: toast
+                  @env: NEXT_PUBLIC_CONVEX_URL
+                  @source: screens-1.jsx:L250
+                */}
+                <Button type="button" variant="ghost" size="sm" aria-label="Walkie-talkie — hold to speak" title="Walkie-talkie — hold to speak">
+                  <Mic size={18} />
+                </Button>
+                {/*
+                  @action openVoiceMode
+                  @action-call: voice.openSession({ mode: hands_free })
+                  @auth: required
+                  @errors: toast
+                  @env: NEXT_PUBLIC_CONVEX_URL
+                  @source: screens-1.jsx:L251 — inline style in export; using Tailwind orange tint instead
+                */}
+                <Button type="button" variant="soft" size="sm" className="border-orange-500/35 text-primary" aria-label="Voice mode — hands-free" title="Voice mode — hands-free">
+                  <Volume size={18} />
+                </Button>
+                {/*
+                  @action sendCoachMessage
+                  @mutation: messages.appendUser + internalAction coach.replyStream
+                  @index: by_conversationId_createdAt
+                  @streaming: token stream via action (OpenRouter via fetch in Convex action)
+                  @auth: required
+                  @errors: toast
+                  @env: NEXT_PUBLIC_CONVEX_URL
+                  @source: screens-1.jsx:L252
+                */}
+                <Button type="button" variant="primary" size="md" leadingIcon={<Send size={14} />}>
+                  Send
+                </Button>
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {mockCoachQuickPills.map((p) => (
+                  <Pill key={p} tone="neutral">
+                    {p}
+                  </Pill>
+                ))}
+              </div>
+            </div>
+          </SoftCard>
+
+          <aside className="space-y-6">
+            <SoftCard padding="md">
+              <p className="mb-2 font-eyebrow text-muted-foreground">Personality dial</p>
+              <p className="mb-3 font-serif text-xl text-foreground">{mockCoachPersonalityLabel}</p>
+              <div className="relative h-2 rounded-full bg-surface-sunken" role="img" aria-label={`Coach warmth ${mockCoachWarmthLevel} of 10`}>
+                <div
+                  className="absolute inset-y-0 left-0 rounded-full bg-primary"
+                  style={{ width: `${dialPct}%` }}
+                />
+                <div
+                  className="absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-primary bg-card shadow-whisper"
+                  style={{ left: `${dialPct}%` }}
+                />
+              </div>
+              <div className="mt-1 flex justify-between text-caption text-muted-foreground">
+                <span>softer</span>
+                <span>sharper</span>
+              </div>
+            </SoftCard>
+
+            <SoftCard padding="md">
+              <p className="mb-3 font-eyebrow text-muted-foreground">Conversation scope</p>
+              <ul className="space-y-2">
+                {mockCoachScopeItems.map((item) => (
+                  <li key={item.title} className="flex items-center gap-2 text-small text-foreground">
+                    {item.kind === "project" ? (
+                      <Folder size={14} strokeWidth={1.5} className="shrink-0 text-muted-foreground" />
+                    ) : (
+                      <Notebook size={14} strokeWidth={1.5} className="shrink-0 text-muted-foreground" />
+                    )}
+                    <span>{item.title}</span>
+                  </li>
+                ))}
+              </ul>
+              {/*
+                @action addScopeItem
+                @mutation: coach.addScopeNoteId (Long Run 2; @todo: requires schema add coachScope)
+                @auth: required
+                @errors: toast
+                @env: NEXT_PUBLIC_CONVEX_URL
+                @source: screens-1.jsx:L282
+              */}
+              <Button type="button" variant="soft" size="sm" className="mt-3" leadingIcon={<Plus size={12} />}>
+                Add to scope
+              </Button>
+            </SoftCard>
+
+            <SoftCard tone="sunken" padding="md">
+              <p className="mb-2 font-eyebrow text-muted-foreground">Past conversations</p>
+              <ul className="space-y-1">
+                {mockCoachPastThreads.map((t) => (
+                  <li key={t} className="font-serif text-small text-muted-foreground">
+                    {t}
+                  </li>
+                ))}
+              </ul>
+            </SoftCard>
+          </aside>
+        </div>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/command/page.tsx
+++ b/apps/web/app/(tempo)/command/page.tsx
@@ -1,23 +1,53 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: command
  * @category: You
  * @source: docs/design/claude-export/design-system/screens-5.jsx
- * @summary: Command bar landing page.
- * @queries: (none)
- * @mutations: (none)
+ * @queries: commandPalette.recent (Long Run 2)
+ * @mutations: none
+ * @navigate: per row
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { mockCommandActions } from "@tempo/mock-data";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const router = useRouter();
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Command bar"
-      category="You"
-      source="screens-5.jsx"
-      summary="Command bar landing page."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-lg space-y-6 p-6 pb-24 md:p-8">
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Command bar</p>
+          <h1 className="text-h1 font-serif text-foreground">Jump anywhere.</h1>
+        </header>
+        <SoftCard padding="md" className="space-y-2">
+          {mockCommandActions.map((a) => (
+            <div key={a.id} className="flex items-center justify-between gap-2 rounded-lg px-2 py-2 hover:bg-surface-sunken">
+              <span className="text-small text-foreground">{a.label}</span>
+              <span className="font-mono text-caption text-muted-foreground">{a.shortcut}</span>
+            </div>
+          ))}
+        </SoftCard>
+        <p className="text-caption text-muted-foreground">
+          Full palette lives in shell (⌘K) — this route mirrors quick actions for deep links.
+        </p>
+        {/*
+          @action commandGoToday
+          @navigate: /today
+          @auth: required
+          @env: NEXT_PUBLIC_CONVEX_URL
+        */}
+        <Button type="button" variant="primary" onClick={() => router.push("/today")}>
+          Go to Today
+        </Button>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/empty-states/page.tsx
+++ b/apps/web/app/(tempo)/empty-states/page.tsx
@@ -1,23 +1,48 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: empty-states
  * @category: You
  * @source: docs/design/claude-export/design-system/screens-6.jsx
- * @summary: Gallery of anti-shame empty states.
- * @queries: (none)
- * @mutations: (none)
+ * @queries: none
+ * @mutations: none
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { mockEmptyStateExamples } from "@tempo/mock-data";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const router = useRouter();
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Empty states gallery"
-      category="You"
-      source="screens-6.jsx"
-      summary="Gallery of anti-shame empty states."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-3xl space-y-8 p-6 pb-24 md:p-8">
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Empty states</p>
+          <h1 className="text-h1 font-serif text-foreground">Quiet rooms.</h1>
+        </header>
+        <div className="space-y-4">
+          {mockEmptyStateExamples.map((e) => (
+            <SoftCard key={e.title} tone="sunken" padding="lg">
+              <h2 className="text-h3 font-serif text-foreground">{e.title}</h2>
+              <p className="mt-2 text-body text-muted-foreground">{e.body}</p>
+              <Button
+                type="button"
+                variant="primary"
+                className="mt-4"
+                onClick={() => router.push(e.title.includes("task") ? "/tasks" : "/notes")}
+              >
+                {e.cta}
+              </Button>
+            </SoftCard>
+          ))}
+        </div>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/goals/[id]/page.tsx
+++ b/apps/web/app/(tempo)/goals/[id]/page.tsx
@@ -1,30 +1,119 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: goal-detail
  * @category: Library
  * @source: docs/design/claude-export/design-system/screens-4.jsx
- * @summary: Goal detail view with milestones.
- * @queries: goals.get
- * @mutations: goals.update, goals.logMilestone
+ * @queries: goals.getById withIndex("by_userId_deletedAt")
+ * @mutations: goals.updateProgress, goals.toggleMilestone @index by_userId_status
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
 
-type Params = { id: string };
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useMemo, useState } from "react";
+import { mockGoals } from "@tempo/mock-data";
+import { Button, Ring, SoftCard } from "@tempo/ui/primitives";
+import { Check } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<Params>;
-}) {
-  const { id } = await params;
+export default function Page() {
+  const params = useParams();
+  const id = typeof params.id === "string" ? params.id : "";
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [milestoneDone, setMilestoneDone] = useState<Record<string, boolean>>({});
+
+  const goal = useMemo(() => mockGoals.find((g) => g.id === id) ?? null, [id]);
+
+  const toggleMilestone = (mid: string, defaultDone: boolean) => {
+    setMilestoneDone((prev) => ({
+      ...prev,
+      [mid]: !(prev[mid] ?? defaultDone),
+    }));
+  };
+
+  if (!goal) {
+    return (
+      <ScreenSurface mode={mode} onModeChange={setMode}>
+        <div className="p-8">
+          <SoftCard padding="md">
+            <p className="text-muted-foreground">Goal not found.</p>
+            <Link href="/goals" className="mt-4 inline-block text-primary underline">
+              Back to goals
+            </Link>
+          </SoftCard>
+        </div>
+      </ScreenSurface>
+    );
+  }
+
   return (
-    <ScaffoldScreen
-      title="Goal detail"
-      category="Library"
-      source="screens-4.jsx"
-      summary={`Goal detail view with milestones. (id: ${id})`}
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-3xl space-y-8 p-6 pb-24 md:p-8">
+        <Link href="/goals" className="text-small text-muted-foreground hover:text-foreground">
+          ← Goals
+        </Link>
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-h1 font-serif text-foreground">{goal.title}</h1>
+            <p className="mt-2 text-body text-muted-foreground">{goal.description}</p>
+          </div>
+          <Ring size={56} stroke={3} value={Math.round(goal.progress * 100)} max={100}>
+            <span className="text-small font-tabular">{Math.round(goal.progress * 100)}%</span>
+          </Ring>
+        </header>
+
+        <SoftCard padding="md">
+          <h2 className="font-eyebrow text-muted-foreground">Milestones</h2>
+          <ul className="mt-4 space-y-2">
+            {goal.milestones.map((m) => {
+              const done = milestoneDone[m.id] ?? m.done;
+              return (
+                <li
+                  key={m.id}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-border-soft px-3 py-2"
+                >
+                  <span className={done ? "text-muted-foreground line-through" : "text-foreground"}>
+                    {m.title}
+                  </span>
+                  {/*
+                    @action toggleGoalMilestone
+                    @mutation: goals.toggleMilestone @index by_userId_status
+                    @soft-delete: no
+                    @optimistic: strike toggle
+                    @auth: required
+                    @errors: toast
+                    @env: NEXT_PUBLIC_CONVEX_URL
+                  */}
+                  <button
+                    type="button"
+                    aria-pressed={done}
+                    aria-label={done ? `Mark ${m.title} not done` : `Mark ${m.title} done`}
+                    onClick={() => toggleMilestone(m.id, m.done)}
+                    className={[
+                      "flex h-8 w-8 shrink-0 items-center justify-center rounded-md border",
+                      done ? "border-primary bg-primary text-primary-foreground" : "border-border",
+                    ].join(" ")}
+                  >
+                    {done ? <Check size={14} strokeWidth={2.5} /> : null}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </SoftCard>
+
+        {/*
+          @action saveGoalEdits
+          @mutation: goals.patch @index by_userId_deletedAt
+          @auth: required
+          @errors: toast
+          @env: NEXT_PUBLIC_CONVEX_URL
+        */}
+        <Button type="button" variant="primary">
+          Save changes
+        </Button>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/goals/page.tsx
+++ b/apps/web/app/(tempo)/goals/page.tsx
@@ -1,23 +1,93 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: goals
  * @category: Library
  * @source: docs/design/claude-export/design-system/screens-4.jsx
- * @summary: Goals list with progress.
- * @queries: goals.list
- * @mutations: goals.create
+ * @queries: goals.listByUser withIndex("by_userId_status")
+ * @mutations: goals.create, goals.softDelete @index by_userId_deletedAt
+ * @routes-to: /goals/[id], /goals/progress
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { mockGoalCategories, mockGoalDueLabels, mockGoals } from "@tempo/mock-data";
+import { Button, Pill, Ring, SoftCard } from "@tempo/ui/primitives";
+import { Plus } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const router = useRouter();
+  const [mode, setMode] = useState<ViewMode>("ready");
+
+  const categoryByGoal = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of mockGoalCategories) {
+      m.set(c.goalId, c.category);
+    }
+    return m;
+  }, []);
+
   return (
-    <ScaffoldScreen
-      title="Goals"
-      category="Library"
-      source="screens-4.jsx"
-      summary="Goals list with progress."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-4xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-eyebrow text-muted-foreground">Goals</p>
+            <h1 className="text-h1 font-serif text-foreground">Direction without pressure.</h1>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {/*
+              @action openGoalsProgress
+              @navigate: /goals/progress
+              @query: goals.aggregateProgress (Long Run 2)
+              @auth: required
+              @env: NEXT_PUBLIC_CONVEX_URL
+            */}
+            <Button type="button" variant="soft" onClick={() => router.push("/goals/progress")}>
+              Progress
+            </Button>
+            {/*
+              @action createGoal
+              @mutation: goals.create @index by_userId_deletedAt
+              @auth: required
+              @errors: toast
+              @env: NEXT_PUBLIC_CONVEX_URL
+            */}
+            <Button type="button" variant="primary" leadingIcon={<Plus size={14} />}>
+              New goal
+            </Button>
+          </div>
+        </header>
+
+        <ul className="space-y-3">
+          {mockGoals.map((g) => (
+            <li key={g.id}>
+              <SoftCard padding="md">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                  <Link href={`/goals/${g.id}`} className="min-w-0 flex-1 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="font-serif text-xl text-foreground hover:underline">{g.title}</h2>
+                      {categoryByGoal.get(g.id) ? (
+                        <Pill tone="slate">{categoryByGoal.get(g.id)}</Pill>
+                      ) : null}
+                    </div>
+                    <p className="text-small text-muted-foreground">{g.description}</p>
+                    <p className="text-caption text-muted-foreground">
+                      Due {mockGoalDueLabels[g.id] ?? "—"}
+                    </p>
+                  </Link>
+                  <Ring size={48} stroke={3} value={Math.round(g.progress * 100)} max={100}>
+                    <span className="text-caption font-tabular">{Math.round(g.progress * 100)}</span>
+                  </Ring>
+                </div>
+              </SoftCard>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/goals/progress/page.tsx
+++ b/apps/web/app/(tempo)/goals/progress/page.tsx
@@ -1,23 +1,65 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: goals-progress
  * @category: Library
  * @source: docs/design/claude-export/design-system/screens-4.jsx
- * @summary: Goals progress chart.
- * @queries: goals.progressSeries
- * @mutations: (none)
+ * @queries: goals.listByUser withIndex("by_userId_status")
+ * @mutations: none (read-only chart in MVP)
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { mockGoals } from "@tempo/mock-data";
+import { SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Goals chart"
-      category="Library"
-      source="screens-4.jsx"
-      summary="Goals progress chart."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-4xl space-y-8 p-6 pb-24 md:p-8">
+        <div className="flex items-center gap-4">
+          <Link href="/goals" className="text-small text-muted-foreground hover:text-foreground">
+            ← Goals
+          </Link>
+        </div>
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Goals · Progress</p>
+          <h1 className="text-h1 font-serif text-foreground">How it&apos;s moving.</h1>
+          <p className="mt-2 text-body text-muted-foreground">
+            Snapshot from mock data — Long Run 2 charts from goals.progressPercent via Convex.
+          </p>
+        </header>
+
+        <div className="space-y-4">
+          {mockGoals.map((g) => (
+            <SoftCard key={g.id} padding="md">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <span className="font-medium text-foreground">{g.title}</span>
+                <span className="font-tabular text-caption text-muted-foreground">
+                  {Math.round(g.progress * 100)}%
+                </span>
+              </div>
+              <div
+                className="h-3 w-full overflow-hidden rounded-full bg-surface-sunken"
+                role="progressbar"
+                aria-valuenow={Math.round(g.progress * 100)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${g.title} progress`}
+              >
+                <div
+                  className="h-full rounded-full bg-primary transition-all"
+                  style={{ width: `${Math.round(g.progress * 100)}%` }}
+                />
+              </div>
+            </SoftCard>
+          ))}
+        </div>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/habits/[id]/page.tsx
+++ b/apps/web/app/(tempo)/habits/[id]/page.tsx
@@ -1,30 +1,107 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: habit-detail
  * @category: Library
- * @source: docs/design/claude-export/design-system/screens-3.jsx
- * @summary: Single-habit detail with streak history.
- * @queries: habits.get
- * @mutations: habits.logComplete, habits.update
+ * @source: docs/design/claude-export/design-system/screens-2.jsx / screens-3.jsx
+ * @queries: habits.getById withIndex("by_userId_deletedAt")
+ * @mutations: habits.logCompletion @index by_userId_deletedAt
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
 
-type Params = { id: string };
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useMemo, useState } from "react";
+import { mockHabitDetailGrid42, mockHabits } from "@tempo/mock-data";
+import { Button, HabitRing, Pill, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<Params>;
-}) {
-  const { id } = await params;
+export default function Page() {
+  const params = useParams();
+  const id = typeof params.id === "string" ? params.id : "";
+  const [mode, setMode] = useState<ViewMode>("ready");
+
+  const habit = useMemo(() => mockHabits.find((h) => h.id === id) ?? null, [id]);
+
+  if (!habit) {
+    return (
+      <ScreenSurface mode={mode} onModeChange={setMode}>
+        <div className="p-8">
+          <SoftCard padding="md">
+            <p className="text-muted-foreground">Habit not found.</p>
+            <Link href="/habits" className="mt-4 inline-block text-primary underline">
+              Back to habits
+            </Link>
+          </SoftCard>
+        </div>
+      </ScreenSurface>
+    );
+  }
+
   return (
-    <ScaffoldScreen
-      title="Habit detail"
-      category="Library"
-      source="screens-3.jsx"
-      summary={`Single-habit detail with streak history. (id: ${id})`}
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-3xl space-y-8 p-6 pb-24 md:p-8">
+        <Link href="/habits" className="text-small text-muted-foreground hover:text-foreground">
+          ← Habits
+        </Link>
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-h1 font-serif text-foreground">{habit.name}</h1>
+            <p className="mt-1 text-body text-muted-foreground">
+              {habit.cadence} · current streak {habit.streak} · longest {habit.longestStreak}
+            </p>
+          </div>
+          <HabitRing completed={Math.min(7, habit.recentCompletions.length)} total={7} />
+        </header>
+
+        <div className="flex flex-wrap gap-2">
+          {/*
+            @action logHabitToday
+            @mutation: habits.logCompletion @index by_userId_deletedAt
+            @optimistic: ring tick
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="primary">
+            Log today
+          </Button>
+          {/*
+            @action skipHabitToday
+            @mutation: habits.logSkip (Long Run 2)
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="ghost">
+            Skip
+          </Button>
+        </div>
+
+        <SoftCard padding="md">
+          <p className="mb-3 font-eyebrow text-muted-foreground">6-week grid</p>
+          <div className="grid grid-cols-7 gap-1" role="img" aria-label="Habit completion heatmap, decorative">
+            {mockHabitDetailGrid42.map((on, i) => (
+              <div
+                key={`c-${i}`}
+                className={[
+                  "aspect-square rounded-sm",
+                  on ? "bg-[color:var(--color-moss)]" : "bg-surface-sunken",
+                ].join(" ")}
+              />
+            ))}
+          </div>
+        </SoftCard>
+
+        <SoftCard tone="sunken" padding="md">
+          <p className="text-small text-muted-foreground">
+            Coach can nudge without shame — toggles respect your quiet days.
+          </p>
+          <Pill tone="orange" className="mt-2">
+            Coach-aware
+          </Pill>
+        </SoftCard>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/habits/page.tsx
+++ b/apps/web/app/(tempo)/habits/page.tsx
@@ -1,23 +1,84 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: habits
  * @category: Library
- * @source: docs/design/claude-export/design-system/screens-3.jsx
- * @summary: Habit rings with weekly progress.
- * @queries: habits.list
- * @mutations: habits.logComplete
+ * @source: docs/design/claude-export/design-system/screens-2.jsx / screens-3.jsx
+ * @queries: habits.listByUser withIndex("by_userId_deletedAt")
+ * @mutations: habits.logCompletion, habits.softDelete
+ * @routes-to: /habits/[id]
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { mockHabitHeatmap14, mockHabits } from "@tempo/mock-data";
+import { Button, HabitRing, Pill, Ring, SoftCard } from "@tempo/ui/primitives";
+import { Plus } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Habits"
-      category="Library"
-      source="screens-3.jsx"
-      summary="Habit rings with weekly progress."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-4xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-eyebrow text-muted-foreground">Library · Habits</p>
+            <h1 className="text-h1 font-serif text-foreground">Small repeats, big calm.</h1>
+          </div>
+          {/*
+            @action createHabit
+            @mutation: habits.create @index by_userId_deletedAt
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="primary" leadingIcon={<Plus size={14} />}>
+            New habit
+          </Button>
+        </header>
+
+        <SoftCard padding="md">
+          <p className="mb-3 font-eyebrow text-muted-foreground">Last 14 days</p>
+          <ul className="flex flex-wrap gap-1" aria-label="Habit heatmap last 14 days">
+            {mockHabitHeatmap14.map((on, i) => (
+              <li
+                key={`h-${i}`}
+                className={[
+                  "h-4 w-4 list-none rounded-sm",
+                  on ? "bg-[color:var(--color-moss)]" : "bg-surface-sunken",
+                ].join(" ")}
+              />
+            ))}
+          </ul>
+        </SoftCard>
+
+        <ul className="space-y-3">
+          {mockHabits.map((h) => (
+            <li key={h.id}>
+              <SoftCard padding="md">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                  <Link href={`/habits/${h.id}`} className="flex min-w-0 flex-1 items-center gap-4">
+                    <HabitRing completed={Math.min(7, h.recentCompletions.length)} total={7} />
+                    <div className="min-w-0">
+                      <h2 className="truncate font-serif text-lg text-foreground">{h.name}</h2>
+                      <p className="text-caption text-muted-foreground">
+                        {h.cadence} · streak {h.streak} · best {h.longestStreak ?? h.streak}
+                      </p>
+                    </div>
+                  </Link>
+                  <div className="flex items-center gap-2">
+                    <Ring size={36} stroke={3} value={Math.round((h.completionRatio ?? 0) * 100)} max={100} />
+                    <Pill tone="moss">{h.streak}d</Pill>
+                  </div>
+                </div>
+              </SoftCard>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/insights/page.tsx
+++ b/apps/web/app/(tempo)/insights/page.tsx
@@ -1,23 +1,42 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
- * @screen: analytics
+ * @screen: insights
  * @category: You
  * @source: docs/design/claude-export/design-system/screens-5.jsx
- * @summary: Personal analytics & trends.
- * @queries: insights.summary
- * @mutations: (none)
+ * @queries: analytics.summary7d (Long Run 2; @todo: requires schema add analyticsEvents)
+ * @mutations: none
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL, NEXT_PUBLIC_POSTHOG_KEY (opt-in only)
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { mockInsightStats } from "@tempo/mock-data";
+import { SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Insights"
-      category="You"
-      source="screens-5.jsx"
-      summary="Personal analytics & trends."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-4xl space-y-8 p-6 pb-24 md:p-8">
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Insights</p>
+          <h1 className="text-h1 font-serif text-foreground">Patterns, not scores.</h1>
+          <p className="mt-2 text-body text-muted-foreground">
+            Mock snapshot — Long Run 2 aggregates from Convex with PostHog opt-in only.
+          </p>
+        </header>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {mockInsightStats.map((s) => (
+            <SoftCard key={s.label} padding="md">
+              <p className="text-caption text-muted-foreground">{s.label}</p>
+              <p className="mt-2 font-serif text-3xl text-foreground">{s.value}</p>
+              <p className="mt-1 text-small text-muted-foreground">{s.delta}</p>
+            </SoftCard>
+          ))}
+        </div>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/journal/page.tsx
+++ b/apps/web/app/(tempo)/journal/page.tsx
@@ -1,23 +1,89 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: journal
  * @category: Library
  * @source: docs/design/claude-export/design-system/screens-2.jsx
- * @summary: Dated journal entries.
- * @queries: journal.list
- * @mutations: journal.create
+ * @queries: journalEntries.listByUser (Long Run 2; @todo: requires schema add journalEntries + by_userId_deletedAt)
+ * @mutations: journalEntries.upsertDay
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { mockJournalEntries, mockJournalPromptTitle, mockJournalTodayDraft } from "@tempo/mock-data";
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
+
+const moodTone: Record<(typeof mockJournalEntries)[0]["mood"], "moss" | "amber" | "slate" | "neutral"> = {
+  settled: "moss",
+  tired: "slate",
+  anxious: "amber",
+  steady: "moss",
+  bright: "moss",
+  low: "slate",
+  meh: "neutral",
+};
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [draft, setDraft] = useState(mockJournalTodayDraft);
+
   return (
-    <ScaffoldScreen
-      title="Journal"
-      category="Library"
-      source="screens-2.jsx"
-      summary="Dated journal entries."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-4xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="space-y-2">
+          <p className="font-eyebrow text-muted-foreground">Library · Journal</p>
+          <h1 className="text-h1 font-serif text-foreground">Write it down, gently.</h1>
+        </header>
+
+        <SoftCard padding="md">
+          <p className="font-eyebrow text-muted-foreground">{mockJournalPromptTitle}</p>
+          <label htmlFor="journal-draft" className="sr-only">
+            Today&apos;s entry
+          </label>
+          <textarea
+            id="journal-draft"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={10}
+            className="mt-3 w-full resize-y rounded-lg border border-border bg-transparent p-3 font-serif text-lg leading-relaxed text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+          <div className="mt-4 flex flex-wrap gap-2">
+            {/*
+              @action saveJournalEntry
+              @mutation: journalEntries.upsertDay (Long Run 2)
+              @auth: required
+              @errors: toast
+              @env: NEXT_PUBLIC_CONVEX_URL
+            */}
+            <Button type="button" variant="primary">
+              Save entry
+            </Button>
+          </div>
+        </SoftCard>
+
+        <section aria-labelledby="journal-past">
+          <h2 id="journal-past" className="mb-4 font-eyebrow text-muted-foreground">
+            Past entries
+          </h2>
+          <ul className="space-y-3">
+            {mockJournalEntries.map((e) => (
+              <li key={e.id}>
+                <SoftCard padding="md">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-tabular text-caption text-muted-foreground">{e.date}</span>
+                    <Pill tone={moodTone[e.mood]}>{e.mood}</Pill>
+                    <span className="text-caption text-muted-foreground">{e.wordCount} words</span>
+                  </div>
+                  <p className="mt-2 line-clamp-3 font-serif text-small leading-relaxed text-foreground">
+                    {e.body}
+                  </p>
+                </SoftCard>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/notes/[id]/page.tsx
+++ b/apps/web/app/(tempo)/notes/[id]/page.tsx
@@ -1,30 +1,160 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: note-detail
  * @category: Library
  * @source: docs/design/claude-export/design-system/screens-2.jsx
- * @summary: Rich-text note editor with slash commands.
- * @queries: notes.get
- * @mutations: notes.update
+ * @queries: notes.getById @index by_userId_deletedAt
+ * @mutations: notes.updateBody, notes.softDelete
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
 
-type Params = { id: string };
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useMemo, useState } from "react";
+import { mockNoteDetailLaunchPost, mockNotes } from "@tempo/mock-data";
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<Params>;
-}) {
-  const { id } = await params;
+export default function Page() {
+  const params = useParams();
+  const id = typeof params.id === "string" ? params.id : "";
+  const [mode, setMode] = useState<ViewMode>("ready");
+
+  const note = useMemo(() => mockNotes.find((n) => n.id === id) ?? null, [id]);
+
+  const initialTitle = note?.title ?? (id === mockNoteDetailLaunchPost.id ? mockNoteDetailLaunchPost.title : "");
+  const initialBody = useMemo(() => {
+    if (note) {
+      return note.body;
+    }
+    if (id === mockNoteDetailLaunchPost.id) {
+      return mockNoteDetailLaunchPost.paragraphs.join("\n\n");
+    }
+    return "";
+  }, [id, note]);
+
+  const [title, setTitle] = useState(initialTitle);
+  const [body, setBody] = useState(initialBody);
+
+  if (!note && id !== mockNoteDetailLaunchPost.id) {
+    return (
+      <ScreenSurface mode={mode} onModeChange={setMode}>
+        <div className="p-8">
+          <SoftCard padding="md">
+            <p className="text-body text-muted-foreground">Note not found.</p>
+            {/*
+              @action backToNotes
+              @navigate: /notes
+              @auth: required
+              @env: NEXT_PUBLIC_CONVEX_URL
+            */}
+            <Link
+              href="/notes"
+              className="mt-4 inline-flex h-10 items-center justify-center rounded-lg border border-border bg-card px-4 text-body font-medium text-foreground hover:bg-surface-sunken"
+            >
+              Back to notes
+            </Link>
+          </SoftCard>
+        </div>
+      </ScreenSurface>
+    );
+  }
+
+  const tags = note?.tags ?? [...mockNoteDetailLaunchPost.tags];
+  const coachStrip =
+    id === mockNoteDetailLaunchPost.id ? mockNoteDetailLaunchPost.coachStrip : null;
+
   return (
-    <ScaffoldScreen
-      title="Note editor"
-      category="Library"
-      source="screens-2.jsx"
-      summary={`Rich-text note editor with slash commands. (id: ${id})`}
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-3xl space-y-6 p-6 pb-24 md:p-8">
+        <div className="flex flex-wrap items-center gap-2">
+          {/*
+            @action backToNotesList
+            @navigate: /notes
+            @auth: required
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Link
+            href="/notes"
+            className="inline-flex h-9 items-center rounded-md px-3 text-small font-medium text-muted-foreground hover:bg-surface-sunken hover:text-foreground"
+          >
+            ← Notes
+          </Link>
+          {tags.map((tag) => (
+            <Pill key={tag} tone="slate">
+              {tag}
+            </Pill>
+          ))}
+        </div>
+        <label htmlFor="note-title" className="sr-only">
+          Title
+        </label>
+        <input
+          id="note-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full border-0 bg-transparent font-serif text-3xl font-medium text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        {coachStrip ? (
+          <SoftCard tone="sunken" padding="md">
+            <p className="text-small text-muted-foreground">{coachStrip}</p>
+            <div className="mt-3 flex gap-2">
+              {/*
+                @action acceptCoachNoteSuggestion
+                @mutation: notes.applyCoachPatch (Long Run 2)
+                @confirm: undoable 5s
+                @auth: required
+                @errors: toast
+                @env: NEXT_PUBLIC_CONVEX_URL
+              */}
+              <Button type="button" size="sm" variant="primary">
+                Show suggestion
+              </Button>
+              <Button type="button" size="sm" variant="ghost">
+                Dismiss
+              </Button>
+            </div>
+          </SoftCard>
+        ) : null}
+        <label htmlFor="note-body" className="sr-only">
+          Body
+        </label>
+        <textarea
+          id="note-body"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={16}
+          className="w-full resize-y rounded-xl border border-border bg-card p-4 font-serif text-lg leading-relaxed text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        <div className="flex flex-wrap gap-2">
+          {/*
+            @action saveNote
+            @mutation: notes.updateBody @index by_userId_updatedAt
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="primary">
+            Save
+          </Button>
+          {/*
+            @action deleteNote
+            @mutation: notes.softDelete @index by_userId_deletedAt
+            @soft-delete: yes
+            @confirm: undoable 5s
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="destructive">
+            Move to archive
+          </Button>
+        </div>
+        <p className="text-caption text-muted-foreground">
+          {id === mockNoteDetailLaunchPost.id ? mockNoteDetailLaunchPost.savedCaption : null}
+        </p>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/notes/page.tsx
+++ b/apps/web/app/(tempo)/notes/page.tsx
@@ -1,23 +1,89 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: notes
  * @category: Library
  * @source: docs/design/claude-export/design-system/screens-2.jsx
- * @summary: Notes library — grid with backlinks.
- * @queries: notes.list
- * @mutations: notes.create
+ * @queries: notes.listByUser withIndex("by_userId_deletedAt")
+ * @mutations: notes.softDelete @index by_userId_deletedAt
+ * @routes-to: /notes/[id]
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { mockNoteFolders, mockNotes } from "@tempo/mock-data";
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
+import { Plus } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Notes"
-      category="Library"
-      source="screens-2.jsx"
-      summary="Notes library — grid with backlinks."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-6xl gap-6 p-6 pb-24 md:flex md:p-8">
+        <aside className="mb-6 w-full shrink-0 space-y-2 md:mb-0 md:w-52">
+          {mockNoteFolders.map((f) => (
+            <Button
+              key={f.name}
+              type="button"
+              variant={f.name === "All notes" ? "soft" : "ghost"}
+              size="sm"
+              className="w-full justify-between"
+            >
+              <span className="truncate">{f.name}</span>
+              <span className="font-tabular text-caption text-muted-foreground">{f.count}</span>
+            </Button>
+          ))}
+        </aside>
+        <div className="min-w-0 flex-1 space-y-6">
+          <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-eyebrow text-muted-foreground">Library · Notes</p>
+              <h1 className="text-h1 font-serif text-foreground">Notes that breathe.</h1>
+            </div>
+            {/*
+              @action createNote
+              @mutation: notes.create @index by_userId_deletedAt
+              @auth: required
+              @errors: toast
+              @env: NEXT_PUBLIC_CONVEX_URL
+            */}
+            <Button type="button" variant="primary" leadingIcon={<Plus size={14} />}>
+              New note
+            </Button>
+          </header>
+          <ul className="space-y-3">
+            {mockNotes.map((n) => (
+              <li key={n.id}>
+                <SoftCard padding="md" className="transition-colors hover:bg-surface-sunken/50">
+                  {/*
+                    @action openNote
+                    @navigate: /notes/{noteId}
+                    @query: notes.getById (with deletedAt undefined check)
+                    @index: by_userId_deletedAt
+                    @auth: required
+                    @errors: not-found state
+                    @env: NEXT_PUBLIC_CONVEX_URL
+                  */}
+                  <Link href={`/notes/${n.id}`} className="block space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="text-h3 font-serif text-foreground">{n.title}</h2>
+                      {n.tags.map((tag) => (
+                        <Pill key={tag} tone="slate">
+                          {tag}
+                        </Pill>
+                      ))}
+                    </div>
+                    <p className="line-clamp-2 text-small text-muted-foreground">{n.body}</p>
+                  </Link>
+                </SoftCard>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/notifications/page.tsx
+++ b/apps/web/app/(tempo)/notifications/page.tsx
@@ -1,23 +1,57 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: notifications
  * @category: Settings
  * @source: docs/design/claude-export/design-system/screens-6.jsx
- * @summary: Quiet notification settings.
- * @queries: users.notificationPrefs
- * @mutations: users.updateNotificationPrefs
+ * @queries: notifications.listByUser (Long Run 2; @todo: requires schema add notifications)
+ * @mutations: notifications.markRead
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { mockNotificationItems } from "@tempo/mock-data";
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Notifications"
-      category="Settings"
-      source="screens-6.jsx"
-      summary="Quiet notification settings."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-eyebrow text-muted-foreground">Notifications</p>
+            <h1 className="text-h1 font-serif text-foreground">Gentle pings only.</h1>
+          </div>
+          {/*
+            @action markAllNotificationsRead
+            @mutation: notifications.markAllRead (Long Run 2)
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="soft" size="sm">
+            Mark all read
+          </Button>
+        </header>
+        <ul className="space-y-3">
+          {mockNotificationItems.map((n) => (
+            <li key={n.id}>
+              <SoftCard padding="md" className={n.unread ? "border-primary/30" : ""}>
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p className="font-medium text-foreground">{n.title}</p>
+                    <p className="mt-1 text-small text-muted-foreground">{n.body}</p>
+                  </div>
+                  {n.unread ? <Pill tone="orange">New</Pill> : null}
+                </div>
+              </SoftCard>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/plan/page.tsx
+++ b/apps/web/app/(tempo)/plan/page.tsx
@@ -1,23 +1,161 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: plan
  * @category: Flow
- * @source: docs/design/claude-export/design-system/screens-1.jsx
- * @summary: Week / month planning grid.
- * @queries: plan.week
- * @mutations: plan.stage
+ * @source: docs/design/claude-export/design-system/screens-1.jsx:L301-L383
+ * @queries:
+ *   - planBlocks.listForDay (Long Run 2; @todo: requires schema add planBlocks + by_userId_deletedAt)
+ *   - tasks.listByUser withIndex("by_userId_deletedAt")
+ * @mutations:
+ *   - planBlocks.replaceDay (Long Run 2)
+ * @routes-to: /today
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { mockCoachPlanBubble, mockPlanBlocks, mockPlanCoachEnergyCaption, mockPlanSummary } from "@tempo/mock-data";
+import { Button, CoachBubble, SoftCard } from "@tempo/ui/primitives";
+import { Leaf, Pebble, Sparkles } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
+
+function EnergyBarPreview({ level }: { level: number }) {
+  return (
+    <div className="flex gap-1" role="img" aria-label={`Energy level ${level} of 5`}>
+      {Array.from({ length: 5 }, (_, i) => (
+        <div
+          key={i}
+          className={[
+            "h-2 w-6 rounded-full",
+            i < level ? "bg-primary" : "bg-surface-sunken",
+          ].join(" ")}
+        />
+      ))}
+    </div>
+  );
+}
+
+function blockToneClasses(tone: (typeof mockPlanBlocks)[0]["tone"]) {
+  if (tone === "accent") {
+    return "border-l-[3px] border-primary bg-[color:var(--color-tempo-orange)]/12";
+  }
+  if (tone === "moss") {
+    return "border-l-[3px] border-[color:var(--color-moss)] bg-[color:var(--color-moss)]/10";
+  }
+  return "border-l-[3px] border-[color:var(--color-slate-blue)] bg-[color:var(--color-slate-blue)]/10";
+}
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [dayWeek, setDayWeek] = useState<"day" | "week">("day");
+
   return (
-    <ScaffoldScreen
-      title="Planning"
-      category="Flow"
-      source="screens-1.jsx"
-      summary="Week / month planning grid."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-6xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <p className="font-eyebrow text-muted-foreground">Plan · Thursday</p>
+            <h1 className="text-h1 font-serif text-foreground">Let&apos;s stage today.</h1>
+            <p className="max-w-xl text-body leading-relaxed text-muted-foreground">
+              Coach suggests six blocks based on yesterday&apos;s energy curve and your two anchors (pages + walk).
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="inline-flex rounded-lg border border-border bg-surface-sunken p-0.5">
+              {/*
+                @action setPlanGranularityDay
+                @query: planBlocks.listForDay
+                @auth: required
+                @env: NEXT_PUBLIC_CONVEX_URL
+                @source: screens-1.jsx:L323
+              */}
+              <Button
+                type="button"
+                variant={dayWeek === "day" ? "primary" : "ghost"}
+                size="sm"
+                onClick={() => setDayWeek("day")}
+              >
+                Day
+              </Button>
+              {/*
+                @action setPlanGranularityWeek
+                @query: planBlocks.listForWeek (Long Run 2)
+                @auth: required
+                @env: NEXT_PUBLIC_CONVEX_URL
+                @source: screens-1.jsx:L324
+              */}
+              <Button
+                type="button"
+                variant={dayWeek === "week" ? "primary" : "ghost"}
+                size="sm"
+                onClick={() => setDayWeek("week")}
+              >
+                Week
+              </Button>
+            </div>
+            {/*
+              @action replanWithCoach
+              @action-call: coach.replanDay (Long Run 2)
+              @auth: required
+              @errors: toast
+              @env: NEXT_PUBLIC_CONVEX_URL
+              @source: screens-1.jsx:L326
+            */}
+            <Button type="button" variant="primary" size="md" leadingIcon={<Sparkles size={14} />}>
+              Re-plan
+            </Button>
+          </div>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+          <SoftCard padding="md">
+            <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+              <h2 className="text-h3 font-serif text-foreground">Timeline</h2>
+              <span className="text-caption text-muted-foreground">{mockPlanSummary}</span>
+            </div>
+            <ul className="space-y-2">
+              {mockPlanBlocks.map((b) => (
+                <li
+                  key={b.id}
+                  className={[
+                    "rounded-lg border border-border-soft px-4 py-3",
+                    blockToneClasses(b.tone),
+                  ].join(" ")}
+                >
+                  <div className="font-medium text-foreground">{b.title}</div>
+                  <div className="text-caption text-muted-foreground">
+                    {b.startLabel}–{b.endLabel}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </SoftCard>
+
+          <aside className="space-y-6">
+            <SoftCard padding="md">
+              <p className="mb-3 font-eyebrow text-muted-foreground">Energy check-in</p>
+              <EnergyBarPreview level={4} />
+              <p className="mt-2 text-caption text-muted-foreground">{mockPlanCoachEnergyCaption}</p>
+            </SoftCard>
+            <SoftCard padding="md">
+              <p className="mb-3 font-eyebrow text-muted-foreground">Anchors</p>
+              <ul className="space-y-3 text-small text-foreground">
+                <li className="flex items-center gap-2">
+                  <Pebble size={16} className="shrink-0 text-muted-foreground" />
+                  <span>Morning pages — 8:00</span>
+                </li>
+                <li className="flex items-center gap-2">
+                  <Leaf size={16} className="shrink-0 text-muted-foreground" />
+                  <span>10-minute walk — 12:30</span>
+                </li>
+              </ul>
+            </SoftCard>
+            <SoftCard tone="sunken" padding="md">
+              <CoachBubble>{mockCoachPlanBubble}</CoachBubble>
+            </SoftCard>
+          </aside>
+        </div>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/projects/[id]/kanban/page.tsx
+++ b/apps/web/app/(tempo)/projects/[id]/kanban/page.tsx
@@ -1,30 +1,77 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: project-kanban
  * @category: Library
  * @source: docs/design/claude-export/design-system/screens-4.jsx
- * @summary: Project kanban board.
- * @queries: projects.get, projects.tasks
- * @mutations: tasks.moveColumn
+ * @queries: tasks.listByProject grouped by column (Long Run 2)
+ * @mutations: tasks.moveColumn (Long Run 2)
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
 
-type Params = { id: string };
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useState } from "react";
+import { mockProjectKanbanColumns } from "@tempo/mock-data";
+import { SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<Params>;
-}) {
-  const { id } = await params;
+export default function Page() {
+  const params = useParams();
+  const id = typeof params.id === "string" ? params.id : "";
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Project kanban"
-      category="Library"
-      source="screens-4.jsx"
-      summary={`Project kanban board. (id: ${id})`}
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="space-y-6 p-6 pb-24 md:p-8">
+        <div className="flex flex-wrap items-center gap-3">
+          <Link
+            href={`/projects/${id}`}
+            className="text-small text-muted-foreground hover:text-foreground"
+          >
+            ← Project
+          </Link>
+        </div>
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Kanban</p>
+          <h1 className="text-h1 font-serif text-foreground">Board view</h1>
+        </header>
+
+        <div className="flex gap-4 overflow-x-auto pb-2">
+          {mockProjectKanbanColumns.map((col) => (
+            <SoftCard key={col.title} padding="md" className="w-72 shrink-0">
+              <h2 className="font-medium text-foreground">{col.title}</h2>
+              <ul className="mt-3 space-y-2">
+                {col.items.map((item) => (
+                  <li key={item}>
+                    {/*
+                      @action moveKanbanCard
+                      @mutation: tasks.setColumn (Long Run 2)
+                      @optimistic: card moves columns
+                      @auth: required
+                      @errors: toast
+                      @env: NEXT_PUBLIC_CONVEX_URL
+                    */}
+                    <button
+                      type="button"
+                      className="w-full rounded-lg border border-border-soft bg-surface-sunken/50 px-3 py-2 text-left text-small text-foreground hover:bg-surface-sunken"
+                    >
+                      {item}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </SoftCard>
+          ))}
+        </div>
+
+        <Link
+          href={`/projects/${id}`}
+          className="inline-flex h-10 items-center justify-center rounded-lg px-4 text-body font-medium text-muted-foreground hover:bg-surface-sunken hover:text-foreground"
+        >
+          List view
+        </Link>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/projects/[id]/page.tsx
+++ b/apps/web/app/(tempo)/projects/[id]/page.tsx
@@ -1,30 +1,118 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: project-detail
  * @category: Library
  * @source: docs/design/claude-export/design-system/screens-4.jsx
- * @summary: Project detail with tasks + notes.
- * @queries: projects.get, projects.tasks
- * @mutations: projects.update
+ * @queries: projects.getById (Long Run 2), tasks.listByProjectId (Long Run 2)
+ * @mutations: tasks.softDelete @index by_userId_deletedAt
+ * @routes-to: /projects/[id]/kanban
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
 
-type Params = { id: string };
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import {
+  mockProjectDetailTasks,
+  mockProjectLinkedNoteTitles,
+  mockProjects,
+} from "@tempo/mock-data";
+import { Button, SoftCard, TaskRow } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<Params>;
-}) {
-  const { id } = await params;
+export default function Page() {
+  const params = useParams();
+  const router = useRouter();
+  const id = typeof params.id === "string" ? params.id : "";
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [tasks, setTasks] = useState(() =>
+    id === "proj-tempo-10"
+      ? mockProjectDetailTasks.map((t) => ({ ...t, done: t.status === "done" }))
+      : [],
+  );
+
+  const project = useMemo(() => mockProjects.find((p) => p.id === id) ?? null, [id]);
+
+  const toggle = (taskId: string, next: boolean) => {
+    setTasks((prev) =>
+      prev.map((t) =>
+        t.id === taskId ? { ...t, done: next, status: next ? ("done" as const) : ("todo" as const) } : t,
+      ),
+    );
+  };
+
+  if (!project) {
+    return (
+      <ScreenSurface mode={mode} onModeChange={setMode}>
+        <div className="p-8">
+          <SoftCard padding="md">
+            <p className="text-muted-foreground">Project not found.</p>
+            <Link href="/projects" className="mt-4 inline-block text-primary underline">
+              Back to projects
+            </Link>
+          </SoftCard>
+        </div>
+      </ScreenSurface>
+    );
+  }
+
   return (
-    <ScaffoldScreen
-      title="Project detail"
-      category="Library"
-      source="screens-4.jsx"
-      summary={`Project detail with tasks + notes. (id: ${id})`}
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-4xl space-y-8 p-6 pb-24 md:p-8">
+        <div className="flex flex-wrap items-center gap-3">
+          <Link href="/projects" className="text-small text-muted-foreground hover:text-foreground">
+            ← Projects
+          </Link>
+          {/*
+            @action openProjectKanban
+            @navigate: /projects/{id}/kanban
+            @query: tasks.listByProject (Long Run 2)
+            @auth: required
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="soft" size="sm" onClick={() => router.push(`/projects/${id}/kanban`)}>
+            Kanban
+          </Button>
+        </div>
+        <header>
+          <h1 className="text-h1 font-serif text-foreground">{project.name}</h1>
+          <p className="mt-2 text-body text-muted-foreground">
+            {project.taskIds.length} tasks · {project.noteIds.length} notes linked
+          </p>
+        </header>
+
+        <SoftCard padding="md">
+          <h2 className="font-eyebrow text-muted-foreground">Tasks</h2>
+          <div className="mt-3 divide-y divide-border-soft">
+            {tasks.length === 0 ? (
+              <p className="py-4 text-small text-muted-foreground">No tasks in mock for this project.</p>
+            ) : (
+              tasks.map((t) => (
+                <TaskRow
+                  key={t.id}
+                  taskId={t.id}
+                  title={t.title}
+                  done={t.done}
+                  meta={[t.dueLabel, t.estimatedMinutes != null ? `${t.estimatedMinutes} min` : ""]
+                    .filter(Boolean)
+                    .join(" · ")}
+                  onToggle={(tid, next) => toggle(tid, next)}
+                />
+              ))
+            )}
+          </div>
+        </SoftCard>
+
+        <SoftCard tone="sunken" padding="md">
+          <h2 className="font-eyebrow text-muted-foreground">Linked notes</h2>
+          <ul className="mt-2 list-inside list-disc text-small text-foreground">
+            {mockProjectLinkedNoteTitles.map((t) => (
+              <li key={t}>{t}</li>
+            ))}
+          </ul>
+        </SoftCard>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/projects/page.tsx
+++ b/apps/web/app/(tempo)/projects/page.tsx
@@ -1,23 +1,95 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: projects
  * @category: Library
  * @source: docs/design/claude-export/design-system/screens-4.jsx
- * @summary: Projects directory.
- * @queries: projects.list
+ * @queries: projects.listByUser (Long Run 2; @todo: requires schema add projects)
  * @mutations: projects.create
+ * @routes-to: /projects/[id]
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { mockProjectCards, mockProjects } from "@tempo/mock-data";
+import { Button, Pill, Ring, SoftCard } from "@tempo/ui/primitives";
+import { Plus } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
+
+const colorBorder: Record<(typeof mockProjects)[0]["color"], string> = {
+  orange: "border-l-[color:var(--color-tempo-orange)]",
+  amber: "border-l-[color:var(--color-amber)]",
+  moss: "border-l-[color:var(--color-moss)]",
+  brick: "border-l-[color:var(--color-brick)]",
+  slate: "border-l-[color:var(--color-slate-blue)]",
+};
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+
+  const cardById = useMemo(() => {
+    const m = new Map<string, (typeof mockProjectCards)[number]>();
+    for (const c of mockProjectCards) {
+      m.set(c.projectId, c);
+    }
+    return m;
+  }, []);
+
   return (
-    <ScaffoldScreen
-      title="Projects"
-      category="Library"
-      source="screens-4.jsx"
-      summary="Projects directory."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-4xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-eyebrow text-muted-foreground">Projects</p>
+            <h1 className="text-h1 font-serif text-foreground">Containers for momentum.</h1>
+          </div>
+          {/*
+            @action createProject
+            @mutation: projects.create (Long Run 2)
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="primary" leadingIcon={<Plus size={14} />}>
+            New project
+          </Button>
+        </header>
+
+        <ul className="space-y-3">
+          {mockProjects.map((p) => {
+            const card = cardById.get(p.id);
+            return (
+              <li key={p.id}>
+                <SoftCard
+                  padding="md"
+                  className={["border-l-4", colorBorder[p.color]].filter(Boolean).join(" ")}
+                >
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <Link href={`/projects/${p.id}`} className="min-w-0 flex-1 space-y-1">
+                      <h2 className="font-serif text-xl text-foreground hover:underline">{p.name}</h2>
+                      {card ? (
+                        <p className="text-small text-muted-foreground">
+                          Due {card.dueLabel} · {card.taskCount} tasks · {card.teamSize}{" "}
+                          teammate
+                        </p>
+                      ) : null}
+                    </Link>
+                    {card ? (
+                      <div className="flex items-center gap-2">
+                        <Ring size={44} stroke={3} value={card.percent} max={100}>
+                          <span className="text-caption font-tabular">{card.percent}</span>
+                        </Ring>
+                        <Pill tone="slate">{p.taskIds.length} linked tasks</Pill>
+                      </div>
+                    ) : null}
+                  </div>
+                </SoftCard>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/routines/[id]/page.tsx
+++ b/apps/web/app/(tempo)/routines/[id]/page.tsx
@@ -1,30 +1,106 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: routine-detail
  * @category: Library
  * @source: docs/design/claude-export/design-system/screens-3.jsx
- * @summary: Guided run of a routine.
- * @queries: routines.get
- * @mutations: routines.logRun
+ * @queries: routines.getById (Long Run 2)
+ * @mutations: routineRuns.start (Long Run 2)
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
 
-type Params = { id: string };
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useMemo, useState } from "react";
+import { mockRoutines } from "@tempo/mock-data";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+import { Check } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<Params>;
-}) {
-  const { id } = await params;
+export default function Page() {
+  const params = useParams();
+  const id = typeof params.id === "string" ? params.id : "";
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [stepDone, setStepDone] = useState<Record<string, boolean>>({});
+
+  const routine = useMemo(() => mockRoutines.find((r) => r.id === id) ?? null, [id]);
+
+  const toggleStep = (stepId: string) => {
+    setStepDone((prev) => ({ ...prev, [stepId]: !prev[stepId] }));
+  };
+
+  if (!routine) {
+    return (
+      <ScreenSurface mode={mode} onModeChange={setMode}>
+        <div className="p-8">
+          <SoftCard padding="md">
+            <p className="text-muted-foreground">Routine not found.</p>
+            <Link href="/routines" className="mt-4 inline-block text-primary underline">
+              Back to routines
+            </Link>
+          </SoftCard>
+        </div>
+      </ScreenSurface>
+    );
+  }
+
   return (
-    <ScaffoldScreen
-      title="Routine guided"
-      category="Library"
-      source="screens-3.jsx"
-      summary={`Guided run of a routine. (id: ${id})`}
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-3xl space-y-8 p-6 pb-24 md:p-8">
+        <Link href="/routines" className="text-small text-muted-foreground hover:text-foreground">
+          ← Routines
+        </Link>
+        <header>
+          <h1 className="text-h1 font-serif text-foreground">{routine.name}</h1>
+          <p className="mt-1 text-body text-muted-foreground">{routine.description}</p>
+        </header>
+
+        {/*
+          @action startGuidedRoutine
+          @mutation: routineRuns.start (Long Run 2)
+          @auth: required
+          @errors: toast
+          @env: NEXT_PUBLIC_CONVEX_URL
+        */}
+        <Button type="button" variant="primary">
+          Start guided run
+        </Button>
+
+        <ol className="space-y-3">
+          {routine.steps.map((s, idx) => (
+            <li key={s.id}>
+              <SoftCard padding="md" className="flex items-start gap-3">
+                <span className="font-tabular text-caption text-muted-foreground">{idx + 1}.</span>
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium text-foreground">{s.title}</p>
+                  <p className="text-caption text-muted-foreground">{s.durationMin} min</p>
+                </div>
+                {/*
+                  @action toggleRoutineStep
+                  @mutation: routineRuns.completeStep (Long Run 2)
+                  @auth: required
+                  @errors: toast
+                  @env: NEXT_PUBLIC_CONVEX_URL
+                */}
+                <button
+                  type="button"
+                  aria-pressed={Boolean(stepDone[s.id])}
+                  aria-label={stepDone[s.id] ? `Mark step ${s.title} not done` : `Mark step ${s.title} done`}
+                  onClick={() => toggleStep(s.id)}
+                  className={[
+                    "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border transition-colors",
+                    stepDone[s.id]
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border hover:border-primary",
+                  ].join(" ")}
+                >
+                  {stepDone[s.id] ? <Check size={16} strokeWidth={2.5} /> : null}
+                </button>
+              </SoftCard>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/routines/page.tsx
+++ b/apps/web/app/(tempo)/routines/page.tsx
@@ -1,23 +1,79 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: routines
  * @category: Library
- * @source: docs/design/claude-export/design-system/screens-3.jsx
- * @summary: Routine library.
- * @queries: routines.list
- * @mutations: routines.create
+ * @source: docs/design/claude-export/design-system/screens-2.jsx / screens-3.jsx
+ * @queries: routines.listByUser (Long Run 2; @todo: requires schema add routines)
+ * @mutations: routines.softDelete
+ * @routes-to: /routines/[id]
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { mockRoutineListMeta, mockRoutines } from "@tempo/mock-data";
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
+import { Plus } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+
+  const metaById = useMemo(() => {
+    const m = new Map<string, (typeof mockRoutineListMeta)[number]>();
+    for (const x of mockRoutineListMeta) {
+      m.set(x.routineId, x);
+    }
+    return m;
+  }, []);
+
   return (
-    <ScaffoldScreen
-      title="Routines"
-      category="Library"
-      source="screens-3.jsx"
-      summary="Routine library."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-4xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-eyebrow text-muted-foreground">Library · Routines</p>
+            <h1 className="text-h1 font-serif text-foreground">Sequences that hold.</h1>
+          </div>
+          {/*
+            @action createRoutine
+            @mutation: routines.create (Long Run 2)
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="primary" leadingIcon={<Plus size={14} />}>
+            New routine
+          </Button>
+        </header>
+
+        <ul className="space-y-3">
+          {mockRoutines.map((r) => {
+            const meta = metaById.get(r.id);
+            return (
+              <li key={r.id}>
+                <SoftCard padding="md">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                      <Link href={`/routines/${r.id}`} className="font-serif text-xl text-foreground hover:underline">
+                        {r.name}
+                      </Link>
+                      <p className="text-caption text-muted-foreground">{r.description}</p>
+                      {meta ? (
+                        <p className="text-small text-muted-foreground">
+                          {meta.scheduleLabel} · last {meta.lastLabel} · {meta.completionRate}% completion
+                        </p>
+                      ) : null}
+                    </div>
+                    <Pill tone="slate">{r.steps.length} steps</Pill>
+                  </div>
+                </SoftCard>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/search/page.tsx
+++ b/apps/web/app/(tempo)/search/page.tsx
@@ -1,23 +1,69 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: search
  * @category: You
  * @source: docs/design/claude-export/design-system/screens-5.jsx
- * @summary: Global search with previews.
- * @queries: search.everything
- * @mutations: (none)
+ * @queries: search.unified ({ q }) — tasks + notes + goals (Long Run 2)
+ * @mutations: none
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { mockSearchResults } from "@tempo/mock-data";
+import { Button, Field, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const router = useRouter();
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [q, setQ] = useState("launch");
+
   return (
-    <ScaffoldScreen
-      title="Search"
-      category="You"
-      source="screens-5.jsx"
-      summary="Global search with previews."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-3xl space-y-8 p-6 pb-24 md:p-8">
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Search</p>
+          <h1 className="text-h1 font-serif text-foreground">Find anything.</h1>
+        </header>
+        <Field
+          label="Query"
+          name="q"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Tasks, notes, goals…"
+        />
+        {/*
+          @action runSearch
+          @query: search.unified({ q }) @index multiple tables by_userId_deletedAt
+          @auth: required
+          @errors: empty state + toast
+          @env: NEXT_PUBLIC_CONVEX_URL
+        */}
+        <Button type="button" variant="primary" onClick={() => router.refresh()}>
+          Search
+        </Button>
+        <ul className="space-y-2">
+          {mockSearchResults.map((r) => (
+            <li key={r.id}>
+              <SoftCard padding="md">
+                {/*
+                  @action openSearchResult
+                  @navigate: dynamic from result
+                  @auth: required
+                  @env: NEXT_PUBLIC_CONVEX_URL
+                */}
+                <Link href={r.href} className="block">
+                  <p className="font-medium text-foreground">{r.title}</p>
+                  <p className="text-caption text-muted-foreground">{r.subtitle}</p>
+                </Link>
+              </SoftCard>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/settings/integrations/page.tsx
+++ b/apps/web/app/(tempo)/settings/integrations/page.tsx
@@ -1,23 +1,57 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: settings-integrations
  * @category: Settings
  * @source: docs/design/claude-export/design-system/screens-6.jsx
- * @summary: Google Calendar & other integrations.
- * @queries: integrations.list
- * @mutations: integrations.connect, integrations.disconnect
+ * @queries: integrations.listConnected (Long Run 2)
+ * @mutations: integrations.connect / disconnect (Long Run 2)
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
+
+const rows = [
+  { id: "cal", name: "Calendar sync", status: "Not connected" },
+  { id: "mail", name: "Email capture", status: "Coming soon" },
+] as const;
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Integrations"
-      category="Settings"
-      source="screens-6.jsx"
-      summary="Google Calendar & other integrations."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-xl space-y-8 p-6 pb-24 md:p-8">
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Settings</p>
+          <h1 className="text-h1 font-serif text-foreground">Integrations</h1>
+          <p className="mt-2 text-body text-muted-foreground">Connect tools gently. Nothing auto-posts without you.</p>
+        </header>
+        <ul className="space-y-3">
+          {rows.map((r) => (
+            <li key={r.id}>
+              <SoftCard padding="md" className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="font-medium text-foreground">{r.name}</p>
+                  <p className="text-caption text-muted-foreground">{r.status}</p>
+                </div>
+                {/*
+                  @action connectIntegration
+                  @mutation: integrations.oauthStart (Long Run 2)
+                  @auth: required
+                  @errors: toast
+                  @env: NEXT_PUBLIC_CONVEX_URL
+                */}
+                <Button type="button" variant="soft" size="sm" disabled={r.id === "mail"}>
+                  Connect
+                </Button>
+              </SoftCard>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/settings/preferences/page.tsx
+++ b/apps/web/app/(tempo)/settings/preferences/page.tsx
@@ -1,23 +1,63 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: settings-prefs
  * @category: Settings
  * @source: docs/design/claude-export/design-system/screens-6.jsx
- * @summary: Theme, dyslexia font, language, motion preferences.
- * @queries: users.preferences
- * @mutations: users.updatePreferences
+ * @queries: users.getPreferences
+ * @mutations: users.setPreferences (theme, dyslexiaFont, reducedMotion)
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { mockUser } from "@tempo/mock-data";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [theme, setTheme] = useState(mockUser.preferences.theme);
+  const [dyslexia, setDyslexia] = useState(mockUser.preferences.dyslexiaFont);
+  const [reduced, setReduced] = useState(mockUser.preferences.reducedMotion);
+
   return (
-    <ScaffoldScreen
-      title="Preferences"
-      category="Settings"
-      source="screens-6.jsx"
-      summary="Theme, dyslexia font, language, motion preferences."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-xl space-y-8 p-6 pb-24 md:p-8">
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Settings</p>
+          <h1 className="text-h1 font-serif text-foreground">Preferences</h1>
+        </header>
+        <SoftCard padding="md" className="space-y-6">
+          <fieldset>
+            <legend className="font-eyebrow text-muted-foreground">Theme</legend>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {(["light", "dark", "system"] as const).map((t) => (
+                <Button key={t} type="button" size="sm" variant={theme === t ? "primary" : "soft"} onClick={() => setTheme(t)}>
+                  {t}
+                </Button>
+              ))}
+            </div>
+          </fieldset>
+          <label className="flex items-center gap-3 text-body text-foreground">
+            <input type="checkbox" checked={dyslexia} onChange={(e) => setDyslexia(e.target.checked)} className="h-4 w-4" />
+            OpenDyslexic font
+          </label>
+          <label className="flex items-center gap-3 text-body text-foreground">
+            <input type="checkbox" checked={reduced} onChange={(e) => setReduced(e.target.checked)} className="h-4 w-4" />
+            Reduce motion
+          </label>
+          {/*
+            @action savePreferences
+            @mutation: users.setPreferences @index by_deletedAt
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="primary">
+            Save preferences
+          </Button>
+        </SoftCard>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/settings/profile/page.tsx
+++ b/apps/web/app/(tempo)/settings/profile/page.tsx
@@ -1,23 +1,65 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
- * @screen: settings
+ * @screen: settings-profile
  * @category: Settings
  * @source: docs/design/claude-export/design-system/screens-6.jsx
- * @summary: User profile settings.
- * @queries: users.me
- * @mutations: users.updateProfile
+ * @queries: users.getMe (Convex auth + users table by_email)
+ * @mutations: users.patchProfile @index by_deletedAt
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { mockUser, mockUserProfileFields } from "@tempo/mock-data";
+import { Button, Field, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [name, setName] = useState(mockUser.name);
+  const [email, setEmail] = useState(mockUser.email);
+  const [displayName, setDisplayName] = useState<string>(mockUserProfileFields.displayName);
+
   return (
-    <ScaffoldScreen
-      title="Profile"
-      category="Settings"
-      source="screens-6.jsx"
-      summary="User profile settings."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-xl space-y-8 p-6 pb-24 md:p-8">
+        <header>
+          <p className="font-eyebrow text-muted-foreground">Settings</p>
+          <h1 className="text-h1 font-serif text-foreground">Profile</h1>
+        </header>
+        <SoftCard padding="md" className="space-y-4">
+          <Field label="Full name" name="name" value={name} onChange={(e) => setName(e.target.value)} />
+          <Field label="Email" name="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+          <Field
+            label="Display name"
+            name="displayName"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+          />
+          <Field label="Pronouns" name="pronouns" readOnly value={mockUserProfileFields.pronouns} />
+          <label htmlFor="bio" className="flex flex-col gap-1.5">
+            <span className="font-eyebrow text-muted-foreground">Bio</span>
+            <textarea
+              id="bio"
+              readOnly
+              rows={3}
+              className="rounded-lg border border-border bg-card p-3 font-serif text-small text-foreground"
+              value={mockUserProfileFields.bio}
+            />
+          </label>
+          {/*
+            @action saveProfile
+            @mutation: users.patch @index by_email
+            @soft-delete: no
+            @auth: required
+            @errors: toast
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="primary">
+            Save profile
+          </Button>
+        </SoftCard>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/tasks/page.tsx
+++ b/apps/web/app/(tempo)/tasks/page.tsx
@@ -1,23 +1,146 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: tasks
  * @category: Library
- * @source: docs/design/claude-export/design-system/screens-2.jsx
- * @summary: Tasks inbox with filters and grouping.
- * @queries: tasks.list
- * @mutations: tasks.complete, tasks.create
+ * @source: docs/design/claude-export/design-system/screens-1.jsx:L385-L434
+ * @queries: tasks.listByUser withIndex("by_userId_deletedAt")
+ * @mutations: tasks.create, tasks.complete, tasks.softDelete @index by_userId_status
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useState } from "react";
+import { mockLibraryTasks } from "@tempo/mock-data";
+import { Button, Pill, SoftCard, TaskRow } from "@tempo/ui/primitives";
+import { Filter, Plus, Tag } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
+
+function meta(t: (typeof mockLibraryTasks)[0]): string {
+  const parts: string[] = [];
+  if (t.dueLabel) {
+    parts.push(t.dueLabel);
+  }
+  if (t.estimatedMinutes != null) {
+    parts.push(`${t.estimatedMinutes} min`);
+  }
+  if (t.energy) {
+    parts.push(`${t.energy} energy`);
+  }
+  return parts.join(" · ");
+}
 
 export default function Page() {
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [tasks, setTasks] = useState(() =>
+    mockLibraryTasks.map((t) => ({ ...t, done: t.status === "done" })),
+  );
+
+  const toggle = (id: string, next: boolean) => {
+    setTasks((prev) =>
+      prev.map((t) =>
+        t.id === id ? { ...t, done: next, status: next ? ("done" as const) : ("todo" as const) } : t,
+      ),
+    );
+  };
+
   return (
-    <ScaffoldScreen
-      title="Tasks"
-      category="Library"
-      source="screens-2.jsx"
-      summary="Tasks inbox with filters and grouping."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-4xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <p className="font-eyebrow text-muted-foreground">Library · Tasks</p>
+            <h1 className="text-h1 font-serif text-foreground">Small things, in order.</h1>
+            <p className="max-w-xl text-body text-muted-foreground">
+              Twelve in flight. Three flagged by Coach as &quot;high energy&quot; — tackle before noon if you can.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <div className="inline-flex rounded-lg border border-border bg-surface-sunken p-0.5">
+              {/*
+                @action setTaskViewList
+                @query: tasks.listByUser
+                @auth: required
+                @env: NEXT_PUBLIC_CONVEX_URL
+                @source: screens-1.jsx:L407-L409
+              */}
+              <Button type="button" variant="primary" size="sm">
+                List
+              </Button>
+              <Button type="button" variant="ghost" size="sm">
+                Board
+              </Button>
+              <Button type="button" variant="ghost" size="sm">
+                Timeline
+              </Button>
+            </div>
+            {/*
+              @action createTask
+              @mutation: tasks.create @index by_userId_deletedAt
+              @navigate: modal or inline form
+              @auth: required
+              @errors: toast
+              @env: NEXT_PUBLIC_CONVEX_URL
+              @source: screens-1.jsx:L412
+            */}
+            <Button type="button" variant="primary" leadingIcon={<Plus size={14} />}>
+              New task
+            </Button>
+          </div>
+        </header>
+
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap gap-1 rounded-lg border border-border bg-card p-1">
+            {(["All", "Today", "Upcoming", "Someday", "Done"] as const).map((tab) => (
+              <Button key={tab} type="button" size="sm" variant={tab === "All" ? "primary" : "ghost"}>
+                {tab}
+              </Button>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            {/*
+              @action openEnergyFilter
+              @query: tasks.listByUser (filtered server-side)
+              @auth: required
+              @env: NEXT_PUBLIC_CONVEX_URL
+              @source: screens-1.jsx:L421
+            */}
+            <Button type="button" variant="soft" size="sm" leadingIcon={<Filter size={14} />}>
+              Energy
+            </Button>
+            {/*
+              @action openTagFilter
+              @query: tasks.listByUser
+              @auth: required
+              @env: NEXT_PUBLIC_CONVEX_URL
+              @source: screens-1.jsx:L422
+            */}
+            <Button type="button" variant="soft" size="sm" leadingIcon={<Tag size={14} />}>
+              Tag
+            </Button>
+          </div>
+        </div>
+
+        <SoftCard padding="md">
+          <div className="divide-y divide-border-soft">
+            {tasks.map((t) => (
+              <TaskRow
+                key={t.id}
+                taskId={t.id}
+                title={t.title}
+                done={t.done}
+                meta={meta(t)}
+                onToggle={(id, next) => toggle(id, next)}
+                trailing={
+                  <div className="flex shrink-0 gap-1">
+                    {t.coachSuggested ? <Pill tone="orange">Coach</Pill> : null}
+                    {t.tag ? <Pill tone="slate">{t.tag}</Pill> : null}
+                  </div>
+                }
+              />
+            ))}
+          </div>
+        </SoftCard>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/templates/editor/[id]/page.tsx
+++ b/apps/web/app/(tempo)/templates/editor/[id]/page.tsx
@@ -1,30 +1,60 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: template-editor
  * @category: You
- * @source: docs/design/claude-export/design-system/screens-5.jsx
- * @summary: Legacy template editor.
- * @queries: (none)
- * @mutations: (none)
+ * @source: docs/design/claude-export/design-system/screens-5.jsx (legacy editor)
+ * @queries: templates.getById (Long Run 2)
+ * @mutations: templates.updateMarkdown
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
 
-type Params = { id: string };
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useMemo, useState } from "react";
+import { mockMyTemplates } from "@tempo/mock-data";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<Params>;
-}) {
-  const { id } = await params;
+export default function Page() {
+  const params = useParams();
+  const id = typeof params.id === "string" ? params.id : "";
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const tpl = useMemo(() => mockMyTemplates.find((t) => t.id === id), [id]);
+  const [body, setBody] = useState(
+    `# ${tpl?.name ?? "Template"}\n\nStep one…\n\nStep two…`,
+  );
+
   return (
-    <ScaffoldScreen
-      title="Template editor (legacy)"
-      category="You"
-      source="screens-5.jsx"
-      summary={`Legacy template editor. (id: ${id})`}
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-3xl space-y-6 p-6 pb-24 md:p-8">
+        <Link href="/templates" className="text-small text-muted-foreground hover:text-foreground">
+          ← Templates
+        </Link>
+        <h1 className="text-h1 font-serif text-foreground">Edit · {tpl?.name ?? id}</h1>
+        <SoftCard padding="md">
+          <label htmlFor="tpl-md" className="sr-only">
+            Markdown
+          </label>
+          <textarea
+            id="tpl-md"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            rows={18}
+            className="w-full resize-y rounded-lg border border-border bg-transparent p-3 font-mono text-small text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </SoftCard>
+        {/*
+          @action saveTemplateMarkdown
+          @mutation: templates.updateMarkdown (Long Run 2)
+          @auth: required
+          @errors: toast
+          @env: NEXT_PUBLIC_CONVEX_URL
+        */}
+        <Button type="button" variant="primary">
+          Save
+        </Button>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/templates/page.tsx
+++ b/apps/web/app/(tempo)/templates/page.tsx
@@ -1,23 +1,132 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: templates
  * @category: You
  * @source: docs/design/claude-export/design-system/screens-templates.jsx
- * @summary: Template library.
- * @queries: templates.list
- * @mutations: (none)
+ * @queries: templates.listStarters, templates.listMine (Long Run 2; @todo: requires schema add templates)
+ * @mutations: templates.forkStarter
+ * @routes-to: /templates/builder, /templates/run/[id], /templates/editor/[id]
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { mockMyTemplates, mockTemplateStarters } from "@tempo/mock-data";
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
+import { Plus } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const router = useRouter();
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Templates"
-      category="You"
-      source="screens-templates.jsx"
-      summary="Template library."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-5xl space-y-10 p-6 pb-24 md:p-8">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-eyebrow text-muted-foreground">Templates</p>
+            <h1 className="text-h1 font-serif text-foreground">Reusable rhythms.</h1>
+          </div>
+          {/*
+            @action openTemplateBuilder
+            @navigate: /templates/builder
+            @mutation: templates.createDraft (Long Run 2)
+            @auth: required
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Button type="button" variant="primary" leadingIcon={<Plus size={14} />} onClick={() => router.push("/templates/builder")}>
+            New template
+          </Button>
+        </header>
+
+        <section aria-labelledby="starters-heading">
+          <h2 id="starters-heading" className="mb-4 font-eyebrow text-muted-foreground">
+            Starters
+          </h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {mockTemplateStarters.map((t) => (
+              <SoftCard key={t.id} padding="md" className="flex flex-col gap-2">
+                <div className="flex items-start justify-between gap-2">
+                  <span className="text-2xl" aria-hidden>
+                    {t.emoji}
+                  </span>
+                  {t.starred ? <Pill tone="moss">Popular</Pill> : null}
+                </div>
+                <h3 className="font-serif text-lg text-foreground">{t.name}</h3>
+                <p className="flex-1 text-small text-muted-foreground">{t.description}</p>
+                <p className="text-caption text-muted-foreground">
+                  {t.stepCount} steps · {t.kicker}
+                </p>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {/*
+                    @action runTemplateStarter
+                    @navigate: /templates/run/{id}
+                    @query: templates.getById
+                    @auth: required
+                    @env: NEXT_PUBLIC_CONVEX_URL
+                  */}
+                  <Button type="button" size="sm" variant="primary" onClick={() => router.push(`/templates/run/${t.id}`)}>
+                    Run
+                  </Button>
+                  {/*
+                    @action forkTemplateStarter
+                    @mutation: templates.fork (Long Run 2)
+                    @auth: required
+                    @errors: toast
+                    @env: NEXT_PUBLIC_CONVEX_URL
+                  */}
+                  <Button type="button" size="sm" variant="soft">
+                    Fork
+                  </Button>
+                </div>
+              </SoftCard>
+            ))}
+          </div>
+        </section>
+
+        <section aria-labelledby="mine-heading">
+          <h2 id="mine-heading" className="mb-4 font-eyebrow text-muted-foreground">
+            My templates
+          </h2>
+          <ul className="space-y-3">
+            {mockMyTemplates.map((t) => (
+              <li key={t.id}>
+                <SoftCard padding="md" className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="flex items-center gap-3">
+                    <span className="text-xl" aria-hidden>
+                      {t.emoji}
+                    </span>
+                    <div>
+                      <p className="font-medium text-foreground">{t.name}</p>
+                      <p className="text-caption text-muted-foreground">{t.description}</p>
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button type="button" size="sm" variant="soft" onClick={() => router.push(`/templates/editor/${t.id}`)}>
+                      Edit
+                    </Button>
+                    <Button type="button" size="sm" variant="primary" onClick={() => router.push(`/templates/run/${t.id}`)}>
+                      Run
+                    </Button>
+                  </div>
+                </SoftCard>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/*
+          @action openTemplateSketch
+          @navigate: /templates/sketch
+          @auth: required
+          @env: NEXT_PUBLIC_CONVEX_URL
+        */}
+        <Button type="button" variant="ghost" onClick={() => router.push("/templates/sketch")}>
+          Open sketch mode
+        </Button>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/templates/sketch/page.tsx
+++ b/apps/web/app/(tempo)/templates/sketch/page.tsx
@@ -1,23 +1,43 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: template-sketch
  * @category: You
  * @source: docs/design/claude-export/design-system/screens-5.jsx
- * @summary: Template sketch playground.
- * @queries: (none)
- * @mutations: (none)
+ * @queries: none
+ * @mutations: templates.saveSketchRaster (Long Run 2; optional)
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
 
 export default function Page() {
+  const router = useRouter();
+  const [mode, setMode] = useState<ViewMode>("ready");
+
   return (
-    <ScaffoldScreen
-      title="Template sketch"
-      category="You"
-      source="screens-5.jsx"
-      summary="Template sketch playground."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-4xl space-y-6 p-6 pb-24 md:p-8">
+        <header className="flex items-center justify-between gap-4">
+          <div>
+            <p className="font-eyebrow text-muted-foreground">Sketch</p>
+            <h1 className="text-h1 font-serif text-foreground">Freehand before structure.</h1>
+          </div>
+          <Button type="button" variant="ghost" onClick={() => router.push("/templates")}>
+            Done
+          </Button>
+        </header>
+        <SoftCard padding="none" className="aspect-[4/3] w-full bg-surface-sunken">
+          <div className="flex h-full min-h-[320px] items-center justify-center p-8">
+            <p className="max-w-sm text-center text-body text-muted-foreground">
+              Drawing surface placeholder — wire to canvas or export PNG in Long Run 2.
+            </p>
+          </div>
+        </SoftCard>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/(tempo)/today/page.tsx
+++ b/apps/web/app/(tempo)/today/page.tsx
@@ -1,24 +1,309 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: today
  * @category: Flow
- * @source: docs/design/claude-export/design-system/screens-1.jsx
+ * @source: docs/design/claude-export/design-system/screens-1.jsx:L4-L111
  * @summary: Single-column daily canvas. Brain-dump composer + staged plan + coach suggestion.
- * @queries: tasks.listToday, calendar.listToday, coach.latestSuggestion
- * @mutations: tasks.capture, tasks.complete, tasks.stage
- * @routes-to: /brain-dump, /coach
+ * @queries:
+ *   - tasks.listByUser({ userId, deletedAt: undefined }) withIndex("by_userId_deletedAt")
+ *   - habits.listByUser({ userId, deletedAt: undefined }) withIndex("by_userId_deletedAt")
+ *   - coach.latestSuggestion (conversations/messages — @todo: requires schema add Long Run 2)
+ * @mutations:
+ *   - tasks.complete({ taskId }) @index by_userId_status
+ *   - tasks.softDelete({ taskId }) @index by_userId_deletedAt @soft-delete: yes
+ * @routes-to: /plan, /brain-dump, /coach
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL
+ * @notes: Copy from Claude export; Vercel preview uses mock-data only until Long Run 2.
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import {
+  mockCoachTodayBubble,
+  mockTodayPage,
+  mockTodayTasks,
+} from "@tempo/mock-data";
+import { Button, CoachBubble, Pill, Ring, SoftCard, TaskRow } from "@tempo/ui/primitives";
+import { Clock, Plus, Sparkles } from "@tempo/ui/icons";
+import { ScreenSurface, type ViewMode } from "@/components/tempo-port/ScreenSurface";
+
+function taskMeta(t: (typeof mockTodayTasks)[0]): string {
+  const parts: string[] = [];
+  if (t.dueLabel) {
+    parts.push(t.dueLabel);
+  }
+  if (t.estimatedMinutes != null) {
+    parts.push(`${t.estimatedMinutes} min`);
+  }
+  if (t.energy) {
+    parts.push(`${t.energy} energy`);
+  }
+  return parts.join(" · ");
+}
+
+function EnergyBarPreview({ level }: { level: number }) {
+  return (
+    <div className="flex gap-1" role="img" aria-label={`Energy level ${level} of 5`}>
+      {Array.from({ length: 5 }, (_, i) => (
+        <div
+          key={i}
+          className={[
+            "h-2 w-6 rounded-full",
+            i < level ? "bg-primary" : "bg-surface-sunken",
+          ].join(" ")}
+        />
+      ))}
+    </div>
+  );
+}
 
 export default function Page() {
+  const router = useRouter();
+  const [mode, setMode] = useState<ViewMode>("ready");
+  const [tasks, setTasks] = useState(() =>
+    mockTodayTasks.map((t) => ({
+      ...t,
+      done: t.status === "done",
+    })),
+  );
+
+  const doneCount = useMemo(() => tasks.filter((t) => t.done).length, [tasks]);
+  const total = tasks.length;
+  const ringPct = total === 0 ? 0 : Math.round((doneCount / total) * 100);
+
+  const toggle = (taskId: string, next: boolean) => {
+    setTasks((prev) =>
+      prev.map((t) =>
+        t.id === taskId
+          ? {
+              ...t,
+              done: next,
+              status: next ? ("done" as const) : ("todo" as const),
+            }
+          : t,
+      ),
+    );
+  };
+
+  const dateEyebrow = mockTodayPage.dateLabel.replace(", ", " · ");
+  const streakLabel = `${mockTodayPage.streakDays} days`;
+  const anchors = mockTodayPage.habitsSidebar.map((h) =>
+    "streakLabel" in h
+      ? {
+          label: h.name,
+          ring: h.ringPct,
+          pill: h.streakLabel,
+          pillTone: "moss" as const,
+        }
+      : {
+          label: h.name,
+          ring: h.ringPct,
+          pill: h.pill,
+          pillTone: h.pill === "due" ? ("amber" as const) : ("neutral" as const),
+        },
+  );
+  const upNext = mockTodayPage.upNextLines;
+
   return (
-    <ScaffoldScreen
-      title="Today"
-      category="Flow"
-      source="screens-1.jsx"
-      summary="Single-column daily canvas. Brain-dump composer + staged plan + coach suggestion."
-    />
+    <ScreenSurface mode={mode} onModeChange={setMode}>
+      <div className="mx-auto max-w-6xl space-y-8 p-6 pb-24 md:p-8">
+        <header className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <p className="font-eyebrow text-muted-foreground">{dateEyebrow}</p>
+            <h1 className="text-h1 font-serif text-foreground">{mockTodayPage.greeting}</h1>
+            <p className="max-w-xl text-body leading-relaxed text-muted-foreground">
+              {mockTodayPage.lede}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-6">
+            <div className="text-right">
+              <p className="font-eyebrow text-muted-foreground">Energy</p>
+              <EnergyBarPreview level={mockTodayPage.energyLevel} />
+            </div>
+            <div className="hidden h-10 w-px bg-border-soft sm:block" aria-hidden />
+            <div className="text-right">
+              <p className="font-eyebrow text-muted-foreground">Streak</p>
+              <p className="font-serif text-[22px] font-medium text-foreground">
+                {streakLabel}
+              </p>
+            </div>
+            {/*
+              @action openPlanWithCoach
+              @navigate: /plan
+              @query: planBlocks.listForDay (Long Run 2; @todo: requires schema add planBlocks)
+              @auth: required
+              @errors: toast on failure
+              @env: NEXT_PUBLIC_CONVEX_URL
+              @source: screens-1.jsx:L18-L19
+            */}
+            <Button
+              type="button"
+              variant="primary"
+              size="md"
+              leadingIcon={<Sparkles size={14} />}
+              onClick={() => router.push("/plan")}
+            >
+              Plan with Coach
+            </Button>
+          </div>
+        </header>
+
+        <div className="grid gap-6 lg:grid-cols-[1fr_minmax(280px,360px)]">
+          <div className="space-y-6">
+            <SoftCard padding="md">
+              <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="font-eyebrow text-muted-foreground">Today&apos;s anchors</p>
+                  <h2 className="text-h2 font-serif text-foreground">
+                    {doneCount} of {total} things
+                  </h2>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Ring size={40} stroke={3} value={ringPct} max={100}>
+                    <span className="text-caption font-tabular">{ringPct}</span>
+                  </Ring>
+                  {/*
+                    @action openQuickCapture
+                    @mutation: tasks.createDraft (Long Run 2)
+                    @index: by_userId_deletedAt
+                    @soft-delete: no
+                    @optimistic: prepend row
+                    @auth: required
+                    @errors: inline field error
+                    @env: NEXT_PUBLIC_CONVEX_URL
+                    @source: screens-1.jsx:L50
+                  */}
+                  <Button type="button" variant="soft" size="sm" leadingIcon={<Plus size={14} />}>
+                    Add
+                  </Button>
+                </div>
+              </div>
+              <div className="divide-y divide-border-soft rounded-lg border border-border-soft">
+                {tasks.map((t) => (
+                  <TaskRow
+                    key={t.id}
+                    taskId={t.id}
+                    title={t.title}
+                    done={t.done}
+                    meta={taskMeta(t)}
+                    onToggle={(id, next) => toggle(id, next)}
+                    trailing={
+                      t.coachSuggested ? (
+                        <Pill tone="orange" className="shrink-0">
+                          Coach
+                        </Pill>
+                      ) : null
+                    }
+                  />
+                ))}
+              </div>
+              <SoftCard tone="sunken" padding="sm" className="mt-4 border-border-soft">
+                <p className="text-small text-muted-foreground">
+                  Two overdue things from yesterday. Carry them to today, or let them rest?
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {/*
+                    @action carryOverOverdue
+                    @mutation: tasks.bulkReschedule (Long Run 2)
+                    @index: by_userId_dueAt
+                    @soft-delete: no
+                    @confirm: undoable 5s
+                    @auth: required
+                    @errors: toast
+                    @env: NEXT_PUBLIC_CONVEX_URL
+                  */}
+                  <Button type="button" size="sm" variant="soft">
+                    Carry to today
+                  </Button>
+                  {/*
+                    @action dismissOverduePrompt
+                    @mutation: none (client dismiss + optional coach.dismissPrompt)
+                    @auth: required
+                    @errors: none
+                    @env: NEXT_PUBLIC_CONVEX_URL
+                  */}
+                  <Button type="button" size="sm" variant="ghost">
+                    Let them rest
+                  </Button>
+                </div>
+              </SoftCard>
+            </SoftCard>
+
+            <SoftCard tone="sunken" padding="md">
+              <CoachBubble
+                actions={
+                  <>
+                    {/*
+                      @action acceptCoachStageOutline
+                      @mutation: coach.acceptSuggestion (Long Run 2; maps to messages insert)
+                      @index: by_conversationId_createdAt
+                      @soft-delete: no
+                      @optimistic: disable buttons until ack
+                      @auth: required
+                      @errors: toast
+                      @env: NEXT_PUBLIC_CONVEX_URL
+                      @source: screens-1.jsx:L64
+                    */}
+                    <Button type="button" size="sm" variant="primary">
+                      Stage the outline
+                    </Button>
+                    {/*
+                      @action skipCoachSuggestion
+                      @mutation: coach.skipSuggestion
+                      @auth: required
+                      @errors: toast
+                      @env: NEXT_PUBLIC_CONVEX_URL
+                      @source: screens-1.jsx:L65
+                    */}
+                    <Button type="button" size="sm" variant="ghost">
+                      Not now
+                    </Button>
+                  </>
+                }
+              >
+                {mockCoachTodayBubble}
+              </CoachBubble>
+            </SoftCard>
+          </div>
+
+          <aside className="space-y-6">
+            <SoftCard padding="md">
+              <p className="mb-3 font-eyebrow text-muted-foreground">Habits · today</p>
+              <div className="space-y-4">
+                {anchors.map((h) => (
+                  <div key={h.label} className="flex items-center justify-between gap-3">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <Ring size={32} stroke={3} value={Math.round(h.ring * 100)} max={100} />
+                      <span className="truncate font-medium text-foreground">{h.label}</span>
+                    </div>
+                    <Pill tone={h.pillTone}>{h.pill}</Pill>
+                  </div>
+                ))}
+              </div>
+            </SoftCard>
+
+            <SoftCard padding="md">
+              <p className="mb-3 font-eyebrow text-muted-foreground">Up next</p>
+              <ul className="space-y-0 divide-y divide-border-soft">
+                {upNext.map((line) => (
+                  <li key={line} className="flex items-center gap-2 py-2 text-small text-foreground">
+                    <Clock size={14} strokeWidth={1.5} className="shrink-0 text-muted-foreground" />
+                    <span>{line}</span>
+                  </li>
+                ))}
+              </ul>
+            </SoftCard>
+
+            <SoftCard tone="sunken" padding="md" className="border-dashed border-border-soft">
+              <p className="font-eyebrow text-muted-foreground">Pebble of the day</p>
+              <p className="mt-2 font-serif text-lg leading-relaxed text-foreground">
+                {mockTodayPage.pebbleQuote}
+              </p>
+            </SoftCard>
+          </aside>
+        </div>
+      </div>
+    </ScreenSurface>
   );
 }

--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -1,20 +1,43 @@
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import Link from "next/link";
+import { SoftCard } from "@tempo/ui/primitives";
 
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005f (marketing port).
  * @screen: about
  * @category: Marketing
  * @source: docs/design/claude-export/design-system/about.html
  * @summary: Founder bio, facts, philosophy.
  * @auth: public
+ * @env: NEXT_PUBLIC_CONVEX_URL
  */
 export default function Page() {
   return (
-    <ScaffoldScreen
-      title="About"
-      category="Marketing"
-      source="about.html"
-      summary="Founder bio, facts, and philosophy."
-    />
+    <main className="mx-auto max-w-3xl px-6 py-16">
+      <Link href="/" className="text-small text-muted-foreground hover:text-foreground">
+        ← Home
+      </Link>
+      <h1 className="mt-6 text-h1 font-serif text-foreground">About Tempo Flow</h1>
+      <p className="mt-4 text-body leading-relaxed text-muted-foreground">
+        Tempo is an overwhelm-first planner: brain dump, gentle sort, small plans, and a coach that never
+        shames you for capacity.
+      </p>
+      <SoftCard padding="lg" className="mt-10">
+        <p className="font-serif text-lg leading-relaxed text-foreground">
+          I built Tempo because I needed a tool that treated low-spoons days as normal, not as failure. The
+          product is opinionated about warmth, consent, and undo — every AI change is a proposal you accept.
+        </p>
+        <p className="mt-4 font-serif text-lg italic text-muted-foreground">— Amit</p>
+      </SoftCard>
+      {/*
+        @action aboutContact
+        @navigate: /contact
+        @auth: public
+      */}
+      <Link
+        href="/contact"
+        className="mt-8 inline-flex h-10 items-center justify-center rounded-lg border border-border bg-card px-4 text-body font-medium text-foreground hover:bg-surface-sunken"
+      >
+        Contact
+      </Link>
+    </main>
   );
 }

--- a/apps/web/app/changelog/page.tsx
+++ b/apps/web/app/changelog/page.tsx
@@ -1,20 +1,43 @@
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import Link from "next/link";
+import { Pill, SoftCard } from "@tempo/ui/primitives";
 
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005f (marketing port).
  * @screen: changelog
  * @category: Marketing
  * @source: docs/design/claude-export/design-system/changelog.html
- * @summary: Shipping notes, quiet & chronological.
+ * @summary: Shipping notes, quiet and chronological.
  * @auth: public
  */
+const releases = [
+  { version: "1.0.0-rc", date: "April 2026", notes: ["42 web screens scaffolded", "Convex soft-delete indexes"] },
+  { version: "0.9.0", date: "March 2026", notes: ["Brain dump RAM-only rule enforced", "Coach warmth dial"] },
+] as const;
+
 export default function Page() {
   return (
-    <ScaffoldScreen
-      title="Changelog"
-      category="Marketing"
-      source="changelog.html"
-      summary="Quiet shipping notes from 0.9.0 through 1.0."
-    />
+    <main className="mx-auto max-w-3xl px-6 py-16">
+      <Link href="/" className="text-small text-muted-foreground hover:text-foreground">
+        ← Home
+      </Link>
+      <h1 className="mt-6 text-h1 font-serif text-foreground">Changelog</h1>
+      <p className="mt-2 text-body text-muted-foreground">Quiet shipping notes. Newest first.</p>
+      <ul className="mt-10 space-y-6">
+        {releases.map((r) => (
+          <li key={r.version}>
+            <SoftCard padding="md">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="font-serif text-xl text-foreground">{r.version}</h2>
+                <Pill tone="slate">{r.date}</Pill>
+              </div>
+              <ul className="mt-3 list-inside list-disc text-small text-muted-foreground">
+                {r.notes.map((n) => (
+                  <li key={n}>{n}</li>
+                ))}
+              </ul>
+            </SoftCard>
+          </li>
+        ))}
+      </ul>
+    </main>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,76 +1,174 @@
 import Link from "next/link";
 import { BrandMark, Wordmark } from "@tempo/ui/brand";
-import { Button, SoftCard } from "@tempo/ui/primitives";
+import { Button, CoachBubble, SoftCard } from "@tempo/ui/primitives";
 
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005f (landing port).
  * @screen: landing
  * @category: Marketing
  * @source: docs/design/claude-export/design-system/landing.html
- * @summary: Marketing landing page (hero, features, coach samples, pricing, founder letter, testimonials, footer).
+ * @summary: Marketing landing — hero, proof stats, feature intro, coach samples, CTA.
+ * @queries: none
+ * @mutations: none
  * @auth: public
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @env: NEXT_PUBLIC_CONVEX_URL (app links only)
  */
 export default function Landing() {
   return (
     <main className="min-h-screen bg-background text-foreground">
-      <nav className="flex items-center justify-between px-6 py-5 max-w-[var(--container-tempo)] mx-auto">
+      <nav className="mx-auto flex max-w-[var(--container-tempo)] items-center justify-between px-6 py-5">
         <div className="flex items-center gap-2">
           <BrandMark size={28} />
           <Wordmark size={20} />
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Link href="/changelog">
+            <Button variant="ghost" size="sm">
+              Changelog
+            </Button>
+          </Link>
+          {/*
+            @action navSignIn
+            @navigate: /sign-in
+            @auth: public
+            @env: NEXT_PUBLIC_CONVEX_URL
+            @source: landing.html:L131
+          */}
           <Link href="/sign-in">
             <Button variant="ghost" size="sm">
               Sign in
             </Button>
           </Link>
+          {/*
+            @action navStartTrial
+            @navigate: /onboarding
+            @auth: public
+            @source: landing.html:L132
+          */}
           <Link href="/onboarding">
             <Button variant="primary" size="sm">
-              Start your $1 walk
+              Start your $1 week
             </Button>
           </Link>
         </div>
       </nav>
 
-      <section className="px-6 pt-16 pb-24 max-w-[var(--container-tempo)] mx-auto">
-        <div className="max-w-3xl flex flex-col gap-6">
-          <span className="font-eyebrow">Scaffold · landing page</span>
-          <h1 className="font-display leading-[1.04]">
-            Your brain's <em className="tempo-gradient-text not-italic">operating system</em>.
-          </h1>
-          <p className="text-h3 text-muted-foreground leading-relaxed font-serif">
-            An overwhelm-first daily planner for ADHD, autistic, and
-            neurodivergent brains. Never shaming. Always gentle.
-          </p>
-          <div className="flex flex-wrap gap-3 pt-2">
-            <Link href="/onboarding">
-              <Button variant="primary" size="lg">
-                Start your seven-day walk — $1
-              </Button>
-            </Link>
-            <Link href="/today">
-              <Button variant="soft" size="lg">
-                Preview the app
-              </Button>
-            </Link>
-          </div>
+      <section className="mx-auto max-w-[var(--container-tempo)] px-6 pb-24 pt-12 md:pt-16">
+        <div className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3.5 py-1.5 text-small text-muted-foreground">
+          <span className="h-1.5 w-1.5 rounded-full bg-primary" aria-hidden />
+          <span>1.0 ships April 23 · Closed beta open now</span>
+        </div>
+        <h1 className="mt-6 max-w-[12ch] font-display text-[clamp(2.75rem,6.8vw,5.75rem)] font-normal leading-[1.02] tracking-tight">
+          A planner that won&apos;t <em className="tempo-gradient-text not-italic">shame</em>
+          <br />
+          your nervous system.
+        </h1>
+        <p className="mt-6 max-w-[54ch] font-serif text-[clamp(1.125rem,1.8vw,1.5rem)] leading-relaxed text-muted-foreground">
+          Tempo Flow is a calm, AI-gentle planner for ADHD brains, autistic brains, anxious brains, and
+          anyone who&apos;s tried seventeen productivity apps and bounced off all of them. Dump your
+          thoughts. We&apos;ll help you find the next doable thing.
+        </p>
+        <div className="mt-8 flex flex-wrap gap-3">
+          {/*
+            @action heroStartTrial
+            @navigate: /onboarding
+            @auth: public
+            @source: landing.html:L163
+          */}
+          <Link href="/onboarding">
+            <Button variant="primary" size="lg" className="rounded-full px-6">
+              Start your seven-day week · $1
+            </Button>
+          </Link>
+          {/*
+            @action heroTryDailyNote
+            @navigate: /daily-note
+            @auth: public
+            @source: landing.html:L164
+          */}
+          <Link href="/daily-note">
+            <Button variant="soft" size="lg" className="rounded-full px-6">
+              Try the daily note
+            </Button>
+          </Link>
         </div>
 
-        <SoftCard tone="sunken" className="mt-12 max-w-2xl">
-          <div className="flex flex-col gap-2">
-            <span className="font-eyebrow">For designers &amp; testers</span>
-            <span className="text-small text-muted-foreground">
-              The full click-through prototype is scaffolded across 42 web
-              routes. Press{" "}
-              <code className="rounded bg-card px-1.5 py-0.5 border border-border-soft font-mono">
-                ⌘K
-              </code>{" "}
-              inside the app to jump to any screen. Real JSX content ships in
-              T-F005 tickets.
-            </span>
+        <div className="mt-10 flex flex-wrap gap-10">
+          {[
+            ["42", "handcrafted screens"],
+            ["1", "person, one year"],
+            ["$1", "week-long trial"],
+            ["0", "guilt trips, ever"],
+          ].map(([strong, label]) => (
+            <div key={label}>
+              <strong className="block font-serif text-3xl font-medium text-foreground">{strong}</strong>
+              <span className="text-small text-muted-foreground">{label}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-12 grid gap-6 lg:grid-cols-2">
+          <SoftCard padding="md">
+            <p className="font-eyebrow text-primary">Brain Dump · 09:41</p>
+            <p className="mt-3 font-serif text-small leading-relaxed text-foreground">
+              Finish landing copy. Book dentist. Ask Sam about Convex. Pick up groceries. Am I shipping fast
+              enough?
+            </p>
+          </SoftCard>
+          <SoftCard padding="md" className="bg-primary text-primary-foreground">
+            <p className="font-eyebrow text-primary-foreground/85">Coach</p>
+            <h2 className="mt-2 font-serif text-xl font-medium">Three things look doable this afternoon.</h2>
+            <p className="mt-2 text-small leading-relaxed text-primary-foreground/85">
+              I pulled them from your dump. The worry I left on the side — we&apos;ll look at it tomorrow.
+            </p>
+          </SoftCard>
+        </div>
+
+        <section className="mt-20 border-t border-border-soft pt-16" id="features">
+          <p className="font-eyebrow text-primary">What&apos;s inside</p>
+          <h2 className="mt-3 max-w-[18ch] font-serif text-[clamp(2rem,4.4vw,3.6rem)] font-normal leading-tight tracking-tight">
+            Tasks, notes, and calendar — one markdown page per day.
+          </h2>
+          <p className="mt-4 max-w-[62ch] font-serif text-xl leading-relaxed text-muted-foreground">
+            Dump, sort, plan, do, reflect — in a single plaintext file you actually own. Linked, searchable,
+            yours forever.
+          </p>
+        </section>
+
+        <section className="mt-16 bg-surface-inverse px-6 py-16 text-cream md:rounded-2xl md:px-10" id="coach">
+          <h2 className="font-serif text-3xl font-normal">Coach samples</h2>
+          <div className="mt-8 grid gap-4 md:grid-cols-3">
+            <CoachBubble className="max-w-none border-border-soft bg-card/10 text-cream" bubbleRole="coach">
+              Morning. I noticed you dumped seven things earlier. Want me to stage the tasks first?
+            </CoachBubble>
+            <CoachBubble className="max-w-none border-border-soft bg-card/10 text-cream" bubbleRole="coach">
+              Five things feels full but fine. If the afternoon wobbles, the founder questions can slide to
+              Friday.
+            </CoachBubble>
+            <CoachBubble className="max-w-none border-border-soft bg-card/10 text-cream" bubbleRole="coach">
+              Always. One small note — you&apos;ve mentioned shipping speed three times this week.
+            </CoachBubble>
           </div>
-        </SoftCard>
+        </section>
+
+        <footer className="mt-20 border-t border-border-soft pt-10">
+          <div className="flex flex-wrap gap-6">
+            <Link href="/about" className="text-small text-muted-foreground hover:text-foreground">
+              About
+            </Link>
+            <Link href="/changelog" className="text-small text-muted-foreground hover:text-foreground">
+              Changelog
+            </Link>
+            <Link href="/privacy" className="text-small text-muted-foreground hover:text-foreground">
+              Privacy
+            </Link>
+            <Link href="/terms" className="text-small text-muted-foreground hover:text-foreground">
+              Terms
+            </Link>
+          </div>
+          <p className="mt-6 max-w-md font-serif text-lg text-muted-foreground">
+            Built slowly, on cream paper, for brains that need a softer operating system.
+          </p>
+        </footer>
       </section>
     </main>
   );

--- a/apps/web/app/sign-in/page.tsx
+++ b/apps/web/app/sign-in/page.tsx
@@ -1,9 +1,20 @@
+/**
+ * @screen: sign-in
+ * @category: Auth (bare route)
+ * @source: docs/design/claude-export/design-system/landing.html (Sign in CTA) + Convex Auth
+ * @mutations: signIn via @convex-dev/auth password provider
+ * @routes-to: /dashboard on success (existing behavior)
+ * @auth: public
+ * @env: NEXT_PUBLIC_CONVEX_URL
+ */
 "use client";
 
 import { useConvexAuth } from "convex/react";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
+import Link from "next/link";
 import { SignInForm } from "@/components/auth/SignInForm";
+import { SoftCard } from "@tempo/ui/primitives";
 
 export default function SignInPage() {
   const { isAuthenticated, isLoading } = useConvexAuth();
@@ -32,7 +43,39 @@ export default function SignInPage() {
 
   return (
     <div className="grain-bg flex min-h-[calc(100vh-8rem)] flex-col items-center justify-center px-4 py-12">
-      <SignInForm variant="page" />
+      <div className="grid w-full max-w-4xl gap-8 lg:grid-cols-2 lg:items-center">
+        <div className="space-y-4 text-left">
+          <p className="font-eyebrow text-muted-foreground">Tempo Flow</p>
+          <h1 className="text-h1 font-serif text-foreground">Sign in, gently.</h1>
+          <p className="text-body leading-relaxed text-muted-foreground">
+            Same account across web and mobile. Convex Auth handles credentials — no third-party auth
+            vendors.
+          </p>
+          {/*
+            @action goToOnboarding
+            @navigate: /onboarding
+            @auth: public
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <Link
+            href="/onboarding"
+            className="inline-flex h-10 items-center justify-center rounded-lg border border-border bg-card px-4 text-body font-medium text-foreground hover:bg-surface-sunken"
+          >
+            New here? Start the walk
+          </Link>
+        </div>
+        <SoftCard padding="lg" className="w-full">
+          {/*
+            @action submitPasswordSignIn
+            @mutation: auth password signIn (Convex Auth)
+            @index: users.by_email
+            @auth: public
+            @errors: inline (SignInForm)
+            @env: NEXT_PUBLIC_CONVEX_URL
+          */}
+          <SignInForm variant="page" />
+        </SoftCard>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/tempo-port/ScreenSurface.tsx
+++ b/apps/web/components/tempo-port/ScreenSurface.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Button, SoftCard } from "@tempo/ui/primitives";
+
+export type ViewMode = "ready" | "loading" | "empty" | "error";
+
+type ScreenSurfaceProps = {
+  children: ReactNode;
+  mode: ViewMode;
+  onModeChange: (next: ViewMode) => void;
+  emptyTitle?: string;
+  emptyBody?: string;
+  errorMessage?: string;
+};
+
+/**
+ * Local preview states for mock-data screens (Long Run 2 removes this strip).
+ * @action setPreviewMode
+ * @mutation none
+ * @auth: required
+ * @errors none
+ * @env: NEXT_PUBLIC_CONVEX_URL (preview only; no network in mock phase)
+ */
+export function ScreenSurface({
+  children,
+  mode,
+  onModeChange,
+  emptyTitle = "Nothing here yet",
+  emptyBody = "When you add items, they will show in this view.",
+  errorMessage = "We could not load this. Check your connection and try again.",
+}: ScreenSurfaceProps) {
+  const modes: ViewMode[] = ["ready", "loading", "empty", "error"];
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {mode === "loading" ? (
+          <div className="mx-auto max-w-3xl space-y-4 p-8" aria-busy="true" aria-live="polite">
+            <div className="h-8 w-48 animate-pulse rounded-lg bg-surface-sunken" />
+            <div className="h-24 w-full animate-pulse rounded-xl bg-surface-sunken" />
+            <div className="h-40 w-full animate-pulse rounded-xl bg-surface-sunken" />
+          </div>
+        ) : null}
+        {mode === "empty" ? (
+          <div className="mx-auto max-w-3xl p-8">
+            <SoftCard tone="sunken" padding="lg">
+              <h2 className="text-h2 font-serif text-foreground">{emptyTitle}</h2>
+              <p className="mt-2 text-body text-muted-foreground">{emptyBody}</p>
+            </SoftCard>
+          </div>
+        ) : null}
+        {mode === "error" ? (
+          <div className="mx-auto max-w-3xl p-8">
+            <SoftCard tone="default" padding="lg" className="border-destructive/40">
+              <p className="text-body text-destructive">{errorMessage}</p>
+              {/*
+                @action retryLoad
+                @query: re-run parent screen queries (tasks.listToday etc.)
+                @index: n/a
+                @soft-delete: n/a
+                @optimistic: none
+                @auth: required
+                @errors: toast if still failing
+                @env: NEXT_PUBLIC_CONVEX_URL
+              */}
+              <Button
+                type="button"
+                variant="soft"
+                className="mt-4"
+                onClick={() => onModeChange("ready")}
+              >
+                Try again
+              </Button>
+            </SoftCard>
+          </div>
+        ) : null}
+        {mode === "ready" ? <div className="min-h-0">{children}</div> : null}
+      </div>
+      <div className="border-t border-border-soft bg-card px-4 py-2">
+        <div className="mx-auto flex max-w-3xl flex-wrap items-center gap-2">
+          <span className="text-caption text-muted-foreground">Preview</span>
+          {modes.map((m) => (
+            <Button
+              key={m}
+              type="button"
+              size="sm"
+              variant={mode === m ? "primary" : "ghost"}
+              onClick={() => onModeChange(m)}
+            >
+              {m}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@convex-dev/auth": "^0.0.90",
     "@polar-sh/nextjs": "^0.9.1",
+    "@tempo/mock-data": "workspace:*",
     "@tempo/ui": "workspace:*",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@react-navigation/native": "^7.1.8",
         "@rn-primitives/slot": "^1.2.0",
         "@rn-primitives/types": "^1.2.0",
+        "@tempo/mock-data": "workspace:*",
         "@tempo/ui": "workspace:*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -78,6 +79,7 @@
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@tempo/mock-data": "workspace:*",
         "@tempo/ui": "workspace:*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -103,6 +105,14 @@
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
         "ultracite": "6.3.10",
+      },
+    },
+    "packages/mock-data": {
+      "name": "@tempo/mock-data",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@biomejs/biome": "2.3.8",
+        "typescript": "^5.9.3",
       },
     },
     "packages/types": {
@@ -741,6 +751,8 @@
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.1", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.1", "@tailwindcss/oxide": "4.2.1", "postcss": "^8.5.6", "tailwindcss": "4.2.1" } }, "sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw=="],
 
     "@tailwindcss/typography": ["@tailwindcss/typography@0.5.19", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1" } }, "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg=="],
+
+    "@tempo/mock-data": ["@tempo/mock-data@workspace:packages/mock-data"],
 
     "@tempo/types": ["@tempo/types@workspace:packages/types"],
 

--- a/docs/design/frontend-port-screenshot-urls.md
+++ b/docs/design/frontend-port-screenshot-urls.md
@@ -1,0 +1,78 @@
+# Frontend port — screenshot checklist (web + mobile)
+
+Use these URLs after `bun run dev:web` (base `http://localhost:3000`) and Expo dev for mobile. Capture light + dark where applicable for the PR body.
+
+## Web — Tempo shell `(tempo)`
+
+| Route | Path |
+|-------|------|
+| Today | `/today` |
+| Brain dump | `/brain-dump` |
+| Coach | `/coach` |
+| Plan | `/plan` |
+| Tasks | `/tasks` |
+| Notes | `/notes` |
+| Note detail | `/notes/note-1` |
+| Journal | `/journal` |
+| Calendar | `/calendar` |
+| Habits | `/habits` |
+| Habit detail | `/habits/habit-morning-pages` |
+| Routines | `/routines` |
+| Routine detail | `/routines/routine-morning` |
+| Goals | `/goals` |
+| Goal detail | `/goals/goal-ship-tempo` |
+| Goals progress | `/goals/progress` |
+| Projects | `/projects` |
+| Project detail | `/projects/proj-tempo-10` |
+| Kanban | `/projects/proj-tempo-10/kanban` |
+| Insights | `/insights` |
+| Activity | `/activity` |
+| Search | `/search` |
+| Command | `/command` |
+| Empty states | `/empty-states` |
+| Templates | `/templates` |
+| Template sketch | `/templates/sketch` |
+| Template editor | `/templates/editor/my-shipping` |
+| Notifications | `/notifications` |
+| Ask founder | `/ask-founder` |
+| Billing | `/billing` |
+| Settings profile | `/settings/profile` |
+| Settings preferences | `/settings/preferences` |
+| Settings integrations | `/settings/integrations` |
+
+## Web — bare
+
+| Route | Path |
+|-------|------|
+| Daily note | `/daily-note` |
+| Onboarding | `/onboarding` |
+| Template builder | `/templates/builder` |
+| Template run | `/templates/run/weekly-review` |
+| Trial end | `/billing/trial-end` |
+
+## Web — marketing + auth
+
+| Route | Path |
+|-------|------|
+| Landing | `/` |
+| About | `/about` |
+| Changelog | `/changelog` |
+| Sign in | `/sign-in` |
+
+## Mobile — Expo `(tempo)` + `(auth)`
+
+| Screen | File route |
+|--------|------------|
+| Today tab | `/(tempo)/(tabs)/today` |
+| Coach tab | `/(tempo)/(tabs)/coach` |
+| Tasks tab | `/(tempo)/(tabs)/tasks` |
+| Notes tab | `/(tempo)/(tabs)/notes` |
+| Capture modal | `/(tempo)/capture` |
+| Plan stack | `/(tempo)/plan` |
+| Journal | `/(tempo)/journal` |
+| Habits | `/(tempo)/habits` |
+| Calendar | `/(tempo)/calendar` |
+| Routines | `/(tempo)/routines` |
+| Templates | `/(tempo)/templates` |
+| Settings | `/(tempo)/settings` |
+| Onboarding | `/(auth)/onboarding` |

--- a/packages/mock-data/biome.json
+++ b/packages/mock-data/biome.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "vcs": {
+    "enabled": false,
+    "clientKind": "git",
+    "useIgnoreFile": false
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": ["**/*.ts", "**/*.tsx", "**/*.json"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "es5",
+      "semicolons": "always",
+      "arrowParentheses": "always"
+    }
+  }
+}

--- a/packages/mock-data/package.json
+++ b/packages/mock-data/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tempo/mock-data",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "biome lint .",
+    "check": "biome check ."
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/mock-data/package.json
+++ b/packages/mock-data/package.json
@@ -14,6 +14,7 @@
     "check": "biome check ."
   },
   "devDependencies": {
+    "@biomejs/biome": "2.3.8",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/mock-data/src/calendar.ts
+++ b/packages/mock-data/src/calendar.ts
@@ -1,0 +1,49 @@
+import { mockAtUtcHour } from "./constants";
+import type { MockCalendarEvent } from "./types";
+
+/** Week of April 21 — screens-2.jsx ScreenCalendar */
+export const mockCalendarWeekLabel = "Week of April 21.";
+
+type DayKey = "Mon" | "Tue" | "Wed" | "Thu" | "Fri" | "Sat" | "Sun";
+
+const baseForDay: Record<DayKey, number> = {
+  Mon: mockAtUtcHour(10, 0) - 3 * 86400000,
+  Tue: mockAtUtcHour(10, 0) - 2 * 86400000,
+  Wed: mockAtUtcHour(10, 0) - 1 * 86400000,
+  Thu: mockAtUtcHour(10, 0),
+  Fri: mockAtUtcHour(10, 0) + 1 * 86400000,
+  Sat: mockAtUtcHour(10, 0) + 2 * 86400000,
+  Sun: mockAtUtcHour(10, 0) + 3 * 86400000,
+};
+
+function ev(
+  day: DayKey,
+  hour: number,
+  title: string,
+  source: MockCalendarEvent["source"] = "tempo",
+): MockCalendarEvent {
+  const start = baseForDay[day] + hour * 60 * 60 * 1000;
+  return {
+    id: `cal-${day}-${hour}-${title.replace(/\s+/g, "-").toLowerCase()}`,
+    title,
+    startAt: start,
+    endAt: start + 60 * 60 * 1000,
+    source,
+  };
+}
+
+export const mockCalendarEvents: MockCalendarEvent[] = [
+  ev("Mon", 10, "PR review"),
+  ev("Mon", 14, "Deep work"),
+  ev("Tue", 9, "Pages"),
+  ev("Tue", 11, "Sam 1:1"),
+  ev("Wed", 9, "Pages"),
+  ev("Wed", 13, "Draft launch"),
+  ev("Thu", 9, "Launch post"),
+  ev("Thu", 12, "Walk"),
+  ev("Thu", 14, "Founder Qs"),
+  ev("Fri", 10, "Weekly review"),
+  ev("Fri", 15, "Deep work"),
+  ev("Sat", 11, "Tea w/ mum"),
+  ev("Sun", 17, "Recap draft"),
+];

--- a/packages/mock-data/src/coach.ts
+++ b/packages/mock-data/src/coach.ts
@@ -1,0 +1,79 @@
+import { mockAtUtcHour, MOCK_REFERENCE_MS } from "./constants";
+import type { MockCoachMessage } from "./types";
+
+export const mockCoachWarmthLevel = 6;
+
+export const mockCoachScopeSummary = "scope: 2 notes · 1 project";
+
+export const mockCoachScopeItems = [
+  { kind: "note" as const, title: "Launch notes" },
+  { kind: "note" as const, title: "Onboarding copy" },
+  { kind: "project" as const, title: "Tempo 1.0" },
+];
+
+export const mockCoachPastThreads = [
+  "Shipping worries · Mon",
+  "Outline: launch post · Sun",
+  "Weekly review · Fri",
+] as const;
+
+/** Coach thread — screens-1.jsx ScreenCoach */
+export const mockCoachMessages: MockCoachMessage[] = [
+  {
+    id: "coach-msg-1",
+    role: "coach",
+    body: "Morning. I noticed you dumped seven things earlier. Three of them look like worries about shipping. Want to talk about those, or should I stage the tasks first?",
+    timestamp: mockAtUtcHour(9, 12),
+  },
+  {
+    id: "coach-msg-2",
+    role: "user",
+    body: "Stage the tasks. I'll come back to the worries tonight.",
+    timestamp: mockAtUtcHour(9, 13),
+  },
+  {
+    id: "coach-msg-3",
+    role: "coach",
+    body: "Good. I'll add Finish landing copy, Book dentist, and Ask Sam about Convex to today. The dentist is quick — five minutes. Can we try it after your walk?",
+    timestamp: mockAtUtcHour(9, 14),
+  },
+  {
+    id: "coach-msg-4",
+    role: "user",
+    body: "Sure. Keep it gentle.",
+    timestamp: mockAtUtcHour(9, 15),
+  },
+  {
+    id: "coach-msg-5",
+    role: "coach",
+    body: "Always. One small note — you've mentioned shipping speed three times this week. It might be worth fifteen minutes of journal time on Friday. I'll leave a gentle prompt, not a task.",
+    timestamp: mockAtUtcHour(9, 16),
+  },
+];
+
+export const mockCoachQuickPills = [
+  "Stage tasks",
+  "Draft journal prompt",
+  "Review this week",
+] as const;
+
+/** Today card coach copy — screens-1.jsx */
+export const mockCoachTodayBubble =
+  "Nice work on morning pages. When you're ready, the Tempo 1.0 post is the biggest thing — sixty minutes, high-energy. Want me to stage the outline first?";
+
+export const mockCoachTodaySuggestion = {
+  preview:
+    "Two overdue things from yesterday. Carry them to today, or let them rest?",
+  kind: "accept" as const,
+  taskIds: ["task-today-3", "task-today-4"],
+};
+
+/** Planning sidebar — screens-1.jsx */
+export const mockCoachPlanBubble =
+  "Five things feels full but fine. If the afternoon wobbles, the founder questions can slide to Friday — they're not time-locked.";
+
+export const mockCoachPersonalityLabel = "Gentle";
+
+/** Plan blocks metadata exported from tasks package conceptually — ids here for coach links */
+export const mockPlanCoachEnergyCaption =
+  "Feeling alert — Coach leaned the day toward deeper work before noon.";

--- a/packages/mock-data/src/coach.ts
+++ b/packages/mock-data/src/coach.ts
@@ -1,4 +1,4 @@
-import { mockAtUtcHour, MOCK_REFERENCE_MS } from "./constants";
+import { mockAtUtcHour } from "./constants";
 import type { MockCoachMessage } from "./types";
 
 export const mockCoachWarmthLevel = 6;

--- a/packages/mock-data/src/constants.ts
+++ b/packages/mock-data/src/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Fixed reference instant for all fixture timestamps.
+ * Aligns with design export copy: "Thursday · April 23" (screens-1) and
+ * `2026-04-23.md` (screens-7 daily note).
+ */
+export const MOCK_REFERENCE_MS = 1776945600000; // 2026-04-23T12:00:00.000Z
+
+/** Offset hours from {@link MOCK_REFERENCE_MS} → epoch ms. */
+export function mockAtUtcHour(hour: number, minute = 0): number {
+  return MOCK_REFERENCE_MS + (hour - 12) * 60 * 60 * 1000 + minute * 60 * 1000;
+}

--- a/packages/mock-data/src/goals.ts
+++ b/packages/mock-data/src/goals.ts
@@ -1,0 +1,73 @@
+import { MOCK_REFERENCE_MS } from "./constants";
+import type { MockGoal } from "./types";
+
+/** Library · Goals — screens-3.jsx */
+export const mockGoals: MockGoal[] = [
+  {
+    id: "goal-ship-tempo",
+    title: "Ship Tempo 1.0",
+    description: "Full MVP, all 42 screens, PWA + iOS + Android. Due May 30. 72% there.",
+    progress: 0.72,
+    targetAt: MOCK_REFERENCE_MS + 37 * 86400000,
+    milestones: [
+      { id: "g1-ms-1", title: "Lock down all 42 screens", done: true },
+      { id: "g1-ms-2", title: "Hire a designer for review", done: true },
+      { id: "g1-ms-3", title: "Internal alpha (5 users)", done: true },
+      { id: "g1-ms-4", title: "Closed beta (30 users)", done: true },
+      { id: "g1-ms-5", title: "Public beta · iOS + Android", done: true },
+      { id: "g1-ms-6", title: "RevenueCat + $1 trial live", done: true },
+      { id: "g1-ms-7", title: "PWA + Apple Store approval", done: false },
+      { id: "g1-ms-8", title: "Launch post + founder vlog", done: false },
+    ],
+  },
+  {
+    id: "goal-letters",
+    title: "Publish twelve letters this year",
+    description: "Creative cadence for the year.",
+    progress: 0.41,
+    targetAt: MOCK_REFERENCE_MS + 252 * 86400000,
+    milestones: Array.from({ length: 12 }, (_, i) => ({
+      id: `g2-ms-${i}`,
+      title: `Letter ${i + 1}`,
+      done: i < 5,
+    })),
+  },
+  {
+    id: "goal-walk",
+    title: "Walk 10 km a week",
+    description: "Ongoing health anchor.",
+    progress: 1,
+    milestones: [
+      { id: "g3-ms-1", title: "Week 1", done: true },
+      { id: "g3-ms-2", title: "Week 2", done: true },
+      { id: "g3-ms-3", title: "Week 3", done: true },
+      { id: "g3-ms-4", title: "Week 4", done: true },
+    ],
+  },
+  {
+    id: "goal-bach",
+    title: "Read the Bach biography",
+    description: "Learning goal.",
+    progress: 0.55,
+    targetAt: MOCK_REFERENCE_MS + 83 * 86400000,
+    milestones: Array.from({ length: 8 }, (_, i) => ({
+      id: `g4-ms-${i}`,
+      title: `Chapter chunk ${i + 1}`,
+      done: i < 4,
+    })),
+  },
+];
+
+export const mockGoalCategories = [
+  { goalId: "goal-ship-tempo", category: "work" as const },
+  { goalId: "goal-letters", category: "creative" as const },
+  { goalId: "goal-walk", category: "health" as const },
+  { goalId: "goal-bach", category: "learning" as const },
+];
+
+export const mockGoalDueLabels: Record<string, string> = {
+  "goal-ship-tempo": "May 30",
+  "goal-letters": "Dec 31",
+  "goal-walk": "ongoing",
+  "goal-bach": "Jul 15",
+};

--- a/packages/mock-data/src/habits.ts
+++ b/packages/mock-data/src/habits.ts
@@ -1,0 +1,91 @@
+import { MOCK_REFERENCE_MS } from "./constants";
+import type { MockHabit } from "./types";
+
+const dayMs = 86400000;
+
+function last7DaysCompletions(streakDays: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < streakDays && i < 7; i += 1) {
+    out.push(MOCK_REFERENCE_MS - i * dayMs);
+  }
+  return out;
+}
+
+/** Library · Habits — screens-2.jsx */
+export const mockHabits: MockHabit[] = [
+  {
+    id: "habit-morning-pages",
+    name: "Morning pages",
+    cadence: "daily",
+    streak: 5,
+    longestStreak: 31,
+    completionRatio: 1,
+    recentCompletions: last7DaysCompletions(5),
+    color: "moss",
+  },
+  {
+    id: "habit-walk",
+    name: "10-minute walk",
+    cadence: "daily",
+    streak: 3,
+    longestStreak: 18,
+    completionRatio: 0.5,
+    recentCompletions: last7DaysCompletions(3),
+    color: "amber",
+  },
+  {
+    id: "habit-shutdown",
+    name: "Shutdown sequence",
+    cadence: "weekdays",
+    streak: 0,
+    longestStreak: 14,
+    completionRatio: 0,
+    recentCompletions: [],
+    color: "slate",
+  },
+  {
+    id: "habit-read",
+    name: "Read one chapter",
+    cadence: "daily",
+    streak: 12,
+    longestStreak: 24,
+    completionRatio: 1,
+    recentCompletions: last7DaysCompletions(7),
+    color: "moss",
+  },
+  {
+    id: "habit-screens",
+    name: "No screens after 10pm",
+    cadence: "daily",
+    streak: 2,
+    longestStreak: 9,
+    completionRatio: 0,
+    recentCompletions: last7DaysCompletions(2),
+    color: "brick",
+  },
+];
+
+/** Deterministic 14-cell heatmap (replaces Math.random in design export). */
+export const mockHabitHeatmap14: boolean[] = [
+  true,
+  true,
+  false,
+  true,
+  true,
+  false,
+  true,
+  true,
+  true,
+  false,
+  false,
+  true,
+  true,
+  false,
+];
+
+/** Deterministic 42-cell grid for habit detail — screens-2.jsx */
+export const mockHabitDetailGrid42: boolean[] = Array.from({ length: 42 }, (_, i) => {
+  const row = Math.floor(i / 7);
+  const col = i % 7;
+  return (row + col) % 3 !== 0;
+});

--- a/packages/mock-data/src/index.ts
+++ b/packages/mock-data/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @tempo/mock-data — deterministic fixtures for web + mobile UI ports.
+ * Long Run 2 replaces imports with Convex queries; annotations cite tables/indexes.
+ */
+export * from "./calendar";
+export * from "./coach";
+export * from "./constants";
+export * from "./goals";
+export * from "./habits";
+export * from "./journal";
+export * from "./notes";
+export * from "./projects";
+export * from "./routines";
+export * from "./tasks";
+export * from "./templates";
+export * from "./types";
+export * from "./user";
+export * from "./you";

--- a/packages/mock-data/src/journal.ts
+++ b/packages/mock-data/src/journal.ts
@@ -1,4 +1,3 @@
-import { MOCK_REFERENCE_MS } from "./constants";
 import type { MockJournalEntry } from "./types";
 
 export const mockJournalTodayDraft =

--- a/packages/mock-data/src/journal.ts
+++ b/packages/mock-data/src/journal.ts
@@ -1,0 +1,42 @@
+import { MOCK_REFERENCE_MS } from "./constants";
+import type { MockJournalEntry } from "./types";
+
+export const mockJournalTodayDraft =
+  "Steady this morning. Pages came easy. The launch post still feels big but it's one paragraph at a time — and today I only need one paragraph.";
+
+export const mockJournalPromptTitle = "What does today want to be?";
+
+export const mockJournalEntries: MockJournalEntry[] = [
+  {
+    id: "journal-1",
+    date: "2026-04-23",
+    mood: "settled",
+    prompt: "Morning",
+    wordCount: 284,
+    body: mockJournalTodayDraft,
+  },
+  {
+    id: "journal-2",
+    date: "2026-04-22",
+    mood: "tired",
+    prompt: "Evening",
+    wordCount: 156,
+    body: "Evening entry placeholder.",
+  },
+  {
+    id: "journal-3",
+    date: "2026-04-21",
+    mood: "anxious",
+    prompt: "Morning",
+    wordCount: 410,
+    body: "Morning entry placeholder.",
+  },
+  {
+    id: "journal-4",
+    date: "2026-04-20",
+    mood: "steady",
+    prompt: "Free",
+    wordCount: 221,
+    body: "Free prompt entry placeholder.",
+  },
+];

--- a/packages/mock-data/src/notes.ts
+++ b/packages/mock-data/src/notes.ts
@@ -1,0 +1,126 @@
+import { MOCK_REFERENCE_MS } from "./constants";
+import type { MockDailyNoteBody, MockNote } from "./types";
+
+/** Library · Notes — screens-2.jsx */
+export const mockNotes: MockNote[] = [
+  {
+    id: "note-1",
+    title: "Launch post — draft",
+    body:
+      "Lorem warmth. A thoughtful opening paragraph. The note rolls gently onward, never rushing, never corporate…",
+    tags: ["writing"],
+    updatedAt: MOCK_REFERENCE_MS,
+  },
+  {
+    id: "note-2",
+    title: "Onboarding copy rewrite",
+    body:
+      "Lorem warmth. A thoughtful opening paragraph. The note rolls gently onward, never rushing, never corporate…",
+    tags: ["writing"],
+    updatedAt: MOCK_REFERENCE_MS - 86400000,
+  },
+  {
+    id: "note-3",
+    title: "Convex migration — notes",
+    body:
+      "Lorem warmth. A thoughtful opening paragraph. The note rolls gently onward, never rushing, never corporate…",
+    tags: ["eng"],
+    updatedAt: MOCK_REFERENCE_MS - 172800000,
+  },
+  {
+    id: "note-4",
+    title: "Meeting: Sam + Ari · alignment",
+    body:
+      "Lorem warmth. A thoughtful opening paragraph. The note rolls gently onward, never rushing, never corporate…",
+    tags: ["meeting"],
+    updatedAt: MOCK_REFERENCE_MS - 172800000,
+  },
+  {
+    id: "note-5",
+    title: "Idea: gradient on first-run splash",
+    body:
+      "Lorem warmth. A thoughtful opening paragraph. The note rolls gently onward, never rushing, never corporate…",
+    tags: ["idea"],
+    updatedAt: MOCK_REFERENCE_MS - 259200000,
+  },
+  {
+    id: "note-6",
+    title: "Research: magic-link vs passkey",
+    body:
+      "Lorem warmth. A thoughtful opening paragraph. The note rolls gently onward, never rushing, never corporate…",
+    tags: ["research"],
+    updatedAt: MOCK_REFERENCE_MS - 345600000,
+  },
+];
+
+export const mockNoteFolders: Array<{ name: string; count: number }> = [
+  { name: "All notes", count: 42 },
+  { name: "Writing", count: 14 },
+  { name: "Engineering", count: 9 },
+  { name: "Journal prompts", count: 6 },
+  { name: "Research", count: 8 },
+  { name: "Archive", count: 5 },
+];
+
+export const mockNoteTags = ["writing", "eng", "meeting", "idea", "research"] as const;
+
+/** Note detail — screens-2.jsx ScreenNoteDetail */
+export const mockNoteDetailLaunchPost = {
+  id: "note-1",
+  title: "Launch post — draft",
+  tags: ["writing"] as const,
+  pinned: true,
+  savedCaption: "Saved · 2 minutes ago · 1,204 words",
+  h1: "A letter, not a form.",
+  subtitle: "Draft for the Tempo 1.0 launch. Tone: Uncle Iroh with a notebook.",
+  paragraphs: [
+    "Most productivity apps want you to be a machine. They count. They streak. They buzz. They reward you for optimizing things that do not, on any honest day, need to be optimized.",
+    "Tempo Flow is built for the other days — the low-spoons ones, the ones where the calendar is a cathedral you cannot enter, the ones where make a plan is itself the impossible task.",
+    "It is a planner that feels like a letter from a thoughtful friend, not a form to fill…",
+  ],
+  coachStrip:
+    "Coach suggests a sharper opening line. Want to see it?",
+} as const;
+
+/** Daily note (bare) — screens-7.jsx + mobile-screens-a.jsx cues */
+export const mockDailyNote: MockDailyNoteBody = {
+  fileName: "2026-04-23.md",
+  headline: "Thursday · April 23 · Week 17",
+  coachGreeting:
+    "Good morning. You've got three things from yesterday still open. Want to move them, or finish one first?",
+  streakLabel: "7 day streak · habits on track",
+  topTasks: [
+    {
+      id: "dn-1",
+      title: "Review PR from Sam",
+      done: true,
+      time: "20 min",
+      tag: "tempo",
+    },
+    {
+      id: "dn-2",
+      title: "Ship mobile preview v1",
+      done: false,
+      time: "60 min",
+      energy: "high",
+      tag: "tempo",
+    },
+    {
+      id: "dn-3",
+      title: "Call the dentist",
+      done: false,
+      time: "5 min",
+      energy: "low",
+    },
+  ],
+  laterTasks: [
+    { id: "dn-4", title: "Pay invoice", done: false, tag: "admin" },
+    {
+      id: "dn-5",
+      title: "Read Convex auth docs",
+      done: false,
+      time: "30 min",
+      tag: "learning",
+    },
+  ],
+};

--- a/packages/mock-data/src/projects.ts
+++ b/packages/mock-data/src/projects.ts
@@ -1,0 +1,90 @@
+import { MOCK_REFERENCE_MS } from "./constants";
+import type { MockProject } from "./types";
+
+/** Library · Projects — screens-3.jsx */
+export const mockProjects: MockProject[] = [
+  {
+    id: "proj-tempo-10",
+    name: "Tempo 1.0",
+    color: "orange",
+    taskIds: [
+      "task-proj-1",
+      "task-proj-2",
+      "task-proj-3",
+      "task-proj-4",
+      "task-proj-5",
+    ],
+    noteIds: ["note-1", "note-2", "note-3"],
+  },
+  {
+    id: "proj-landing",
+    name: "Landing redesign",
+    color: "amber",
+    taskIds: [],
+    noteIds: [],
+  },
+  {
+    id: "proj-book",
+    name: "Book: Everyday Anchors",
+    color: "moss",
+    taskIds: [],
+    noteIds: [],
+  },
+];
+
+export const mockProjectCards = [
+  {
+    projectId: "proj-tempo-10",
+    dueLabel: "May 30",
+    taskCount: 42,
+    teamSize: 1,
+    percent: 72,
+  },
+  {
+    projectId: "proj-landing",
+    dueLabel: "Apr 29",
+    taskCount: 11,
+    teamSize: 1,
+    percent: 54,
+  },
+  {
+    projectId: "proj-book",
+    dueLabel: "Sep 1",
+    taskCount: 27,
+    teamSize: 1,
+    percent: 18,
+  },
+] as const;
+
+export const mockProjectKanbanColumns: Array<{
+  title: string;
+  items: readonly string[];
+}> = [
+  {
+    title: "Backlog",
+    items: [
+      "Pricing page v2",
+      "Recovery email flow",
+      "Onboarding analytics",
+      "Dark mode polish",
+    ],
+  },
+  {
+    title: "This week",
+    items: ["Submit to Apple", "Finish landing copy", "Record founder vlog"],
+  },
+  {
+    title: "In progress",
+    items: ["Launch post draft", "Landing rewrite"],
+  },
+  {
+    title: "Shipped",
+    items: ["Brand style guide v1", "Convex migration", "All 42 screens"],
+  },
+];
+
+export const mockProjectLinkedNoteTitles = [
+  "A letter, not a form",
+  "Onboarding rewrite",
+  "Convex migration",
+] as const;

--- a/packages/mock-data/src/projects.ts
+++ b/packages/mock-data/src/projects.ts
@@ -1,4 +1,3 @@
-import { MOCK_REFERENCE_MS } from "./constants";
 import type { MockProject } from "./types";
 
 /** Library · Projects — screens-3.jsx */

--- a/packages/mock-data/src/routines.ts
+++ b/packages/mock-data/src/routines.ts
@@ -1,0 +1,95 @@
+import { MOCK_REFERENCE_MS } from "./constants";
+import type { MockRoutine } from "./types";
+
+/** Library · Routines — screens-2.jsx */
+export const mockRoutines: MockRoutine[] = [
+  {
+    id: "routine-morning",
+    name: "Morning routine",
+    description: "Daily · 7:30 AM",
+    steps: [
+      { id: "routine-morning-s1", title: "Kettle on", durationMin: 2 },
+      {
+        id: "routine-morning-s2",
+        title: "Open Tempo, check today's plan",
+        durationMin: 2,
+      },
+      {
+        id: "routine-morning-s3",
+        title: "Morning pages — three pages",
+        durationMin: 15,
+      },
+      { id: "routine-morning-s4", title: "Ten-minute walk", durationMin: 10 },
+      { id: "routine-morning-s5", title: "Shower", durationMin: 8 },
+    ],
+    lastRunAt: MOCK_REFERENCE_MS - 3600000,
+  },
+  {
+    id: "routine-shutdown",
+    name: "Shutdown sequence",
+    description: "Weekdays · 4:00 PM",
+    steps: [
+      { id: "routine-shutdown-s1", title: "Close browser tabs", durationMin: 5 },
+      { id: "routine-shutdown-s2", title: "Inbox zero-ish", durationMin: 10 },
+      {
+        id: "routine-shutdown-s3",
+        title: "Write tomorrow's top 3",
+        durationMin: 5,
+      },
+      { id: "routine-shutdown-s4", title: "Dim the lights", durationMin: 1 },
+      { id: "routine-shutdown-s5", title: "Phone on charger", durationMin: 1 },
+      { id: "routine-shutdown-s6", title: "One line in journal", durationMin: 3 },
+      { id: "routine-shutdown-s7", title: "Laptop closed", durationMin: 1 },
+    ],
+    lastRunAt: MOCK_REFERENCE_MS - 86400000,
+  },
+  {
+    id: "routine-weekly",
+    name: "Weekly review",
+    description: "Fri · 3:00 PM",
+    steps: Array.from({ length: 9 }, (_, i) => ({
+      id: `routine-weekly-s${i + 1}`,
+      title: `Weekly review step ${i + 1}`,
+      durationMin: 5,
+    })),
+    lastRunAt: MOCK_REFERENCE_MS - 5 * 86400000,
+  },
+  {
+    id: "routine-deep",
+    name: "Deep work kickoff",
+    description: "On demand",
+    steps: Array.from({ length: 4 }, (_, i) => ({
+      id: `routine-deep-s${i + 1}`,
+      title: `Deep work prep ${i + 1}`,
+      durationMin: 3,
+    })),
+    lastRunAt: MOCK_REFERENCE_MS - 2 * 86400000,
+  },
+];
+
+export const mockRoutineListMeta = [
+  {
+    routineId: "routine-morning",
+    scheduleLabel: "5 steps · Daily · 7:30 AM",
+    lastLabel: "Today",
+    completionRate: 92,
+  },
+  {
+    routineId: "routine-shutdown",
+    scheduleLabel: "7 steps · Weekdays · 4:00 PM",
+    lastLabel: "Yesterday",
+    completionRate: 78,
+  },
+  {
+    routineId: "routine-weekly",
+    scheduleLabel: "9 steps · Fri · 3:00 PM",
+    lastLabel: "Last Fri",
+    completionRate: 81,
+  },
+  {
+    routineId: "routine-deep",
+    scheduleLabel: "4 steps · On demand",
+    lastLabel: "Mon",
+    completionRate: 65,
+  },
+] as const;

--- a/packages/mock-data/src/tasks.ts
+++ b/packages/mock-data/src/tasks.ts
@@ -1,0 +1,288 @@
+import { mockAtUtcHour, MOCK_REFERENCE_MS } from "./constants";
+import type { MockBrainDumpSortedItem, MockPlanBlock, MockTask } from "./types";
+
+/** Today / dashboard rows — screens-1.jsx */
+export const mockTodayTasks: MockTask[] = [
+  {
+    id: "task-today-1",
+    title: "Morning pages",
+    status: "done",
+    priority: "low",
+    createdAt: mockAtUtcHour(7, 0),
+    dueAt: mockAtUtcHour(8, 0),
+    completedAt: mockAtUtcHour(8, 5),
+    dueLabel: "08:00",
+    estimatedMinutes: 15,
+    energy: "low",
+  },
+  {
+    id: "task-today-2",
+    title: "Draft Tempo 1.0 launch post",
+    status: "in_progress",
+    priority: "high",
+    createdAt: mockAtUtcHour(8, 0),
+    dueAt: mockAtUtcHour(9, 30),
+    dueLabel: "09:30",
+    estimatedMinutes: 60,
+    energy: "high",
+    tag: "writing",
+    coachSuggested: true,
+  },
+  {
+    id: "task-today-3",
+    title: "Review PRs from yesterday",
+    status: "todo",
+    priority: "medium",
+    createdAt: mockAtUtcHour(8, 30),
+    dueAt: mockAtUtcHour(11, 0),
+    dueLabel: "11:00",
+    estimatedMinutes: 30,
+    energy: "medium",
+  },
+  {
+    id: "task-today-4",
+    title: "10-minute walk",
+    status: "todo",
+    priority: "low",
+    createdAt: mockAtUtcHour(9, 0),
+    dueAt: mockAtUtcHour(12, 30),
+    dueLabel: "12:30",
+    estimatedMinutes: 10,
+    energy: "low",
+  },
+  {
+    id: "task-today-5",
+    title: "Respond to three founder questions",
+    status: "todo",
+    priority: "medium",
+    createdAt: mockAtUtcHour(9, 15),
+    dueAt: mockAtUtcHour(14, 0),
+    dueLabel: "14:00",
+    estimatedMinutes: 25,
+    energy: "medium",
+    coachSuggested: true,
+  },
+];
+
+/** Library · Tasks — screens-1.jsx ScreenTasks */
+export const mockLibraryTasks: MockTask[] = [
+  {
+    id: "task-lib-1",
+    title: "Draft Tempo 1.0 launch post",
+    status: "todo",
+    priority: "high",
+    createdAt: MOCK_REFERENCE_MS - 86400000,
+    dueLabel: "Today",
+    estimatedMinutes: 60,
+    energy: "high",
+    tag: "writing",
+    coachSuggested: true,
+  },
+  {
+    id: "task-lib-2",
+    title: "Finish landing copy",
+    status: "todo",
+    priority: "medium",
+    createdAt: MOCK_REFERENCE_MS - 172800000,
+    dueLabel: "Today",
+    estimatedMinutes: 45,
+    energy: "medium",
+    tag: "writing",
+  },
+  {
+    id: "task-lib-3",
+    title: "Review PRs from yesterday",
+    status: "todo",
+    priority: "medium",
+    createdAt: MOCK_REFERENCE_MS - 3600000,
+    dueLabel: "Today",
+    estimatedMinutes: 30,
+    energy: "medium",
+  },
+  {
+    id: "task-lib-4",
+    title: "Book dentist",
+    status: "todo",
+    priority: "low",
+    createdAt: MOCK_REFERENCE_MS - 259200000,
+    dueLabel: "Tomorrow",
+    estimatedMinutes: 5,
+    energy: "low",
+    tag: "admin",
+  },
+  {
+    id: "task-lib-5",
+    title: "Ask Sam about the Convex migration",
+    status: "todo",
+    priority: "medium",
+    createdAt: MOCK_REFERENCE_MS - 432000000,
+    dueLabel: "Fri",
+    estimatedMinutes: 15,
+    energy: "medium",
+    tag: "eng",
+  },
+  {
+    id: "task-lib-6",
+    title: "Publish weekly recap",
+    status: "todo",
+    priority: "low",
+    createdAt: MOCK_REFERENCE_MS - 518400000,
+    dueLabel: "Sun",
+    estimatedMinutes: 25,
+    energy: "low",
+    coachSuggested: true,
+  },
+  {
+    id: "task-lib-7",
+    title: "Read one chapter of the Bach book",
+    status: "done",
+    priority: "low",
+    createdAt: MOCK_REFERENCE_MS - 604800000,
+    dueLabel: "Anytime",
+    estimatedMinutes: 30,
+    energy: "low",
+    completedAt: MOCK_REFERENCE_MS - 7200000,
+  },
+];
+
+/** Linked tasks on goal / project detail — screens-3.jsx */
+export const mockGoalLinkedTaskTitles = [
+  "Finish landing copy",
+  "Launch post draft",
+  "Submit to Apple",
+] as const;
+
+export const mockProjectDetailTasks: MockTask[] = [
+  {
+    id: "task-proj-1",
+    title: "Finish landing copy",
+    status: "todo",
+    priority: "medium",
+    projectId: "proj-tempo-10",
+    createdAt: MOCK_REFERENCE_MS - 86400000,
+  },
+  {
+    id: "task-proj-2",
+    title: "Review PRs",
+    status: "todo",
+    priority: "medium",
+    projectId: "proj-tempo-10",
+    createdAt: MOCK_REFERENCE_MS - 72000000,
+  },
+  {
+    id: "task-proj-3",
+    title: "Submit to Apple",
+    status: "todo",
+    priority: "high",
+    projectId: "proj-tempo-10",
+    createdAt: MOCK_REFERENCE_MS - 36000000,
+  },
+  {
+    id: "task-proj-4",
+    title: "Push Android alpha",
+    status: "done",
+    priority: "medium",
+    projectId: "proj-tempo-10",
+    createdAt: MOCK_REFERENCE_MS - 259200000,
+    completedAt: MOCK_REFERENCE_MS - 86400000,
+  },
+  {
+    id: "task-proj-5",
+    title: "Brand style guide — v1",
+    status: "done",
+    priority: "low",
+    projectId: "proj-tempo-10",
+    createdAt: MOCK_REFERENCE_MS - 345600000,
+    completedAt: MOCK_REFERENCE_MS - 172800000,
+  },
+];
+
+export const mockBrainDumpDefaultText =
+  "Remember to finish the landing copy. Book dentist. Ask Sam about the Convex migration. Pick up groceries on the way home. Worry: am I shipping fast enough? Idea: use the orange gradient on the first-run splash. Journal later about the talk.";
+
+export const mockBrainDumpSortedItems: MockBrainDumpSortedItem[] = [
+  { text: "Finish the landing copy", type: "task", confidence: 0.94 },
+  { text: "Book dentist", type: "task", confidence: 0.97 },
+  { text: "Ask Sam about the Convex migration", type: "task", confidence: 0.91 },
+  { text: "Pick up groceries on the way home", type: "reminder", confidence: 0.86 },
+  { text: "Am I shipping fast enough?", type: "worry", confidence: 0.88 },
+  { text: "Orange gradient on the first-run splash", type: "idea", confidence: 0.82 },
+  { text: "Journal about the talk", type: "reminder", confidence: 0.79 },
+];
+
+export const mockBrainDumpPrompts = [
+  "What's one thing you've been avoiding?",
+  "Any small wins from yesterday?",
+  "What would help your shoulders drop?",
+] as const;
+
+/** Today header + copy — screens-1.jsx */
+export const mockTodayPage = {
+  dateLabel: "Thursday, April 23",
+  crumb: "Thursday, April 23",
+  greeting: "Good morning, Amit.",
+  lede: "Three things look doable this afternoon. Your energy tends to dip after lunch — that's allowed.",
+  streakDays: 5,
+  energyLevel: 4,
+  pebbleQuote:
+    '"10 minute walk" beats "some movement." — small, gentle, specific.',
+  upNextLines: [
+    "11:00 Review PRs · 30 min",
+    "12:30 10-minute walk",
+    "14:00 Respond to founder Qs",
+  ],
+  habitsSidebar: [
+    { name: "Morning pages", streakLabel: "5-day streak", ringPct: 1 },
+    { name: "10-min walk", pill: "due" as const, ringPct: 0.5 },
+    { name: "Shutdown sequence", pill: "8pm" as const, ringPct: 0 },
+  ],
+} as const;
+
+/** Planning timeline — screens-1.jsx ScreenPlan */
+export const mockPlanBlocks: MockPlanBlock[] = [
+  {
+    id: "plan-1",
+    startLabel: "8:00",
+    endLabel: "8:15",
+    title: "Morning pages",
+    tone: "moss",
+  },
+  {
+    id: "plan-2",
+    startLabel: "9:30",
+    endLabel: "10:30",
+    title: "Draft Tempo 1.0 launch post",
+    tone: "accent",
+  },
+  {
+    id: "plan-3",
+    startLabel: "11:00",
+    endLabel: "11:30",
+    title: "Review PRs",
+    tone: "slate",
+  },
+  {
+    id: "plan-4",
+    startLabel: "12:30",
+    endLabel: "12:40",
+    title: "10-minute walk",
+    tone: "moss",
+  },
+  {
+    id: "plan-5",
+    startLabel: "14:00",
+    endLabel: "14:25",
+    title: "Respond to founder Qs",
+    tone: "accent",
+  },
+  {
+    id: "plan-6",
+    startLabel: "16:00",
+    endLabel: "16:10",
+    title: "Shutdown sequence",
+    tone: "slate",
+  },
+];
+
+export const mockPlanSummary =
+  "6 blocks · 2h 30m focused work · 4h 30m open";

--- a/packages/mock-data/src/templates.ts
+++ b/packages/mock-data/src/templates.ts
@@ -1,0 +1,153 @@
+import { MOCK_REFERENCE_MS } from "./constants";
+import type { MockTemplate } from "./types";
+
+/** Starter catalog — screens-templates.jsx TF_STARTERS */
+export const mockTemplateStarters: MockTemplate[] = [
+  {
+    id: "weekly-review",
+    name: "Weekly Review",
+    emoji: "🗓",
+    description:
+      "Nine questions that turn the week into a plan for the next one.",
+    stepCount: 9,
+    kicker: "Every Friday · 15 min",
+    cadence: "Weekly",
+    author: "Amit · Tempo",
+    tone: "amber",
+    lastRunAt: MOCK_REFERENCE_MS - 3 * 86400000,
+  },
+  {
+    id: "morning-pages",
+    name: "Morning Pages",
+    emoji: "☀",
+    description:
+      "Three long-form pages before the inbox. No prompts, just the blinking cursor.",
+    stepCount: 3,
+    kicker: "Daily · 10 min",
+    cadence: "Daily",
+    author: "Julia Cameron style",
+    tone: "orange",
+  },
+  {
+    id: "builder-shutdown",
+    name: "Builder Shutdown",
+    emoji: "🌙",
+    description:
+      "Close the loops. Park the next thread. Put the laptop down with a clean room.",
+    stepCount: 6,
+    kicker: "End of workday · 8 min",
+    cadence: "Daily",
+    author: "Cal Newport style",
+    tone: "slate",
+  },
+  {
+    id: "sunday-reset",
+    name: "Sunday Reset",
+    emoji: "🌿",
+    description:
+      "Recap · clear · re-aim. The single most-forked template in the library.",
+    stepCount: 11,
+    kicker: "Weekly · 20 min",
+    cadence: "Weekly",
+    author: "Community · 2.4k forks",
+    tone: "moss",
+    starred: true,
+    lastRunAt: MOCK_REFERENCE_MS - 86400000,
+  },
+  {
+    id: "monthly-retro",
+    name: "Monthly Retrospective",
+    emoji: "📊",
+    description:
+      "Wins, misses, what changed, what's next. Feeds the yearly review.",
+    stepCount: 7,
+    kicker: "Last day of month · 30 min",
+    cadence: "Monthly",
+    author: "Amit · Tempo",
+    tone: "rust",
+  },
+  {
+    id: "yearly-review",
+    name: "Yearly Review",
+    emoji: "🎯",
+    description:
+      "Big one. Twelve monthly retros compressed into the shape of a year.",
+    stepCount: 14,
+    kicker: "December 28 · 90 min",
+    cadence: "Yearly",
+    author: "Amit · Tempo",
+    tone: "tempo",
+  },
+  {
+    id: "energy-checkin",
+    name: "Energy Check-in",
+    emoji: "🔥",
+    description:
+      "Mood, body, sleep, spoons. Runs in under two minutes so you actually do it.",
+    stepCount: 4,
+    kicker: "Anytime · 90 sec",
+    cadence: "Ad-hoc",
+    author: "Amit · Tempo",
+    tone: "orange",
+  },
+  {
+    id: "project-kickoff",
+    name: "Project Kickoff",
+    emoji: "⚡",
+    description:
+      "Why, who, what shippable looks like, what would make this fail. Ten questions.",
+    stepCount: 10,
+    kicker: "Once per project · 25 min",
+    cadence: "Ad-hoc",
+    author: "Shape Up style",
+    tone: "amber",
+  },
+  {
+    id: "daily-standup",
+    name: "Daily Standup (solo)",
+    emoji: "✅",
+    description:
+      "Yesterday · today · blockers. The PM script, for people with no PM.",
+    stepCount: 3,
+    kicker: "Daily · 3 min",
+    cadence: "Daily",
+    author: "Community · 812 forks",
+    tone: "moss",
+  },
+];
+
+export const mockMyTemplates: MockTemplate[] = [
+  {
+    id: "my-shipping",
+    name: "Shipping-day routine",
+    emoji: "🚢",
+    description: "Last run · Tue",
+    stepCount: 7,
+    kicker: "Last run · Tue",
+    cadence: "Ad-hoc",
+    author: "You",
+    lastRunAt: MOCK_REFERENCE_MS - 2 * 86400000,
+  },
+  {
+    id: "my-weekly",
+    name: "Weekly Review — my version",
+    emoji: "🗓",
+    description: "Every Friday 4pm",
+    stepCount: 12,
+    kicker: "Every Friday 4pm",
+    cadence: "Weekly",
+    author: "You · forked from Amit",
+    lastRunAt: MOCK_REFERENCE_MS - 5 * 86400000,
+  },
+  {
+    id: "my-reset",
+    name: "Sunday Reset",
+    emoji: "🌿",
+    description: "Every Sunday",
+    stepCount: 11,
+    kicker: "Every Sunday",
+    cadence: "Weekly",
+    author: "Community · forked",
+    lastRunAt: MOCK_REFERENCE_MS - 86400000,
+  },
+];

--- a/packages/mock-data/src/types.ts
+++ b/packages/mock-data/src/types.ts
@@ -1,0 +1,178 @@
+/**
+ * Shared TypeScript types for Tempo Flow fixtures.
+ *
+ * These mirror the shape of what Convex will return in Long Run 2 — they
+ * use plain JS Date/number types rather than Convex `Id<"...">` branded
+ * types so tests and previews aren't coupled to Convex codegen.
+ */
+
+export type TaskStatus = "todo" | "in_progress" | "done" | "cancelled";
+export type TaskPriority = "low" | "medium" | "high";
+
+export type MockTask = {
+  id: string;
+  title: string;
+  notes?: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  projectId?: string;
+  goalId?: string;
+  dueAt?: number; // epoch ms
+  completedAt?: number;
+  createdAt: number;
+  /** Library/tasks list label from design export (e.g. "Today", "Tomorrow"). */
+  dueLabel?: string;
+  /** Estimated minutes from design export TaskRow. */
+  estimatedMinutes?: number;
+  /** Design-export energy hint: low | medium | high */
+  energy?: "low" | "medium" | "high";
+  /** Tag slug without # */
+  tag?: string;
+  /** Coach / AI flagged row */
+  coachSuggested?: boolean;
+};
+
+export type MockHabit = {
+  id: string;
+  name: string;
+  cadence: "daily" | "weekly" | "weekdays";
+  streak: number;
+  longestStreak?: number;
+  completionRatio?: number; // 0..1 for ring
+  /** Epoch ms of the last 7 completed days (may be shorter if new). */
+  recentCompletions: number[];
+  color: "moss" | "brick" | "amber" | "slate" | "orange";
+};
+
+export type MockNote = {
+  id: string;
+  title: string;
+  body: string;
+  tags: string[];
+  updatedAt: number;
+};
+
+export type MockJournalEntry = {
+  id: string;
+  date: string; // ISO yyyy-mm-dd
+  /** Mood chips from design export (screens-2.jsx). */
+  mood: "settled" | "tired" | "anxious" | "steady" | "bright" | "low" | "meh";
+  body: string;
+  prompt?: string;
+  wordCount?: number;
+};
+
+export type MockCalendarEvent = {
+  id: string;
+  title: string;
+  startAt: number;
+  endAt: number;
+  location?: string;
+  taskId?: string;
+  source: "tempo" | "google" | "ics";
+};
+
+export type MockCoachMessage = {
+  id: string;
+  role: "coach" | "user" | "system";
+  body: string;
+  timestamp: number;
+  suggestion?: {
+    kind: "accept" | "tweak" | "skip";
+    taskIds?: string[];
+    preview: string;
+  };
+};
+
+export type MockRoutine = {
+  id: string;
+  name: string;
+  description: string;
+  steps: Array<{ id: string; title: string; durationMin: number }>;
+  lastRunAt?: number;
+};
+
+export type MockGoal = {
+  id: string;
+  title: string;
+  description: string;
+  progress: number; // 0..1
+  milestones: Array<{ id: string; title: string; done: boolean }>;
+  targetAt?: number;
+};
+
+export type MockProject = {
+  id: string;
+  name: string;
+  color: "moss" | "brick" | "amber" | "slate" | "orange";
+  taskIds: string[];
+  noteIds: string[];
+};
+
+export type MockTemplateTone =
+  | "amber"
+  | "orange"
+  | "slate"
+  | "moss"
+  | "rust"
+  | "tempo";
+
+export type MockTemplate = {
+  id: string;
+  name: string;
+  emoji: string;
+  description: string;
+  stepCount: number;
+  lastRunAt?: number;
+  kicker?: string;
+  cadence?: string;
+  author?: string;
+  tone?: MockTemplateTone;
+  starred?: boolean;
+};
+
+export type MockBrainDumpSortedItem = {
+  text: string;
+  type: "task" | "reminder" | "worry" | "idea" | "note";
+  confidence: number;
+};
+
+export type MockPlanBlock = {
+  id: string;
+  startLabel: string;
+  endLabel: string;
+  title: string;
+  tone: "moss" | "accent" | "slate";
+};
+
+export type MockDailyNoteTaskLine = {
+  id: string;
+  title: string;
+  done: boolean;
+  time?: string;
+  tag?: string;
+  energy?: "low" | "medium" | "high";
+};
+
+export type MockDailyNoteBody = {
+  fileName: string;
+  headline: string;
+  topTasks: MockDailyNoteTaskLine[];
+  laterTasks: MockDailyNoteTaskLine[];
+  streakLabel: string;
+  coachGreeting: string;
+};
+
+export type MockUser = {
+  id: string;
+  name: string;
+  email: string;
+  avatarUrl?: string;
+  trialEndsAt: number;
+  isPremium: boolean;
+  preferences: {
+    theme: "light" | "dark" | "system";
+    dyslexiaFont: boolean;
+    reducedMotion: boolean;
+  };
+};

--- a/packages/mock-data/src/user.ts
+++ b/packages/mock-data/src/user.ts
@@ -1,0 +1,33 @@
+import { MOCK_REFERENCE_MS } from "./constants";
+import type { MockUser } from "./types";
+
+/** Settings profile + billing copy — screens-4.jsx */
+export const mockUser: MockUser = {
+  id: "user-amit",
+  name: "Amit Levin",
+  email: "amitlevin65@protonmail.com",
+  trialEndsAt: MOCK_REFERENCE_MS + 3 * 86400000,
+  isPremium: true,
+  preferences: {
+    theme: "system",
+    dyslexiaFont: false,
+    reducedMotion: false,
+  },
+};
+
+export const mockUserProfileFields = {
+  displayName: "Amit",
+  pronouns: "he/him",
+  bio: "Building Tempo Flow, slowly, on cream paper.",
+  oneWobble:
+    "Shipping feels like a cathedral I can't enter on low-spoons days.",
+} as const;
+
+export const mockBillingCopy = {
+  trialDay: 4,
+  trialTotalDays: 7,
+  daysLeft: 3,
+  progressPct: 57,
+  headline: "Your seven-day walk.",
+  lede: "A dollar buys a week. Keep going, pause, or walk away — all are fine.",
+} as const;

--- a/packages/mock-data/src/you.ts
+++ b/packages/mock-data/src/you.ts
@@ -1,0 +1,36 @@
+/** You + Settings + Command surfaces — screens-5.jsx + screens-6.jsx */
+
+export const mockInsightStats = [
+  { label: "Tasks completed (7d)", value: "24", delta: "+6 vs prior week" },
+  { label: "Focus blocks", value: "11", delta: "steady" },
+  { label: "Journal words", value: "3.1k", delta: "gentle upward" },
+] as const;
+
+export const mockActivityLines = [
+  { id: "act-1", text: "Completed · Morning pages", at: "08:12" },
+  { id: "act-2", text: "Updated · Launch post draft", at: "09:40" },
+  { id: "act-3", text: "Coach · Staged outline for Tempo 1.0 post", at: "10:05" },
+  { id: "act-4", text: "Logged · 10-minute walk", at: "12:41" },
+] as const;
+
+export const mockSearchResults = [
+  { id: "sr-1", title: "Launch post — draft", subtitle: "Notes · writing", href: "/notes/note-1" },
+  { id: "sr-2", title: "Draft Tempo 1.0 launch post", subtitle: "Tasks · today", href: "/tasks" },
+  { id: "sr-3", title: "Plan · Thursday", subtitle: "Screens", href: "/plan" },
+] as const;
+
+export const mockCommandActions = [
+  { id: "cmd-1", label: "Go to Today", shortcut: "G T" },
+  { id: "cmd-2", label: "Go to Brain Dump", shortcut: "G B" },
+  { id: "cmd-3", label: "Go to Coach", shortcut: "G C" },
+] as const;
+
+export const mockEmptyStateExamples = [
+  { title: "No tasks yet", body: "Add one small thing. It counts.", cta: "Add a task" },
+  { title: "No notes yet", body: "Start with a sentence. The rest can wait.", cta: "New note" },
+] as const;
+
+export const mockNotificationItems = [
+  { id: "n-1", title: "Trial · day 4 of 7", body: "Three gentle days left on your walk.", unread: true },
+  { id: "n-2", title: "Coach nudge", body: "The launch post outline is ready when you are.", unread: false },
+] as const;

--- a/packages/mock-data/tsconfig.json
+++ b/packages/mock-data/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/ui/src/primitives/CoachBubble.tsx
+++ b/packages/ui/src/primitives/CoachBubble.tsx
@@ -11,7 +11,8 @@ import type { ReactNode } from "react";
 export type CoachBubbleRole = "coach" | "user" | "system";
 
 export type CoachBubbleProps = {
-  role?: CoachBubbleRole;
+  /** Visual variant — named `bubbleRole` so we never forward invalid `role` to the DOM. */
+  bubbleRole?: CoachBubbleRole;
   children: ReactNode;
   actions?: ReactNode;
   timestamp?: string;
@@ -27,7 +28,7 @@ const roleMap: Record<CoachBubbleRole, string> = {
 };
 
 export function CoachBubble({
-  role = "coach",
+  bubbleRole = "coach",
   children,
   actions,
   timestamp,
@@ -37,7 +38,7 @@ export function CoachBubble({
     <div
       className={[
         "flex max-w-[85%] flex-col gap-2 rounded-2xl border px-4 py-3 shadow-whisper",
-        roleMap[role],
+        roleMap[bubbleRole],
         className,
       ].join(" ")}
     >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR completes the Long Run 1 frontend port: all Tempo web routes under `(tempo)` / `(bare)` and all 12 mobile Tempo surfaces now render real layouts from `@tempo/mock-data`, with Convex-oriented pseudo-code annotations (`@mutation`, `@query`, `@index`, `@env`, etc.). It adds the `@tempo/mock-data` package barrel, `you.ts` fixtures for You/Settings surfaces, a reusable `ScreenSurface` preview strip, registers mock-data in web + mobile, renames `CoachBubble`’s visual variant prop to `bubbleRole` (avoids invalid DOM `role`), and documents screenshot URLs for PR polish.

## Linked task(s)

Task: T-F000 (children: T-F011, T-F005a, T-F005b, T-F005c, T-F005d, T-F005e, T-F006, T-F009a, T-F009b)

## Screenshots / screen recording

Screenshots not attached in this environment. Use the checklist in `docs/design/frontend-port-screenshot-urls.md` (all paths listed for web + mobile). Please capture light/dark for key routes before merge.

## Test plan

- [x] Local `bun run typecheck` passes
- [x] Local `bun run lint` passes
- [ ] Relevant unit / integration tests added or updated (no new Convex mutations; screen-only port)
- [x] Manual QA: spot-check representative routes after `bun run dev:web` (see screenshot doc)
- [x] Reproduces the acceptance criteria below (mock-data only; no Convex imports in new route bodies)

## Acceptance criteria

**T-F011 — Mock data package**

- [x] `packages/mock-data/` with name `@tempo/mock-data`
- [x] Typed fixtures exported via `src/index.ts`
- [x] Deterministic fixtures (no `Date.now` / `Math.random` in fixtures)
- [x] `bun run typecheck` green

**T-F005a–e / T-F006 / T-F009a–b (cluster)**

- [x] Scaffold screens replaced with real content per vertical
- [x] Imports: React, Next/Expo, `@tempo/ui`, `@tempo/mock-data` only (no `convex/*` in route files)
- [x] Interactive elements annotated (`@action`, `@mutation`/`@query`, `@navigate`, `@auth`, `@errors`, `@env` where applicable)
- [x] Empty/loading/error via local `mode` on `ScreenSurface` where applicable
- [x] Biome + typecheck pass

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI-originated state remains preview/proposal in UI (no silent Convex writes from these routes)
- [x] No schema changes in this PR
- [x] Styling uses design tokens / Tailwind semantic classes from existing setup
- [x] Accessibility: fixed `CoachBubble` prop clash with ARIA; heatmap uses `role="img"`; mobile `Pressable`s labeled
- [x] No secrets committed
- [x] Brand: anti-shame copy preserved from exports where used

## Owner tag (§14)

- [x] `cursor-cloud-3`

## Reviewer

human-amit
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-641103fc-62ed-4a30-8223-f1d265e92638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-641103fc-62ed-4a30-8223-f1d265e92638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

