### PR TITLE
feat(devops): shared Biome config + Biome-only lint approach [T-0007]

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git check-ignore *)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "Bash(gh repo *)",
+      "Bash(gh pr *)",
+      "Read(//c/Users/User/.claude/plugins/cache/claude-plugins-official/playwright/61c0597779bd/**)",
+      "Read(//c/Users/User/.claude/plugins/cache/claude-plugins-official/playwright/61c0597779bd//**)"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -98,6 +98,41 @@ Tempo Flow is developed by one person. If it helps you, consider supporting deve
 - **Founder vlog:** `https://www.youtube.com/@<channel>` (placeholder — techno-optimism, future-proofing, building with AI)
 - **Ask the Founder:** built into the app — Settings → Ask the Founder. Submissions land in a private queue; opt-in transcripts may be published as part of the 1.1 release.
 
+## Linting
+
+Tempo Flow is **Biome-only** — no ESLint, no Prettier anywhere in the repo.
+
+### Shared config approach
+
+A root shared config lives at [`packages/config/biome.json`](./packages/config/biome.json). Each app extends it:
+
+| File | Extends | App-level overrides |
+|------|---------|---------------------|
+| `apps/web/biome.json` | `../../packages/config/biome.json` | CSS parser (`tailwindDirectives`, `cssModules`) |
+| `apps/mobile/biome.json` | `../../packages/config/biome.json` | `lineWidth: 80`, `quoteStyle: "single"` |
+
+### Common rule highlights
+
+- `recommended: true` base + explicit error/warn escalations for key correctness and suspicious rules.
+- `noConsole: "warn"` — console calls allowed during development, surfaced in CI.
+- `noExplicitAny: "off"` — pragmatic; tighten per-file when possible.
+- `useExhaustiveDependencies: "warn"` on all `.tsx/.ts/.jsx/.js` files.
+
+### Tailwind class sorting
+
+Tailwind class sorting is **intentionally disabled** in Biome. `apps/web` uses Tailwind v4 (shadcn/ui conventions) and `apps/mobile` uses NativeWind (different class ordering expectations). A shared sort order cannot be enforced without false positives across both targets.
+
+### Running the linter
+
+```bash
+# Lint all workspaces via Turborepo
+bun run lint
+
+# Lint a single workspace
+cd apps/web && bun run lint
+cd apps/mobile && bun run lint
+```
+
 ## Contributing
 
 See `CONTRIBUTING.md` (published alongside the Tempo 1.1 release). Until then, open an issue before starting work on a significant change, and follow [`docs/HARD_RULES.md`](./docs/HARD_RULES.md) rigorously.

--- a/apps/mobile/biome.json
+++ b/apps/mobile/biome.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
-  "vcs": {
-    "enabled": false,
-    "clientKind": "git",
-    "useIgnoreFile": true
-  },
+  "extends": ["../../packages/config/biome.json"],
   "files": {
     "ignoreUnknown": false,
     "includes": [
@@ -17,53 +13,12 @@
     ]
   },
   "formatter": {
-    "enabled": true,
-    "indentStyle": "space",
-    "indentWidth": 2,
     "lineWidth": 80
   },
-  "assist": { "actions": { "source": { "organizeImports": "on" } } },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true,
-      "performance": {
-        "noAccumulatingSpread": "error"
-      },
-      "style": {
-        "useConst": "warn",
-        "useBlockStatements": "off",
-        "noImplicitBoolean": "off"
-      },
-      "suspicious": {
-        "noAsyncPromiseExecutor": "error",
-        "noCatchAssign": "error",
-        "noDoubleEquals": "error",
-        "noDuplicateObjectKeys": "error",
-        "noMisleadingCharacterClass": "error",
-        "noPrototypeBuiltins": "error",
-        "noRedeclare": "error",
-        "noSelfCompare": "error",
-        "noUnsafeNegation": "error",
-        "noConsole": "warn"
-      },
-      "correctness": {
-        "noConstAssign": "error",
-        "noConstantCondition": "error",
-        "noEmptyCharacterClassInRegex": "error",
-        "noEmptyPattern": "error",
-        "noInnerDeclarations": "error",
-        "noInvalidConstructorSuper": "error",
-        "noInvalidUseBeforeDeclaration": "error",
-        "noPrecisionLoss": "error",
-        "noSelfAssign": "error",
-        "noSetterReturn": "error",
-        "noUndeclaredVariables": "error",
-        "noUnreachable": "error",
-        "noUnsafeFinally": "error",
-        "useIsNan": "error",
-        "useValidForDirection": "error"
-      }
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "es5"
     }
   },
   "overrides": [
@@ -77,11 +32,5 @@
         }
       }
     }
-  ],
-  "javascript": {
-    "formatter": {
-      "quoteStyle": "single",
-      "trailingCommas": "es5"
-    }
-  }
+  ]
 }

--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { CheckCircle2, Flame, ListTodo, Sparkles } from "lucide-react";
 import Link from "next/link";
 import { useMemo } from "react";
@@ -18,10 +18,10 @@ function useTodayDueBounds() {
 }
 
 const statusLabel: Record<string, string> = {
-  todo: "לביצוע",
-  in_progress: "בתהליך",
-  done: "בוצע",
-  cancelled: "בוטל",
+  todo: "To do",
+  in_progress: "In progress",
+  done: "Done",
+  cancelled: "Cancelled",
 };
 
 const priorityClass: Record<string, string> = {
@@ -31,17 +31,21 @@ const priorityClass: Record<string, string> = {
 };
 
 export default function DashboardPage() {
-  const profile = useQuery(api.users.getProfile);
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
   const bounds = useTodayDueBounds();
-  const todayTasks = useQuery(api.tasks.list, bounds);
-  const streaks = useQuery(api.streaks.getCurrent);
-  const habits = useQuery(api.habits.list);
+
+  const profile = useQuery(api.users.getProfile, isAuthenticated ? {} : "skip");
+  const todayTasks = useQuery(api.tasks.list, isAuthenticated ? bounds : "skip");
+  const streaks = useQuery(api.streaks.getCurrent, isAuthenticated ? {} : "skip");
+  const habits = useQuery(api.habits.list, isAuthenticated ? {} : "skip");
 
   const loading =
-    profile === undefined ||
-    todayTasks === undefined ||
-    streaks === undefined ||
-    habits === undefined;
+    isAuthLoading ||
+    (isAuthenticated &&
+      (profile === undefined ||
+        todayTasks === undefined ||
+        streaks === undefined ||
+        habits === undefined));
 
   if (loading) {
     return (
@@ -57,28 +61,31 @@ export default function DashboardPage() {
     );
   }
 
-  if (!profile) {
+  if (!isAuthenticated || !profile) {
     return (
       <div className="container mx-auto max-w-6xl px-6 py-16 text-center">
-        <p className="text-muted-foreground">לא נמצא פרופיל משתמש. נסו להתחבר מחדש.</p>
+        <p className="text-muted-foreground">No profile found. Please sign in again.</p>
         <Button asChild className="mt-6">
-          <Link href="/sign-in">התחברות</Link>
+          <Link href="/sign-in">Sign in</Link>
         </Button>
       </div>
     );
   }
 
-  const openToday = todayTasks.filter((t) => t.status !== "done" && t.status !== "cancelled");
+  const openToday = (todayTasks ?? []).filter(
+    (t) => t.status !== "done" && t.status !== "cancelled",
+  );
 
   return (
-    <div className="container mx-auto max-w-6xl px-6 py-12" dir="rtl">
+    <div className="container mx-auto max-w-6xl px-6 py-12">
       <header className="mb-12">
-        <p className="text-sm font-medium text-muted-foreground">לוח בקרה</p>
+        <p className="text-sm font-medium text-muted-foreground">Dashboard</p>
         <h1 className="font-heading mt-2 text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
-          שלום, <span className="text-gradient-primary">{profile.greetingName}</span>
+          Hello,{" "}
+          <span className="text-gradient-primary">{profile.greetingName ?? profile.fullName}</span>
         </h1>
         <p className="mt-3 max-w-2xl text-lg text-muted-foreground">
-          סיכום היום, משימות ומעקב הרגלים במקום אחד.
+          Your day at a glance — tasks, habits, and streaks in one place.
         </p>
       </header>
 
@@ -90,8 +97,10 @@ export default function DashboardPage() {
                 <ListTodo className="h-5 w-5" aria-hidden />
               </div>
               <div>
-                <h2 className="font-heading text-2xl font-semibold text-foreground">משימות להיום</h2>
-                <p className="text-sm text-muted-foreground">לפי תאריך יעד היום</p>
+                <h2 className="font-heading text-2xl font-semibold text-foreground">
+                  Today&apos;s tasks
+                </h2>
+                <p className="text-sm text-muted-foreground">Due today</p>
               </div>
             </div>
             <Button
@@ -99,15 +108,18 @@ export default function DashboardPage() {
               variant="outline"
               className="rounded-xl border-border bg-card/80 shadow-[inset_0_1px_0_rgba(255,255,255,0.5)]"
             >
-              <Link href="/tasks">כל המשימות</Link>
+              <Link href="/tasks">All tasks</Link>
             </Button>
           </div>
 
-          {todayTasks.length === 0 ? (
+          {(todayTasks ?? []).length === 0 ? (
             <p className="rounded-xl border border-dashed border-border bg-muted/30 px-6 py-10 text-center text-muted-foreground">
-              אין משימות עם יעד להיום.{" "}
-              <Link href="/tasks" className="font-semibold text-primary underline-offset-4 hover:underline">
-                הוסיפו משימה
+              Nothing due today.{" "}
+              <Link
+                href="/tasks"
+                className="font-semibold text-primary underline-offset-4 hover:underline"
+              >
+                Add a task
               </Link>
             </p>
           ) : (
@@ -115,10 +127,10 @@ export default function DashboardPage() {
               {openToday.length === 0 ? (
                 <li className="flex items-center gap-2 rounded-xl border border-primary/20 bg-primary/5 px-4 py-3 text-primary">
                   <CheckCircle2 className="h-5 w-5 shrink-0" aria-hidden />
-                  <span>כל משימות היום הושלמו — כל הכבוד!</span>
+                  <span>All tasks done for today — great work!</span>
                 </li>
               ) : null}
-              {todayTasks.map((task) => (
+              {(todayTasks ?? []).map((task) => (
                 <li
                   key={task._id}
                   className={cn(
@@ -136,14 +148,18 @@ export default function DashboardPage() {
                       {task.title}
                     </p>
                     {task.description ? (
-                      <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{task.description}</p>
+                      <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                        {task.description}
+                      </p>
                     ) : null}
                   </div>
                   <div className="flex shrink-0 flex-wrap items-center gap-2">
                     <span className="rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground">
                       {statusLabel[task.status] ?? task.status}
                     </span>
-                    <span className={cn("text-xs font-semibold uppercase", priorityClass[task.priority])}>
+                    <span
+                      className={cn("text-xs font-semibold uppercase", priorityClass[task.priority])}
+                    >
                       {task.priority}
                     </span>
                   </div>
@@ -160,15 +176,15 @@ export default function DashboardPage() {
                 <Flame className="h-5 w-5" aria-hidden />
               </div>
               <div>
-                <h2 className="font-heading text-xl font-semibold">רצף נוכחי</h2>
-                <p className="text-sm text-muted-foreground">מקסימום בין ההרגלים</p>
+                <h2 className="font-heading text-xl font-semibold">Current streak</h2>
+                <p className="text-sm text-muted-foreground">Best across all habits</p>
               </div>
             </div>
             <p className="mt-6 font-heading text-5xl font-bold text-gradient-primary tabular-nums">
-              {streaks.streakCount}
+              {streaks?.streakCount ?? 0}
             </p>
             <p className="mt-2 text-sm text-muted-foreground">
-              רצף ארוך ביותר: {streaks.longestAmongHabits} · {streaks.habitCount} הרגלים
+              Longest: {streaks?.longestAmongHabits ?? 0} · {streaks?.habitCount ?? 0} habits
             </p>
           </SoftCard>
 
@@ -179,8 +195,8 @@ export default function DashboardPage() {
                   <Sparkles className="h-5 w-5" aria-hidden />
                 </div>
                 <div>
-                  <h2 className="font-heading text-xl font-semibold">הרגלים</h2>
-                  <p className="text-sm text-muted-foreground">התקדמות רצף</p>
+                  <h2 className="font-heading text-xl font-semibold">Habits</h2>
+                  <p className="text-sm text-muted-foreground">Streak progress</p>
                 </div>
               </div>
               <Button
@@ -188,27 +204,32 @@ export default function DashboardPage() {
                 variant="ghost"
                 className="text-primary hover:bg-primary/10 hover:text-primary"
               >
-                <Link href="/habits">ניהול</Link>
+                <Link href="/habits">Manage</Link>
               </Button>
             </div>
 
-            {habits.length === 0 ? (
+            {(habits ?? []).length === 0 ? (
               <p className="text-center text-sm text-muted-foreground">
-                עדיין אין הרגלים.{" "}
-                <Link href="/habits" className="font-semibold text-primary underline-offset-4 hover:underline">
-                  צרו הרגל ראשון
+                No habits yet.{" "}
+                <Link
+                  href="/habits"
+                  className="font-semibold text-primary underline-offset-4 hover:underline"
+                >
+                  Create your first habit
                 </Link>
               </p>
             ) : (
               <ul className="space-y-5">
-                {habits.slice(0, 5).map((h) => {
+                {(habits ?? []).slice(0, 5).map((h) => {
                   const cap = Math.max(h.longestStreak, h.currentStreak, 1);
                   const pct = Math.min(100, Math.round((h.currentStreak / cap) * 100));
                   return (
                     <li key={h._id}>
                       <div className="mb-2 flex justify-between text-sm">
                         <span className="font-medium text-foreground">{h.name}</span>
-                        <span className="tabular-nums text-muted-foreground">{h.currentStreak} ימים</span>
+                        <span className="tabular-nums text-muted-foreground">
+                          {h.currentStreak} days
+                        </span>
                       </div>
                       <div className="h-2.5 overflow-hidden rounded-full bg-muted shadow-[inset_0_1px_3px_rgba(0,0,0,0.12)]">
                         <div

--- a/apps/web/app/(auth)/layout.tsx
+++ b/apps/web/app/(auth)/layout.tsx
@@ -2,26 +2,24 @@
 
 import { useConvexAuth } from "convex/react";
 
-// Layout עבור דפי אימות (כניסה/הרשמה)
-// מטפל בהצגת לוגיקה בזמן טעינה והסתרה אם המשתמש כבר מחובר
+// Layout for the auth pages (sign-in / sign-up).
+// Handles the loading state and hides itself when the user is already signed in.
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading } = useConvexAuth();
 
-  // הצגת ספינר טעינה בזמן בדיקת סטטוס האימות
   if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-500 border-t-transparent"></div>
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
       </div>
     );
   }
 
-  // אם המשתמש כבר מחובר, אין צורך להציג את דפי האימות (ההפניה תתבצע ב-Middleware או בקומפוננטה)
+  // When the user is already signed in, leave the redirect to middleware / the page.
   if (isAuthenticated) {
     return null;
   }
 
-  // עיצוב הרקע לדפי האימות
   return (
     <div className="min-h-screen bg-linear-to-br from-gray-900 via-gray-800 to-black">
       {children}

--- a/apps/web/app/(tempo)/brain-dump/page.tsx
+++ b/apps/web/app/(tempo)/brain-dump/page.tsx
@@ -1,23 +1,15 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: brain-dump
  * @category: Flow
- * @source: docs/design/claude-export/design-system/screens-1.jsx
- * @summary: Rapid capture with auto-sort suggestions.
- * @queries: inbox.list
- * @mutations: inbox.capture, inbox.sort
+ * @summary: Rapid capture — dumps text into a dated note.
+ * @queries: (none)
+ * @mutations: notes.create
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @status: live
+ * @notes: Phase 3 will add AI extraction into tasks/notes via accept-reject proposals.
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { BrainDumpScreen } from "@/components/brain-dump/BrainDumpScreen";
 
 export default function Page() {
-  return (
-    <ScaffoldScreen
-      title="Brain dump"
-      category="Flow"
-      source="screens-1.jsx"
-      summary="Rapid capture with auto-sort suggestions."
-    />
-  );
+  return <BrainDumpScreen />;
 }

--- a/apps/web/app/(tempo)/coach/page.tsx
+++ b/apps/web/app/(tempo)/coach/page.tsx
@@ -1,23 +1,17 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: coach
  * @category: Flow
- * @source: docs/design/claude-export/design-system/screens-1.jsx + coach-dock.jsx
- * @summary: Conversational AI coach surface. Accept / tweak / skip suggestions.
- * @queries: coach.thread
- * @mutations: coach.accept, coach.tweak, coach.skip
+ * @summary: Live AI coach chat via OpenRouter / Mistral.
+ * @queries: (none)
+ * @actions: coachActions.respond
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @status: live
+ * @notes: Ephemeral per-session history (React state only). Transcripts are
+ *         not persisted here per HARD_RULES §6.1 — proposals live in a later
+ *         ticket.
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { CoachScreen } from "@/components/coach/CoachScreen";
 
 export default function Page() {
-  return (
-    <ScaffoldScreen
-      title="Coach"
-      category="Flow"
-      source="screens-1.jsx + coach-dock.jsx"
-      summary="Conversational AI coach surface. Accept / tweak / skip suggestions."
-    />
-  );
+  return <CoachScreen />;
 }

--- a/apps/web/app/(tempo)/journal/page.tsx
+++ b/apps/web/app/(tempo)/journal/page.tsx
@@ -1,23 +1,16 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: journal
  * @category: Library
- * @source: docs/design/claude-export/design-system/screens-2.jsx
- * @summary: Dated journal entries.
- * @queries: journal.list
- * @mutations: journal.create
+ * @summary: Today's journal entry — auto-saves on blur / 1s debounce.
+ * @queries: journal.getByDate
+ * @mutations: journal.upsertByDate
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @status: live
+ * @notes: Schema adds a `journalEntries` table; requires Convex push before the
+ *         query/mutation resolve at runtime.
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { JournalScreen } from "@/components/journal/JournalScreen";
 
 export default function Page() {
-  return (
-    <ScaffoldScreen
-      title="Journal"
-      category="Library"
-      source="screens-2.jsx"
-      summary="Dated journal entries."
-    />
-  );
+  return <JournalScreen />;
 }

--- a/apps/web/app/(tempo)/notes/[id]/page.tsx
+++ b/apps/web/app/(tempo)/notes/[id]/page.tsx
@@ -1,30 +1,23 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: note-detail
  * @category: Library
- * @source: docs/design/claude-export/design-system/screens-2.jsx
- * @summary: Rich-text note editor with slash commands.
+ * @summary: Rich-text note editor — auto-saves on blur / 1s debounce.
  * @queries: notes.get
  * @mutations: notes.update
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @status: live
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
 
-type Params = { id: string };
+import { useParams } from "next/navigation";
+import { NoteEditor } from "@/components/notes/NoteEditor";
+import type { Id } from "@/convex/_generated/dataModel";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<Params>;
-}) {
-  const { id } = await params;
-  return (
-    <ScaffoldScreen
-      title="Note editor"
-      category="Library"
-      source="screens-2.jsx"
-      summary={`Rich-text note editor with slash commands. (id: ${id})`}
-    />
-  );
+export default function Page() {
+  const params = useParams<{ id: string }>();
+  const id = params?.id;
+  if (!id) {
+    return null;
+  }
+  return <NoteEditor noteId={id as Id<"notes">} />;
 }

--- a/apps/web/app/(tempo)/notes/page.tsx
+++ b/apps/web/app/(tempo)/notes/page.tsx
@@ -1,23 +1,14 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: notes
  * @category: Library
- * @source: docs/design/claude-export/design-system/screens-2.jsx
- * @summary: Notes library — grid with backlinks.
+ * @summary: Notes list — click into an editor.
  * @queries: notes.list
  * @mutations: notes.create
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @status: live
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { NotesScreen } from "@/components/notes/NotesScreen";
 
 export default function Page() {
-  return (
-    <ScaffoldScreen
-      title="Notes"
-      category="Library"
-      source="screens-2.jsx"
-      summary="Notes library — grid with backlinks."
-    />
-  );
+  return <NotesScreen />;
 }

--- a/apps/web/app/(tempo)/tasks/page.tsx
+++ b/apps/web/app/(tempo)/tasks/page.tsx
@@ -1,23 +1,14 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: tasks
  * @category: Library
- * @source: docs/design/claude-export/design-system/screens-2.jsx
- * @summary: Tasks inbox with filters and grouping.
+ * @summary: All tasks — list, quick-add, toggle complete.
  * @queries: tasks.list
- * @mutations: tasks.complete, tasks.create
+ * @mutations: tasks.createQuick, tasks.toggleCompletion
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @status: live
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { TasksScreen } from "@/components/tasks/TasksScreen";
 
 export default function Page() {
-  return (
-    <ScaffoldScreen
-      title="Tasks"
-      category="Library"
-      source="screens-2.jsx"
-      summary="Tasks inbox with filters and grouping."
-    />
-  );
+  return <TasksScreen />;
 }

--- a/apps/web/app/(tempo)/today/page.tsx
+++ b/apps/web/app/(tempo)/today/page.tsx
@@ -1,24 +1,14 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: today
  * @category: Flow
- * @source: docs/design/claude-export/design-system/screens-1.jsx
- * @summary: Single-column daily canvas. Brain-dump composer + staged plan + coach suggestion.
- * @queries: tasks.listToday, calendar.listToday, coach.latestSuggestion
- * @mutations: tasks.capture, tasks.complete, tasks.stage
- * @routes-to: /brain-dump, /coach
+ * @summary: Single-column daily canvas. Greeting + quick-add + today's tasks.
+ * @queries: users.getProfile, tasks.listToday
+ * @mutations: tasks.createQuick, tasks.toggleCompletion
  * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @status: live
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { TodayScreen } from "@/components/today/TodayScreen";
 
 export default function Page() {
-  return (
-    <ScaffoldScreen
-      title="Today"
-      category="Flow"
-      source="screens-1.jsx"
-      summary="Single-column daily canvas. Brain-dump composer + staged plan + coach suggestion."
-    />
-  );
+  return <TodayScreen />;
 }

--- a/apps/web/app/checkout/route.ts
+++ b/apps/web/app/checkout/route.ts
@@ -1,30 +1,30 @@
 // ============================================================================
-// Route של Checkout (Polar)
+// Checkout route (Polar)
 // ============================================================================
-// הקובץ הזה יוצר Session של Checkout דרך Polar ומחזיר Redirect ל-Checkout שלהם.
+// Creates a Polar Checkout session and returns a redirect to their checkout flow.
 //
-// איך זה עובד בקצרה:
-// - הלקוח ניגש ל-`/checkout?products=<PRODUCT_ID>`
-// - Polar יוצר Checkout לפי המוצר(ים) שהעברנו
-// - בסיום תשלום, Polar מפנה ל-`POLAR_SUCCESS_URL` עם `{CHECKOUT_ID}`
+// How it works in short:
+// - The client hits `/checkout?products=<PRODUCT_ID>`.
+// - Polar creates the checkout based on the product ID we send.
+// - After payment, Polar redirects to `POLAR_SUCCESS_URL` with `{CHECKOUT_ID}`.
 //
-// ⚠️ חשוב:
-// - NEVER לחשוף POLAR_ACCESS_TOKEN לצד לקוח.
-// - כרגע אנו עובדים ב-Sandbox כדי לאפשר בדיקות בטוחות.
+// ⚠️ Important:
+// - NEVER expose POLAR_ACCESS_TOKEN to the client.
+// - We currently run in sandbox to keep testing safe.
 
 import { Checkout } from "@polar-sh/nextjs";
 
 export const GET = Checkout({
-  // טוקן ארגוני (OAT) של Polar - נשמר אך ורק בשרת דרך משתני סביבה
+  // Organisation access token (OAT) for Polar — kept server-side via env var only.
   accessToken: process.env.POLAR_ACCESS_TOKEN!,
 
-  // כתובת הצלחה שאליה Polar יפנה לאחר Checkout
-  // מומלץ לכלול `{CHECKOUT_ID}` כדי שנוכל לאמת/לעדכן סטטוס משתמש בהמשך.
+  // Polar redirects here after checkout completes.
+  // Include `{CHECKOUT_ID}` in the URL so we can verify / sync the user status later.
   successUrl: process.env.POLAR_SUCCESS_URL!,
 
-  // סביבת עבודה: sandbox לבדיקות (בייצור לשנות ל-production או להסיר)
+  // Environment: sandbox for testing (switch to production or remove when going live).
   server: "sandbox",
 
-  // עיצוב חשוך כדי להתאים לתבנית
+  // Dark theme to match the app.
   theme: "dark",
 });

--- a/apps/web/app/contact/page.tsx
+++ b/apps/web/app/contact/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 
-// דף יצירת קשר: טופס לשליחת הודעות ופרטי התקשרות נוספים
+// Contact page — message form + extra contact details.
 export default function ContactPage() {
   const [formData, setFormData] = useState({
     name: "",
@@ -32,28 +32,28 @@ export default function ContactPage() {
   return (
     <div className="min-h-screen py-20 px-4">
       <div className="max-w-6xl mx-auto">
-        <h1 className="text-5xl font-bold mb-4 text-center">צור קשר</h1>
+        <h1 className="text-5xl font-bold mb-4 text-center">Get in touch</h1>
         <p className="text-xl text-muted-foreground text-center mb-16">
-          נשמח לשמוע ממך! מלא את הטופס ונחזור אליך בהקדם
+          We'd love to hear from you. Drop us a note and we'll get back to you.
         </p>
 
         <div className="grid md:grid-cols-2 gap-12">
           <div>
             <Card className="border-2">
               <CardHeader>
-                <CardTitle className="text-2xl">שלח לנו הודעה</CardTitle>
+                <CardTitle className="text-2xl">Send us a message</CardTitle>
               </CardHeader>
               <CardContent>
                 <form onSubmit={handleSubmit} className="space-y-4">
                   <div>
                     <label htmlFor="name" className="block text-sm font-medium mb-2">
-                      שם מלא *
+                      Full name *
                     </label>
                     <Input
                       id="name"
                       name="name"
                       type="text"
-                      placeholder="השם המלא שלך"
+                      placeholder="Your full name"
                       value={formData.name}
                       onChange={handleChange}
                       required={true}
@@ -63,13 +63,13 @@ export default function ContactPage() {
 
                   <div>
                     <label htmlFor="email" className="block text-sm font-medium mb-2">
-                      אימייל *
+                      Email *
                     </label>
                     <Input
                       id="email"
                       name="email"
                       type="email"
-                      placeholder="your@email.com"
+                      placeholder="you@example.com"
                       value={formData.email}
                       onChange={handleChange}
                       required={true}
@@ -79,13 +79,13 @@ export default function ContactPage() {
 
                   <div>
                     <label htmlFor="subject" className="block text-sm font-medium mb-2">
-                      נושא *
+                      Subject *
                     </label>
                     <Input
                       id="subject"
                       name="subject"
                       type="text"
-                      placeholder="נושא הפנייה"
+                      placeholder="What's this about?"
                       value={formData.subject}
                       onChange={handleChange}
                       required={true}
@@ -95,12 +95,12 @@ export default function ContactPage() {
 
                   <div>
                     <label htmlFor="message" className="block text-sm font-medium mb-2">
-                      הודעה *
+                      Message *
                     </label>
                     <textarea
                       id="message"
                       name="message"
-                      placeholder="ספר לנו איך נוכל לעזור..."
+                      placeholder="Tell us how we can help…"
                       value={formData.message}
                       onChange={handleChange}
                       required={true}
@@ -110,7 +110,7 @@ export default function ContactPage() {
                   </div>
 
                   <Button type="submit" size="lg" className="w-full text-lg py-6">
-                    שלח הודעה
+                    Send message
                   </Button>
                 </form>
               </CardContent>
@@ -119,9 +119,9 @@ export default function ContactPage() {
 
           <div className="space-y-8">
             <div>
-              <h2 className="text-3xl font-bold mb-6">פרטי התקשרות</h2>
+              <h2 className="text-3xl font-bold mb-6">Other ways to reach us</h2>
               <p className="text-muted-foreground mb-8">
-                ניתן ליצור קשר איתנו גם באמצעות הערוצים הבאים:
+                Prefer email or another channel? Pick whichever works for you.
               </p>
             </div>
 
@@ -130,7 +130,7 @@ export default function ContactPage() {
                 <div className="flex items-start gap-4">
                   <Mail className="w-6 h-6 text-primary mt-1" />
                   <div>
-                    <h3 className="font-semibold mb-1">אימייל</h3>
+                    <h3 className="font-semibold mb-1">Email</h3>
                     <p className="text-muted-foreground">support@temporhythm.app</p>
                   </div>
                 </div>
@@ -142,7 +142,7 @@ export default function ContactPage() {
                 <div className="flex items-start gap-4">
                   <Phone className="w-6 h-6 text-primary mt-1" />
                   <div>
-                    <h3 className="font-semibold mb-1">טלפון</h3>
+                    <h3 className="font-semibold mb-1">Phone</h3>
                     <p className="text-muted-foreground">support@temporhythm.app</p>
                   </div>
                 </div>
@@ -154,10 +154,8 @@ export default function ContactPage() {
                 <div className="flex items-start gap-4">
                   <MapPin className="w-6 h-6 text-primary mt-1" />
                   <div>
-                    <h3 className="font-semibold mb-1">כתובת</h3>
-                    <p className="text-muted-foreground">
-                      ישראל
-                    </p>
+                    <h3 className="font-semibold mb-1">Location</h3>
+                    <p className="text-muted-foreground">Remote-first, worldwide</p>
                   </div>
                 </div>
               </CardContent>
@@ -165,10 +163,10 @@ export default function ContactPage() {
 
             <Card className="border-2 bg-primary/5">
               <CardContent className="p-6">
-                <h3 className="font-semibold mb-2">זמני תגובה</h3>
+                <h3 className="font-semibold mb-2">Response time</h3>
                 <p className="text-muted-foreground text-sm">
-                  אנו שואפים להגיב לכל פניה תוך 24 שעות בימי עבודה. בסופי שבוע וחגים, זמני התגובה
-                  עשויים להיות ארוכים יותר.
+                  We aim to reply within 24 hours on weekdays. On weekends and holidays response
+                  times may be a bit longer.
                 </p>
               </CardContent>
             </Card>
@@ -177,7 +175,7 @@ export default function ContactPage() {
 
         <div className="mt-12 text-center">
           <Link href="/" className="text-primary hover:underline">
-            ← חזרה לדף הבית
+            ← Back to home
           </Link>
         </div>
       </div>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -58,7 +58,7 @@ export default function RootLayout({
           {/* biome-ignore lint/security/noDangerouslySetInnerHtml: pre-hydration theme script, locally generated, no user input */}
           <Script id="tempo-theme-init" strategy="beforeInteractive" dangerouslySetInnerHTML={{ __html: themeInitScript() }} />
         </head>
-        <body className="antialiased">
+        <body className="antialiased" suppressHydrationWarning>
           <ThemeProvider>
             <Providers>{children}</Providers>
           </ThemeProvider>

--- a/apps/web/app/page1/page.tsx
+++ b/apps/web/app/page1/page.tsx
@@ -1,9 +1,9 @@
-// דף דוגמה 1
+// Example page 1 (scaffold).
 export default function Page1() {
   return (
     <div className="min-h-screen p-8">
       <main className="container mx-auto">
-        <h1 className="font-bold text-4xl">עמוד 1</h1>
+        <h1 className="font-bold text-4xl">Page 1</h1>
       </main>
     </div>
   );

--- a/apps/web/app/page2/page.tsx
+++ b/apps/web/app/page2/page.tsx
@@ -1,12 +1,12 @@
 import PremiumGate from "@/components/payments/PremiumGate";
 
-// דף דוגמה 2
+// Example page 2 (scaffold, gated by PremiumGate).
 export default function Page2() {
   return (
     <PremiumGate>
       <div className="min-h-screen p-8">
         <main className="container mx-auto">
-          <h1 className="font-bold text-4xl">עמוד 2</h1>
+          <h1 className="font-bold text-4xl">Page 2</h1>
         </main>
       </div>
     </PremiumGate>

--- a/apps/web/app/page3/page.tsx
+++ b/apps/web/app/page3/page.tsx
@@ -1,12 +1,12 @@
 import PremiumGate from "@/components/payments/PremiumGate";
 
-// דף דוגמה 3
+// Example page 3 (scaffold, gated by PremiumGate).
 export default function Page3() {
   return (
     <PremiumGate>
       <div className="min-h-screen p-8">
         <main className="container mx-auto">
-          <h1 className="font-bold text-4xl">עמוד 3</h1>
+          <h1 className="font-bold text-4xl">Page 3</h1>
         </main>
       </div>
     </PremiumGate>

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -1,81 +1,81 @@
 import Link from "next/link";
 
-// דף מדיניות פרטיות: מסמך משפטי המסביר כיצד נאסף ומנוהל המידע באתר
+// Privacy Policy page — plain-language summary. Customise as needed.
 export default function PrivacyPage() {
   return (
     <div className="min-h-screen py-20 px-4">
       <div className="max-w-4xl mx-auto">
-        <h1 className="text-5xl font-bold mb-8">מדיניות פרטיות</h1>
+        <h1 className="text-5xl font-bold mb-8">Privacy Policy</h1>
 
         <div className="space-y-6 text-muted-foreground">
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">1. איסוף מידע</h2>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">1. What we collect</h2>
             <p>
-              אנו אוספים מידע אישי שאתם מספקים לנו ביודעין, כגון שם וכתובת דואר אלקטרוני, כאשר אתם
-              נרשמים לשירותים שלנו או יוצרים קשר איתנו.
+              We collect the personal information you share with us — things like your name and
+              email — when you sign up for our services or get in touch.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">2. שימוש במידע</h2>
-            <p>המידע שאנו אוספים משמש אותנו למטרות הבאות:</p>
-            <ul className="list-disc list-inside mr-6 mt-2 space-y-2">
-              <li>מתן ושיפור השירותים שלנו</li>
-              <li>שליחת עדכונים ומידע רלוונטי</li>
-              <li>מענה לפניות שירות לקוחות</li>
-              <li>שיפור חווית המשתמש באתר</li>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">2. How we use it</h2>
+            <p>We use the information to:</p>
+            <ul className="list-disc list-inside ml-6 mt-2 space-y-2">
+              <li>Provide and improve our services</li>
+              <li>Send updates and relevant information</li>
+              <li>Respond to support requests</li>
+              <li>Make your experience with the product smoother</li>
             </ul>
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">3. אבטחת מידע</h2>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">3. Security</h2>
             <p>
-              אנו מיישמים אמצעי אבטחה טכניים וארגוניים מתקדמים כדי להגן על המידע האישי שלכם מפני
-              גישה, שימוש או גילוי בלתי מורשים.
+              We apply modern technical and organisational safeguards to protect your personal
+              information from unauthorised access, use, or disclosure.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">4. שיתוף מידע</h2>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">4. Sharing</h2>
             <p>
-              אנו לא מוכרים, משכירים או משתפים את המידע האישי שלכם עם צדדים שלישיים למטרות שיווק,
-              אלא אם כן קיבלנו הסכמה מפורשת מכם לכך.
+              We don't sell, rent, or share your personal information with third parties for
+              marketing purposes unless you've explicitly opted in.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">5. קובצי Cookie</h2>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">5. Cookies</h2>
             <p>
-              האתר שלנו משתמש בקובצי Cookie כדי לשפר את חווית המשתמש ולנתח את השימוש באתר. אתם
-              יכולים לבחור לדחות קובצי Cookie דרך הגדרות הדפדפן שלכם.
+              Our site uses cookies to improve your experience and understand how the site is used.
+              You can block cookies in your browser settings at any time.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">6. זכויותיכם</h2>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">6. Your rights</h2>
             <p>
-              יש לכם זכות לגשת למידע האישי שלכם, לבקש תיקון או מחיקה שלו, ולבטל את הסכמתכם לשימוש
-              במידע בכל עת.
+              You can request access to your personal information, ask us to correct or delete it,
+              or withdraw consent to its use at any time.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">7. שינויים במדיניות</h2>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">7. Changes to this policy</h2>
             <p>
-              אנו שומרים לעצמנו את הזכות לעדכן את מדיניות הפרטיות מעת לעת. שינויים משמעותיים יפורסמו
-              באתר ויכללו תאריך עדכון.
+              We may update this policy from time to time. Significant changes will be posted on the
+              site with an updated date.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">8. יצירת קשר</h2>
-            <p>לשאלות או בקשות הנוגעות לפרטיות שלכם, אנא צרו קשר: support@temporhythm.app</p>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">8. Contact</h2>
+            <p>Questions about privacy? Reach us at support@temporhythm.app.</p>
           </section>
         </div>
 
         <div className="mt-12">
           <Link href="/" className="text-primary hover:underline">
-            ← חזרה לדף הבית
+            ← Back to home
           </Link>
         </div>
       </div>

--- a/apps/web/app/sign-in/page.tsx
+++ b/apps/web/app/sign-in/page.tsx
@@ -11,7 +11,7 @@ export default function SignInPage() {
 
   useEffect(() => {
     if (!isLoading && isAuthenticated) {
-      router.replace("/dashboard");
+      router.replace("/today");
     }
   }, [isAuthenticated, isLoading, router]);
 

--- a/apps/web/app/sign-up/page.tsx
+++ b/apps/web/app/sign-up/page.tsx
@@ -11,7 +11,7 @@ export default function SignUpPage() {
 
   useEffect(() => {
     if (!isLoading && isAuthenticated) {
-      router.replace("/dashboard");
+      router.replace("/today");
     }
   }, [isAuthenticated, isLoading, router]);
 

--- a/apps/web/app/success/page.tsx
+++ b/apps/web/app/success/page.tsx
@@ -1,13 +1,13 @@
 // ============================================================================
-// דף הצלחה לאחר Checkout
+// Post-checkout success page
 // ============================================================================
-// Polar מפנה לכאן לאחר תשלום מוצלח (לפי POLAR_SUCCESS_URL).
+// Polar redirects here after a successful purchase (POLAR_SUCCESS_URL).
 //
-// כרגע הדף מציג אישור בסיסי בלבד.
-// כדי להפוך את זה ל"מערכת תשלומים מלאה", יש להוסיף:
-// - Webhook מ-Polar
-// - אימות התשלום בצד שרת
-// - עדכון userType ל-'paid' ב-Convex
+// Right now this page shows a basic confirmation. To make it a full payment
+// system you'd want to add:
+// - A webhook from Polar
+// - Server-side payment verification
+// - A Convex mutation bumping userType to 'paid'
 
 type SuccessPageProps = {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -20,17 +20,17 @@ export default async function SuccessPage({ searchParams }: SuccessPageProps) {
 
   return (
     <div className="min-h-screen p-8">
-      <main className="container mx-auto" dir="rtl">
-        <h1 className="mb-4 font-bold text-4xl">התשלום התקבל בהצלחה</h1>
+      <main className="container mx-auto">
+        <h1 className="mb-4 font-bold text-4xl">Payment received</h1>
         <p className="text-lg text-foreground/80 leading-relaxed">
-          תודה! אם תרצו, ניתן להשתמש ב-Checkout ID כדי לאמת את הרכישה מול Polar ולעדכן את סטטוס
-          המשתמש.
+          Thanks! You can use the Checkout ID below to verify the purchase with Polar and sync the
+          user's subscription status.
         </p>
 
         <div className="mt-6 rounded-xl border border-orange-500/30 bg-orange-500/5 p-4">
           <div className="text-sm text-gray-500">Checkout ID</div>
           <div className="mt-1 font-mono text-sm text-gray-200 break-all">
-            {checkoutId || "(לא התקבל Checkout ID)"}
+            {checkoutId || "(no Checkout ID received)"}
           </div>
         </div>
       </main>

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -1,62 +1,63 @@
 import Link from "next/link";
 
-// דף תנאי שימוש: הסכם משפטי בין בעל האתר למשתמשים
+// Terms of Use page — a plain-language summary. Customise as needed.
 export default function TermsPage() {
   return (
     <div className="min-h-screen py-20 px-4">
       <div className="max-w-4xl mx-auto">
-        <h1 className="text-5xl font-bold mb-8">תנאי שימוש</h1>
+        <h1 className="text-5xl font-bold mb-8">Terms of Use</h1>
 
         <div className="space-y-6 text-muted-foreground">
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">1. קבלת התנאים</h2>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">1. Accepting these terms</h2>
             <p>
-              על ידי גישה לאתר זה ושימוש בו, אתם מסכימים לכל התנאים וההגבלות המפורטים כאן. אם אינכם
-              מסכימים לתנאים אלה, אנא הימנעו משימוש באתר.
+              By accessing and using this site you agree to everything laid out here. If any of it
+              doesn't sit right, please don't use the site.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">2. שימוש באתר</h2>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">2. Using the site</h2>
             <p>
-              השימוש באתר מותר למטרות חוקיות בלבד. אתם מתחייבים שלא לעשות שימוש באתר בכל דרך שעלולה
-              לפגוע בתפקודו, או לגרום נזק לאתר או לצדדים שלישיים.
+              The site is for lawful use only. You agree not to use it in any way that harms its
+              operation or causes damage to us or to third parties.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">3. קניין רוחני</h2>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">3. Intellectual property</h2>
             <p>
-              כל התכנים באתר זה, לרבות טקסטים, גרפיקה, לוגואים ותמונות, הינם רכושנו או רכוש ספקי
-              התוכן שלנו ומוגנים על פי חוקי זכויות היוצרים.
+              All content on this site — text, graphics, logos, images — belongs to us or to our
+              content providers and is protected under applicable copyright law.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">4. הגבלת אחריות</h2>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">4. Liability</h2>
             <p>
-              השירותים והמידע באתר מסופקים &quot;כמות שהם&quot;. איננו מתחייבים לדיוק, שלמות או
-              התאמה למטרה מסוימת של המידע המוצג באתר.
+              Services and information on this site are provided &quot;as is&quot;. We do not
+              guarantee accuracy, completeness, or fitness for a particular purpose.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">5. שינויים בתנאים</h2>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">5. Changes to these terms</h2>
             <p>
-              אנו שומרים לעצמנו את הזכות לשנות את תנאי השימוש בכל עת. השינויים ייכנסו לתוקף מיד עם
-              פרסומם באתר.
+              We may update these terms over time. Updates take effect as soon as they are posted.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold text-foreground mb-4">6. יצירת קשר</h2>
-            <p>לשאלות או הבהרות בנוגע לתנאי השימוש, ניתן ליצור קשר בכתובת: support@temporhythm.app</p>
+            <h2 className="text-2xl font-semibold text-foreground mb-4">6. Contact</h2>
+            <p>
+              Questions about these terms? Reach us at support@temporhythm.app.
+            </p>
           </section>
         </div>
 
         <div className="mt-12">
           <Link href="/" className="text-primary hover:underline">
-            ← חזרה לדף הבית
+            ← Back to home
           </Link>
         </div>
       </div>

--- a/apps/web/biome.json
+++ b/apps/web/biome.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
-  "vcs": {
-    "enabled": true,
-    "clientKind": "git",
-    "useIgnoreFile": true
-  },
+  "extends": ["../../packages/config/biome.json"],
   "files": {
     "ignoreUnknown": false,
     "includes": [
@@ -18,105 +14,10 @@
       "!**/convex/_generated"
     ]
   },
-  "formatter": {
-    "enabled": true,
-    "indentStyle": "space",
-    "indentWidth": 2,
-    "lineWidth": 100
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true,
-      "performance": {
-        "noAccumulatingSpread": "error"
-      },
-      "style": {
-        "useConst": "warn",
-        "noNonNullAssertion": "off",
-        "useBlockStatements": "off",
-        "noImplicitBoolean": "off"
-      },
-      "suspicious": {
-        "noAsyncPromiseExecutor": "error",
-        "noCatchAssign": "error",
-        "noDoubleEquals": "error",
-        "noDuplicateObjectKeys": "error",
-        "noMisleadingCharacterClass": "error",
-        "noPrototypeBuiltins": "error",
-        "noRedeclare": "error",
-        "noSelfCompare": "error",
-        "noUnsafeNegation": "error",
-        "noConsole": "warn",
-        "noArrayIndexKey": "off",
-        "noUnknownAtRules": "off",
-        "noExplicitAny": "off"
-      },
-      "correctness": {
-        "noConstAssign": "error",
-        "noConstantCondition": "error",
-        "noEmptyCharacterClassInRegex": "error",
-        "noEmptyPattern": "error",
-        "noInnerDeclarations": "error",
-        "noInvalidConstructorSuper": "error",
-        "noInvalidUseBeforeDeclaration": "error",
-        "noPrecisionLoss": "error",
-        "noSelfAssign": "error",
-        "noSetterReturn": "error",
-        "noUndeclaredVariables": "error",
-        "noUnreachable": "error",
-        "noUnsafeFinally": "error",
-        "useIsNan": "error",
-        "useValidForDirection": "error",
-        "useUniqueElementIds": "off"
-      },
-      "a11y": {
-        "noSvgWithoutTitle": "off"
-      },
-      "complexity": {
-        "noForEach": "off"
-      }
-    }
-  },
-  "javascript": {
-    "formatter": {
-      "quoteStyle": "double",
-      "jsxQuoteStyle": "double",
-      "trailingCommas": "es5",
-      "semicolons": "always",
-      "arrowParentheses": "always"
-    }
-  },
-  "json": {
-    "formatter": {
-      "indentStyle": "space",
-      "indentWidth": 2
-    }
-  },
   "css": {
     "parser": {
       "cssModules": true,
       "tailwindDirectives": true
-    }
-  },
-  "overrides": [
-    {
-      "includes": ["*.tsx", "*.ts", "*.jsx", "*.js"],
-      "linter": {
-        "rules": {
-          "correctness": {
-            "useExhaustiveDependencies": "warn"
-          }
-        }
-      }
-    }
-  ],
-  "assist": {
-    "enabled": true,
-    "actions": {
-      "source": {
-        "organizeImports": "on"
-      }
     }
   }
 }

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
 
 // ============================================================================
-// רכיב Footer (כותרת תחתונה)
+// Footer component
 // ============================================================================
-// מציג קישורים משפטיים, פרטי קשר וזכויות יוצרים
+// Shows legal links, contact info, and copyright.
 
 export default function Footer() {
   return (
@@ -11,20 +11,21 @@ export default function Footer() {
       <div className="max-w-6xl mx-auto">
         <div className="grid md:grid-cols-3 gap-8 mb-8">
           <div>
-            <h3 className="font-bold text-lg mb-4">אודות</h3>
+            <h3 className="font-bold text-lg mb-4">About</h3>
             <p className="text-sm text-muted-foreground">
-              פתרון מוביל להשגת תוצאות מדהימות בזמן קצר. מאמינים בפשטות, יעילות ותוצאות מוכחות.
+              An overwhelm-first daily planner for ADHD, autistic, and neurodivergent brains.
+              Built on calm, concrete next steps — not shame.
             </p>
           </div>
           <div>
-            <h3 className="font-bold text-lg mb-4">קישורים מהירים</h3>
+            <h3 className="font-bold text-lg mb-4">Quick links</h3>
             <ul className="space-y-2 text-sm">
               <li>
                 <Link
                   href="/terms"
                   className="text-muted-foreground hover:text-foreground transition-colors"
                 >
-                  תנאי שימוש
+                  Terms of use
                 </Link>
               </li>
               <li>
@@ -32,7 +33,7 @@ export default function Footer() {
                   href="/privacy"
                   className="text-muted-foreground hover:text-foreground transition-colors"
                 >
-                  מדיניות פרטיות
+                  Privacy policy
                 </Link>
               </li>
               <li>
@@ -40,20 +41,18 @@ export default function Footer() {
                   href="/contact"
                   className="text-muted-foreground hover:text-foreground transition-colors"
                 >
-                  צור קשר
+                  Contact
                 </Link>
               </li>
             </ul>
           </div>
           <div>
-            <h3 className="font-bold text-lg mb-4">יצירת קשר</h3>
-            <p className="text-sm text-muted-foreground">
-              support@temporhythm.app
-            </p>
+            <h3 className="font-bold text-lg mb-4">Get in touch</h3>
+            <p className="text-sm text-muted-foreground">support@temporhythm.app</p>
           </div>
         </div>
         <div className="pt-8 border-t text-center text-sm text-muted-foreground">
-          <p>© 2026 Tempo Rhythm. כל הזכויות שמורות.</p>
+          <p>© 2026 Tempo Rhythm. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/apps/web/components/Navbar.tsx
+++ b/apps/web/components/Navbar.tsx
@@ -21,28 +21,27 @@ import {
 import { api } from "@/convex/_generated/api";
 
 export default function Navbar() {
-  const { isAuthenticated, isLoading } = useConvexAuth(); // סטטוס אימות
-  const { signOut } = useAuthActions(); // פעולת התנתקות
-  const user = useQuery(api.users.getCurrentUser); // פרטי המשתמש המחובר
-  const [isOpen, setIsOpen] = useState(false); // מצב תפריט המשתמש (Dropdown)
-  const [showSignInModal, setShowSignInModal] = useState(false); // הצגת מודל התחברות
-  const [showSignUpModal, setShowSignUpModal] = useState(false); // הצגת מודל הרשמה
-  const [showPaywallModal, setShowPaywallModal] = useState(false); // הצגת מודל Paywall (Preview)
-  const [isDebugOpen, setIsDebugOpen] = useState(false); // מצב קונסולת דיבאג
-  const [showLogoutDialog, setShowLogoutDialog] = useState(false); // דיאלוג התנתקות/מחיקה
-  const [logoutStep, setLogoutStep] = useState<"main" | "deleteConfirm">("main"); // שלבי הדיאלוג
-  const [isDeleteLoading, setIsDeleteLoading] = useState(false); // מצב טעינה למחיקה
-  const dropdownRef = useRef<HTMLDivElement>(null); // Ref לזיהוי קליקים מחוץ לתפריט
-  const debugRef = useRef<HTMLDivElement>(null); // Ref לזיהוי קליקים מחוץ לקונסולה
+  const { isAuthenticated, isLoading } = useConvexAuth(); // Auth status
+  const { signOut } = useAuthActions(); // Sign-out action
+  const user = useQuery(api.users.getCurrentUser); // Current-user details
+  const [isOpen, setIsOpen] = useState(false); // User menu open state
+  const [showSignInModal, setShowSignInModal] = useState(false); // Sign-in modal
+  const [showSignUpModal, setShowSignUpModal] = useState(false); // Sign-up modal
+  const [showPaywallModal, setShowPaywallModal] = useState(false); // Paywall preview modal
+  const [isDebugOpen, setIsDebugOpen] = useState(false); // Debug console
+  const [showLogoutDialog, setShowLogoutDialog] = useState(false); // Sign-out / delete dialog
+  const [logoutStep, setLogoutStep] = useState<"main" | "deleteConfirm">("main");
+  const [isDeleteLoading, setIsDeleteLoading] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const debugRef = useRef<HTMLDivElement>(null);
 
-  // סגירת התפריט בעת לחיצה מחוץ לו
+  // Close the menus when clicking outside them.
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false);
       }
 
-      // סגירת קונסולת דיבאג בעת לחיצה מחוץ לה
       if (debugRef.current && !debugRef.current.contains(event.target as Node)) {
         setIsDebugOpen(false);
       }
@@ -52,42 +51,38 @@ export default function Navbar() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  const displayName = user?.fullName || user?.email?.split("@")[0] || "משתמש";
-  const updateUserType = useMutation(api.users.updateUserType); // שינוי סטטוס משתמש (למצב בדיקה)
-  const deleteMyAccount = useMutation(api.users.deleteMyAccount); // מחיקת חשבון (Convex)
+  const displayName = user?.fullName || user?.email?.split("@")[0] || "friend";
+  const updateUserType = useMutation(api.users.updateUserType);
+  const deleteMyAccount = useMutation(api.users.deleteMyAccount);
 
-  // פתיחת דיאלוג התנתקות (במקום התנתקות מיידית)
   const openLogoutDialog = () => {
     setIsOpen(false);
     setLogoutStep("main");
     setShowLogoutDialog(true);
   };
 
-  // ביצוע התנתקות
   const confirmSignOut = async () => {
     await signOut();
     setShowLogoutDialog(false);
   };
 
-  // מעבר למסך אישור מחיקה
   const goToDeleteConfirm = () => {
-    setIsOpen(false); // סגירת ה-dropdown
+    setIsOpen(false);
     setLogoutStep("deleteConfirm");
-    setShowLogoutDialog(true); // פתיחת הדיאלוג עם שלב המחיקה
+    setShowLogoutDialog(true);
   };
 
-  // ביצוע מחיקת חשבון (2 שלבים — זהו השלב הסופי)
+  // Two-step account deletion — this is the final confirm step.
   const confirmDeleteAccount = async () => {
     setIsDeleteLoading(true);
     try {
       await deleteMyAccount();
-      // התנתקות אוטומטית לאחר מחיקת החשבון
+      // Sign out automatically after the account is deleted.
       await signOut();
       setShowLogoutDialog(false);
-      // הערה: בדפדפן, ההתנתקות תפנה את המשתמש אוטומטית, אז לא צריך הודעת הצלחה נפרדת
     } catch (_error) {
-      // במקרה של שגיאה, נשארים בדיאלוג כדי שהמשתמש יוכל לנסות שוב
-      // ניתן להוסיף כאן toast notification או הודעת שגיאה ב-UI
+      // On failure we stay in the dialog so the user can retry.
+      // TODO: surface a toast or inline error message.
     } finally {
       setIsDeleteLoading(false);
     }
@@ -97,25 +92,24 @@ export default function Navbar() {
     <nav className="border-b border-border sticky top-0 z-50 backdrop-blur-sm bg-background/95">
       <div className="container mx-auto px-6 py-4">
         <div className="flex justify-between items-center">
-          {/* קישורי ניווט - צד ימין (RTL) */}
           <div className="flex max-w-[70vw] flex-wrap items-center gap-x-4 gap-y-2 sm:max-w-none sm:gap-x-6">
             <Link
               href="/"
               className="text-2xl hover:scale-110 transition-transform"
-              aria-label="דף הבית"
+              aria-label="Home"
             >
               <Home className="w-6 h-6 text-foreground" />
             </Link>
             {[
-              { href: "/dashboard", label: "לוח בית" },
-              { href: "/tasks", label: "משימות" },
-              { href: "/notes", label: "פתקים" },
-              { href: "/calendar", label: "יומן" },
-              { href: "/coach", label: "מאמן" },
-              { href: "/habits", label: "הרגלים" },
-              { href: "/goals", label: "מטרות" },
-              { href: "/settings", label: "הגדרות" },
-              { href: "/analytics", label: "נתונים" },
+              { href: "/today", label: "Today" },
+              { href: "/tasks", label: "Tasks" },
+              { href: "/notes", label: "Notes" },
+              { href: "/calendar", label: "Calendar" },
+              { href: "/coach", label: "Coach" },
+              { href: "/habits", label: "Habits" },
+              { href: "/goals", label: "Goals" },
+              { href: "/settings/profile", label: "Settings" },
+              { href: "/insights", label: "Insights" },
             ].map(({ href, label }) => (
               <Link
                 key={href}
@@ -127,81 +121,81 @@ export default function Navbar() {
             ))}
           </div>
 
-          {/* פרופיל משתמש או כפתור התחברות - צד שמאל (RTL) */}
-          <div className="mr-auto flex items-center gap-3">
-            {/* כפתור דיבאג (Dev בלבד) - אייקון באג בצד שמאל למעלה */}
+          <div className="ml-auto flex items-center gap-3">
             {IS_DEV_MODE && (
               <div className="relative" ref={debugRef}>
                 <Button
                   variant="ghost"
                   onClick={() => setIsDebugOpen((v) => !v)}
                   className="h-10 w-10 rounded-lg bg-yellow-500/20 border border-yellow-500/50 hover:bg-yellow-500/30 hover:border-yellow-500/70"
-                  aria-label="קונסולת דיבאג"
+                  aria-label="Debug console"
                 >
                   <Bug className="h-5 w-5 text-yellow-400" />
                 </Button>
 
-                {/* קונסולת דיבאג - popup שנפתח כלפי מטה */}
                 <div
                   className={[
-                    "absolute left-0 mt-2 w-80 overflow-hidden rounded-xl border border-orange-500/30 bg-gray-900/95 shadow-xl backdrop-blur-sm transition-all",
+                    "absolute right-0 mt-2 w-80 overflow-hidden rounded-xl border border-orange-500/30 bg-gray-900/95 shadow-xl backdrop-blur-sm transition-all",
                     isDebugOpen ? "max-h-[480px] opacity-100" : "max-h-0 opacity-0",
                   ].join(" ")}
                 >
-                  <div className="p-4" dir="rtl">
+                  <div className="p-4">
                     <div className="mb-3 flex items-center justify-between">
-                      <div className="text-sm font-bold text-white">קונסולת דיבאג</div>
+                      <div className="text-sm font-bold text-white">Debug console</div>
                       <div className="text-xs text-gray-400">{APP_ENV}</div>
                     </div>
 
-                    {/* שורות מצב */}
                     <div className="mb-4 space-y-1 text-xs text-gray-300">
-                      <DebugRow label="Paywall פעיל" value={PAYWALL_ENABLED ? "כן" : "לא"} />
+                      <DebugRow label="Paywall enabled" value={PAYWALL_ENABLED ? "yes" : "no"} />
                       <DebugRow
-                        label="תשלומים פעילים"
-                        value={PAYMENT_SYSTEM_ENABLED ? "כן" : "לא"}
+                        label="Payments enabled"
+                        value={PAYMENT_SYSTEM_ENABLED ? "yes" : "no"}
                       />
-                      <DebugRow label="Mock Payments" value={MOCK_PAYMENTS ? "כן" : "לא"} />
+                      <DebugRow label="Mock payments" value={MOCK_PAYMENTS ? "yes" : "no"} />
                       <DebugRow
-                        label="סטטוס משתמש"
-                        value={user ? (user.userType === "paid" ? "פרימיום" : "חינמי") : "לא מחובר"}
+                        label="User status"
+                        value={
+                          user
+                            ? user.userType === "paid"
+                              ? "premium"
+                              : "free"
+                            : "signed out"
+                        }
                       />
                     </div>
 
-                    {/* כפתורי Preview */}
                     <div className="space-y-2">
                       <button
                         type="button"
                         onClick={() => setShowSignInModal(true)}
-                        className="w-full rounded-lg border border-gray-700 bg-gray-800/60 px-3 py-2 text-right text-sm text-white transition hover:border-orange-500/40"
+                        className="w-full rounded-lg border border-gray-700 bg-gray-800/60 px-3 py-2 text-left text-sm text-white transition hover:border-orange-500/40"
                       >
-                        פתח מודל התחברות (Preview)
+                        Open sign-in modal (preview)
                       </button>
                       <button
                         type="button"
                         onClick={() => setShowSignUpModal(true)}
-                        className="w-full rounded-lg border border-gray-700 bg-gray-800/60 px-3 py-2 text-right text-sm text-white transition hover:border-orange-500/40"
+                        className="w-full rounded-lg border border-gray-700 bg-gray-800/60 px-3 py-2 text-left text-sm text-white transition hover:border-orange-500/40"
                       >
-                        פתח מודל הרשמה (Preview)
+                        Open sign-up modal (preview)
                       </button>
                       <button
                         type="button"
                         onClick={() => setShowPaywallModal(true)}
-                        className="w-full rounded-lg border border-gray-700 bg-gray-800/60 px-3 py-2 text-right text-sm text-white transition hover:border-orange-500/40"
+                        className="w-full rounded-lg border border-gray-700 bg-gray-800/60 px-3 py-2 text-left text-sm text-white transition hover:border-orange-500/40"
                       >
-                        פתח Paywall (Preview)
+                        Open paywall (preview)
                       </button>
 
-                      {/* כפתור בדיקה: סימון המשתמש כ-paid (רק אם MOCK_PAYMENTS) */}
                       {MOCK_PAYMENTS && (
                         <button
                           type="button"
                           onClick={async () => {
                             await updateUserType({ userType: "paid" });
                           }}
-                          className="w-full rounded-lg border border-orange-500/40 bg-orange-500/10 px-3 py-2 text-right text-sm text-orange-100 transition hover:bg-orange-500/15"
+                          className="w-full rounded-lg border border-orange-500/40 bg-orange-500/10 px-3 py-2 text-left text-sm text-orange-100 transition hover:bg-orange-500/15"
                         >
-                          מצב בדיקה: שדרג אותי לפרימיום
+                          Dev test: upgrade me to premium
                         </button>
                       )}
                     </div>
@@ -222,12 +216,13 @@ export default function Navbar() {
                   <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center">
                     <User className="w-4 h-4 text-primary-foreground" />
                   </div>
-                  <span className="text-sm font-medium text-foreground">שלום, {displayName}</span>
+                  <span className="text-sm font-medium text-foreground">
+                    Hi, {displayName}
+                  </span>
                 </Button>
 
-                {/* תפריט נפתח (Dropdown) */}
                 {isOpen && (
-                  <Card className="absolute left-0 mt-2 w-72 shadow-lg border-border z-50">
+                  <Card className="absolute right-0 mt-2 w-72 shadow-lg border-border z-50">
                     <CardContent className="p-0">
                       <div className="px-4 py-4 border-b border-border bg-muted/50">
                         <p className="text-sm font-semibold text-foreground mb-1">{displayName}</p>
@@ -238,19 +233,19 @@ export default function Navbar() {
                         <Button
                           variant="ghost"
                           onClick={openLogoutDialog}
-                          className="w-full justify-start px-3 py-2 text-right hover:bg-destructive/10 text-destructive rounded-md"
+                          className="w-full justify-start px-3 py-2 text-left hover:bg-destructive/10 text-destructive rounded-md"
                         >
-                          <LogOut className="w-4 h-4 ml-2" />
-                          <span className="text-sm font-medium">התנתק</span>
+                          <LogOut className="w-4 h-4 mr-2" />
+                          <span className="text-sm font-medium">Sign out</span>
                         </Button>
 
                         <Button
                           variant="ghost"
                           onClick={goToDeleteConfirm}
-                          className="w-full justify-start px-3 py-2 text-right hover:bg-red-950/20 text-red-500 rounded-md border border-red-900/30"
+                          className="w-full justify-start px-3 py-2 text-left hover:bg-red-950/20 text-red-500 rounded-md border border-red-900/30"
                         >
-                          <Trash2 className="w-4 h-4 ml-2" />
-                          <span className="text-sm font-medium">מחק חשבון</span>
+                          <Trash2 className="w-4 h-4 mr-2" />
+                          <span className="text-sm font-medium">Delete account</span>
                         </Button>
                       </div>
                     </CardContent>
@@ -262,31 +257,27 @@ export default function Navbar() {
                 onClick={() => setShowSignInModal(true)}
                 className="bg-linear-to-r from-orange-500 to-red-600 hover:from-orange-600 hover:to-red-700 text-white font-medium px-6 py-2 rounded-lg shadow-md transition-all"
               >
-                התחברות
+                Sign in
               </Button>
             )}
           </div>
         </div>
       </div>
 
-      {/* מודל התחברות */}
       <SignInModal
         open={showSignInModal}
         onOpenChange={setShowSignInModal}
         onSwitchToSignUp={() => setShowSignUpModal(true)}
       />
 
-      {/* מודל הרשמה */}
       <SignUpModal
         open={showSignUpModal}
         onOpenChange={setShowSignUpModal}
         onSwitchToSignIn={() => setShowSignInModal(true)}
       />
 
-      {/* מודל Paywall (Preview לדיבאג) */}
       <PaywallModal open={showPaywallModal} onOpenChange={setShowPaywallModal} preview={true} />
 
-      {/* דיאלוג התנתקות + מחיקת חשבון */}
       <Dialog
         open={showLogoutDialog}
         onOpenChange={(open) => {
@@ -297,20 +288,20 @@ export default function Navbar() {
         }}
       >
         <DialogContent className="sm:max-w-lg bg-linear-to-br from-gray-900 via-gray-800 to-black border-gray-700 p-0">
-          <div className="rounded-2xl bg-gray-800/50 backdrop-blur-sm p-8" dir="rtl">
+          <div className="rounded-2xl bg-gray-800/50 backdrop-blur-sm p-8">
             {logoutStep === "main" ? (
               <>
                 <DialogHeader className="mb-6">
                   <DialogTitle className="text-2xl font-bold text-white text-center">
-                    התנתקות מהחשבון
+                    Sign out of your account
                   </DialogTitle>
                   <p className="text-gray-400 text-center mt-2">
-                    האם אתה בטוח שברצונך להתנתק? ניתן גם למחוק את החשבון לצמיתות.
+                    Ready to sign out? You can also delete your account permanently.
                   </p>
                 </DialogHeader>
 
-                <div className="mb-6 rounded-xl border border-gray-700 bg-gray-900/40 p-4 text-right">
-                  <div className="text-sm text-gray-400">מחובר בתור</div>
+                <div className="mb-6 rounded-xl border border-gray-700 bg-gray-900/40 p-4 text-left">
+                  <div className="text-sm text-gray-400">Signed in as</div>
                   <div className="mt-1 text-base font-semibold text-white">{displayName}</div>
                   <div className="mt-1 text-xs text-gray-500 truncate">{user?.email || ""}</div>
                 </div>
@@ -321,7 +312,7 @@ export default function Navbar() {
                     onClick={confirmSignOut}
                     className="w-full rounded-xl bg-linear-to-r from-orange-500 to-red-600 px-6 py-3 font-bold text-white shadow-md transition-all hover:from-orange-600 hover:to-red-700 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 focus:ring-offset-gray-800"
                   >
-                    התנתק
+                    Sign out
                   </button>
 
                   <button
@@ -329,7 +320,7 @@ export default function Navbar() {
                     onClick={goToDeleteConfirm}
                     className="w-full rounded-xl border-2 border-red-900 bg-red-950/30 px-6 py-3 font-bold text-red-200 transition hover:bg-red-950/40"
                   >
-                    מחיקת חשבון
+                    Delete account
                   </button>
 
                   <button
@@ -337,7 +328,7 @@ export default function Navbar() {
                     onClick={() => setShowLogoutDialog(false)}
                     className="w-full rounded-xl border border-gray-700 bg-gray-900/40 px-6 py-3 font-semibold text-gray-200 transition hover:border-orange-500/30"
                   >
-                    ביטול
+                    Cancel
                   </button>
                 </div>
               </>
@@ -345,12 +336,11 @@ export default function Navbar() {
               <>
                 <DialogHeader className="mb-6">
                   <DialogTitle className="text-2xl font-bold text-white text-center">
-                    אישור סופי למחיקת חשבון
+                    Confirm account deletion
                   </DialogTitle>
                   <p className="text-gray-300 text-center mt-2 leading-relaxed">
-                    פעולה זו תמחק לצמיתות את החשבון שלך ואת הנתונים המשויכים אליו.
-                    <br />
-                    לא ניתן לשחזר את הנתונים לאחר המחיקה.
+                    This moves your account to Recently deleted — you can restore it within 30
+                    days. After that it is permanently removed.
                   </p>
                 </DialogHeader>
 
@@ -361,7 +351,7 @@ export default function Navbar() {
                     disabled={isDeleteLoading}
                     className="w-full rounded-xl bg-red-600 px-6 py-3 font-bold text-white transition hover:bg-red-700 disabled:opacity-60"
                   >
-                    {isDeleteLoading ? "מוחק חשבון..." : "כן, מחק את החשבון"}
+                    {isDeleteLoading ? "Deleting account…" : "Yes, delete my account"}
                   </button>
 
                   <button
@@ -369,7 +359,7 @@ export default function Navbar() {
                     onClick={() => setLogoutStep("main")}
                     className="w-full rounded-xl border border-gray-700 bg-gray-900/40 px-6 py-3 font-semibold text-gray-200 transition hover:border-orange-500/30"
                   >
-                    חזור
+                    Back
                   </button>
                 </div>
               </>
@@ -381,12 +371,12 @@ export default function Navbar() {
   );
 }
 
-// שורת דיבאג קצרה להצגת ערך/תווית
+// Small label/value row for the debug console.
 function DebugRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-center justify-between">
-      <div className="text-gray-200">{value}</div>
       <div className="text-gray-500">{label}</div>
+      <div className="text-gray-200">{value}</div>
     </div>
   );
 }

--- a/apps/web/components/SignInModal.tsx
+++ b/apps/web/components/SignInModal.tsx
@@ -14,17 +14,17 @@ interface SignInModalProps {
   onSwitchToSignUp?: () => void;
 }
 
-// קומפוננטת מודל התחברות
+// Sign-in modal component.
 export default function SignInModal({ open, onOpenChange, onSwitchToSignUp }: SignInModalProps) {
-  const { signIn } = useAuthActions(); // פעולת התחברות
+  const { signIn } = useAuthActions();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const [rememberMe, setRememberMe] = useState(false); // זכור אותי
-  const [showPassword, setShowPassword] = useState(false); // הצגת סיסמה
+  const [rememberMe, setRememberMe] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
-  // טעינת אימייל שמור בעת טעינת הקומפוננטה
+  // Restore remembered email on mount.
   useEffect(() => {
     const rememberedEmail = localStorage.getItem(REMEMBERED_EMAIL_KEY);
     if (rememberedEmail) {
@@ -40,33 +40,31 @@ export default function SignInModal({ open, onOpenChange, onSwitchToSignUp }: Si
     setError("");
 
     try {
-      // ביצוע התחברות
       await signIn("password", { email, password, flow: "signIn" });
 
-      // שמירה או מחיקה של האימייל מה-LocalStorage
       if (rememberMe) {
         localStorage.setItem(REMEMBERED_EMAIL_KEY, email);
       } else {
         localStorage.removeItem(REMEMBERED_EMAIL_KEY);
       }
 
-      onOpenChange(false); // סגירת המודל
+      onOpenChange(false);
     } catch (err: unknown) {
       const error = err as { message?: string };
       const errorMessage = error.message || "";
 
-      // מיפוי שגיאות Convex Auth להודעות בעברית
+      // Map Convex Auth errors to friendly copy.
       if (errorMessage.includes("InvalidSecret")) {
-        setError("הסיסמה שהוזנה שגויה");
+        setError("That password doesn't match. Try again?");
       } else if (
         errorMessage.includes("InvalidAccountId") ||
         errorMessage.includes("Could not find")
       ) {
-        setError("לא נמצא חשבון עם כתובת הדואר האלקטרוני הזו");
+        setError("We couldn't find an account with that email.");
       } else if (errorMessage.includes("TooManyRequests")) {
-        setError("יותר מדי ניסיונות התחברות. אנא נסו שוב מאוחר יותר");
+        setError("Too many attempts. Give it a minute and try again.");
       } else {
-        setError("התחברות נכשלה. אנא בדקו את הפרטים ונסו שוב");
+        setError("Couldn't sign in. Double-check your details and try again.");
       }
     } finally {
       setIsLoading(false);
@@ -76,16 +74,16 @@ export default function SignInModal({ open, onOpenChange, onSwitchToSignUp }: Si
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md bg-linear-to-br from-gray-900 via-gray-800 to-black border-gray-700 p-0">
-        <div className="rounded-2xl bg-gray-800/50 backdrop-blur-sm p-8" dir="rtl">
+        <div className="rounded-2xl bg-gray-800/50 backdrop-blur-sm p-8">
           <DialogHeader className="mb-6">
-            <DialogTitle className="text-3xl font-bold text-white text-center">התחברות</DialogTitle>
-            <p className="text-gray-400 text-center mt-2">ברוכים השבים! אנא התחברו לחשבונכם</p>
+            <DialogTitle className="text-3xl font-bold text-white text-center">Sign in</DialogTitle>
+            <p className="text-gray-400 text-center mt-2">Welcome back — let's pick up where you left off.</p>
           </DialogHeader>
 
           <form onSubmit={handleSubmit} className="space-y-5">
             <div>
               <label htmlFor="modal-email" className="block text-sm font-medium text-gray-300 mb-2">
-                דואר אלקטרוני
+                Email
               </label>
               <input
                 id="modal-email"
@@ -93,7 +91,7 @@ export default function SignInModal({ open, onOpenChange, onSwitchToSignUp }: Si
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 className="w-full px-4 py-3 bg-gray-900/50 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent transition"
-                placeholder="support@temporhythm.app"
+                placeholder="you@example.com"
                 required={true}
                 disabled={isLoading}
               />
@@ -104,7 +102,7 @@ export default function SignInModal({ open, onOpenChange, onSwitchToSignUp }: Si
                 htmlFor="modal-password"
                 className="block text-sm font-medium text-gray-300 mb-2"
               >
-                סיסמה
+                Password
               </label>
               <div className="relative">
                 <input
@@ -112,7 +110,7 @@ export default function SignInModal({ open, onOpenChange, onSwitchToSignUp }: Si
                   type={showPassword ? "text" : "password"}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="w-full px-4 py-3 pl-12 bg-gray-900/50 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent transition"
+                  className="w-full px-4 py-3 pr-12 bg-gray-900/50 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent transition"
                   placeholder="••••••••"
                   required={true}
                   disabled={isLoading}
@@ -120,15 +118,15 @@ export default function SignInModal({ open, onOpenChange, onSwitchToSignUp }: Si
                 <button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
-                  className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-300 transition"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-300 transition"
                   tabIndex={-1}
+                  aria-label={showPassword ? "Hide password" : "Show password"}
                 >
                   {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
                 </button>
               </div>
             </div>
 
-            {/* תיבת סימון זכור אותי */}
             <div className="flex items-center gap-3">
               <input
                 id="remember-me"
@@ -139,7 +137,7 @@ export default function SignInModal({ open, onOpenChange, onSwitchToSignUp }: Si
                 disabled={isLoading}
               />
               <label htmlFor="remember-me" className="text-sm text-gray-300 cursor-pointer">
-                זכור אותי
+                Remember me
               </label>
             </div>
 
@@ -156,17 +154,17 @@ export default function SignInModal({ open, onOpenChange, onSwitchToSignUp }: Si
             >
               {isLoading ? (
                 <div className="flex items-center justify-center gap-2">
-                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent"></div>
-                  <span>מתחבר...</span>
+                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                  <span>Signing in…</span>
                 </div>
               ) : (
-                "התחבר"
+                "Sign in"
               )}
             </button>
           </form>
 
           <p className="mt-6 text-center text-sm text-gray-400">
-            עדיין אין לכם חשבון?{" "}
+            New here?{" "}
             <button
               type="button"
               onClick={() => {
@@ -175,7 +173,7 @@ export default function SignInModal({ open, onOpenChange, onSwitchToSignUp }: Si
               }}
               className="text-orange-500 hover:text-orange-400 font-semibold transition"
             >
-              הירשמו כאן
+              Create an account
             </button>
           </p>
         </div>

--- a/apps/web/components/SignUpModal.tsx
+++ b/apps/web/components/SignUpModal.tsx
@@ -16,18 +16,17 @@ interface SignUpModalProps {
   onSwitchToSignIn?: () => void;
 }
 
-// קומפוננטת מודל הרשמה
+// Sign-up modal component.
 export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: SignUpModalProps) {
-  const { signIn } = useAuthActions(); // פעולת הרשמה (משתמשת באותה פונקציה כמו התחברות)
+  const { signIn } = useAuthActions(); // Sign-up uses the same Convex Auth action as sign-in.
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
-  const [rememberMe, setRememberMe] = useState(false); // זכור אותי
-  const [showPassword, setShowPassword] = useState(false); // הצגת סיסמה
-  const [consentAccepted, setConsentAccepted] = useState(false); // הסכמה לתנאי שימוש ופרטיות
+  const [rememberMe, setRememberMe] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [consentAccepted, setConsentAccepted] = useState(false);
 
-  // טעינת אימייל שמור
   useEffect(() => {
     const rememberedEmail = localStorage.getItem(REMEMBERED_EMAIL_KEY);
     if (rememberedEmail) {
@@ -39,9 +38,8 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    // בדיקה שהמשתמש אישר את תנאי השימוש ומדיניות הפרטיות
     if (!consentAccepted) {
-      setError("אנא קראו ואשרו קודם את תנאי השימוש ומדיניות הפרטיות");
+      setError("Please read and accept the Terms and Privacy Policy to continue.");
       return;
     }
 
@@ -49,10 +47,8 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
     setError("");
 
     try {
-      // יצירת משתמש חדש והתחברות (flow: "signUp")
       await signIn("password", { email, password, flow: "signUp" });
 
-      // שמירה או מחיקה של האימייל מה-LocalStorage
       if (rememberMe) {
         localStorage.setItem(REMEMBERED_EMAIL_KEY, email);
       } else {
@@ -64,20 +60,19 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
       const error = err as { message?: string };
       const errorMessage = error.message || "";
 
-      // מיפוי שגיאות Convex Auth להודעות בעברית
       if (
         errorMessage.includes("already exists") ||
         errorMessage.includes("AccountAlreadyExists")
       ) {
-        setError("כתובת הדואר האלקטרוני כבר רשומה במערכת");
+        setError("An account with that email already exists — try signing in.");
       } else if (errorMessage.includes("password") && errorMessage.includes("weak")) {
-        setError("הסיסמה חלשה מדי. אנא בחרו סיסמה חזקה יותר");
+        setError("That password is a bit light — try something stronger.");
       } else if (errorMessage.includes("TooManyRequests")) {
-        setError("יותר מדי ניסיונות. אנא נסו שוב מאוחר יותר");
+        setError("Too many attempts. Give it a minute and try again.");
       } else if (errorMessage.includes("invalid") && errorMessage.includes("email")) {
-        setError("כתובת הדואר האלקטרוני אינה תקינה");
+        setError("That email doesn't look right. Double-check it?");
       } else {
-        setError("הרשמה נכשלה. אנא בדקו את הפרטים ונסו שוב");
+        setError("Couldn't create your account. Check your details and try again.");
       }
     } finally {
       setIsLoading(false);
@@ -92,10 +87,12 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md bg-linear-to-br from-gray-900 via-gray-800 to-black border-gray-700 p-0">
-        <div className="rounded-2xl bg-gray-800/50 backdrop-blur-sm p-8" dir="rtl">
+        <div className="rounded-2xl bg-gray-800/50 backdrop-blur-sm p-8">
           <DialogHeader className="mb-6">
-            <DialogTitle className="text-3xl font-bold text-white text-center">הרשמה</DialogTitle>
-            <p className="text-gray-400 text-center mt-2">צרו חשבון חדש והצטרפו אלינו</p>
+            <DialogTitle className="text-3xl font-bold text-white text-center">
+              Create your account
+            </DialogTitle>
+            <p className="text-gray-400 text-center mt-2">A calm home for your plan, your way.</p>
           </DialogHeader>
 
           <form onSubmit={handleSubmit} className="space-y-5">
@@ -104,7 +101,7 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
                 htmlFor="signup-modal-email"
                 className="block text-sm font-medium text-gray-300 mb-2"
               >
-                דואר אלקטרוני
+                Email
               </label>
               <input
                 id="signup-modal-email"
@@ -112,7 +109,7 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 className="w-full px-4 py-3 bg-gray-900/50 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent transition"
-                placeholder="support@temporhythm.app"
+                placeholder="you@example.com"
                 required={true}
                 disabled={isLoading}
               />
@@ -123,7 +120,7 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
                 htmlFor="signup-modal-password"
                 className="block text-sm font-medium text-gray-300 mb-2"
               >
-                סיסמה
+                Password
               </label>
               <div className="relative">
                 <input
@@ -131,7 +128,7 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
                   type={showPassword ? "text" : "password"}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="w-full px-4 py-3 pl-12 bg-gray-900/50 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent transition"
+                  className="w-full px-4 py-3 pr-12 bg-gray-900/50 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent transition"
                   placeholder="••••••••"
                   required={true}
                   disabled={isLoading}
@@ -139,15 +136,15 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
                 <button
                   type="button"
                   onClick={() => setShowPassword(!showPassword)}
-                  className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-300 transition"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-300 transition"
                   tabIndex={-1}
+                  aria-label={showPassword ? "Hide password" : "Show password"}
                 >
                   {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
                 </button>
               </div>
             </div>
 
-            {/* תיבת סימון זכור אותי */}
             <div className="flex items-center gap-3">
               <input
                 id="signup-remember-me"
@@ -158,11 +155,10 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
                 disabled={isLoading}
               />
               <label htmlFor="signup-remember-me" className="text-sm text-gray-300 cursor-pointer">
-                זכור אותי
+                Remember me
               </label>
             </div>
 
-            {/* תיבת סימון הסכמה לתנאי שימוש ומדיניות פרטיות */}
             <div className="flex items-start gap-3 p-4 bg-gray-900/30 rounded-lg border border-gray-700">
               <div className="relative flex-shrink-0 mt-0.5">
                 <input
@@ -182,6 +178,7 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
                       ? "bg-orange-500 border-orange-500"
                       : "bg-transparent border-gray-600 hover:border-gray-500"
                   } ${isLoading ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+                  aria-label={consentAccepted ? "Consent granted" : "Accept terms"}
                 >
                   {consentAccepted && <Check className="w-3 h-3 text-black" />}
                 </button>
@@ -190,26 +187,27 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
                 htmlFor="signup-consent"
                 className="text-sm text-gray-300 flex-1 cursor-pointer"
               >
-                אני מסכים ל
+                I agree to the{" "}
                 <Link
                   href={TERMS_URL}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-orange-500 hover:text-orange-400 font-semibold mx-1"
+                  className="text-orange-500 hover:text-orange-400 font-semibold"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  תנאי השימוש
+                  Terms of Use
                 </Link>
-                ול
+                {" "}and{" "}
                 <Link
                   href={PRIVACY_URL}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-orange-500 hover:text-orange-400 font-semibold mr-1"
+                  className="text-orange-500 hover:text-orange-400 font-semibold"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  מדיניות הפרטיות
+                  Privacy Policy
                 </Link>
+                .
               </label>
             </div>
 
@@ -226,23 +224,23 @@ export default function SignUpModal({ open, onOpenChange, onSwitchToSignIn }: Si
             >
               {isLoading ? (
                 <div className="flex items-center justify-center gap-2">
-                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent"></div>
-                  <span>יוצר חשבון...</span>
+                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                  <span>Creating account…</span>
                 </div>
               ) : (
-                "צור חשבון"
+                "Create account"
               )}
             </button>
           </form>
 
           <p className="mt-6 text-center text-sm text-gray-400">
-            כבר יש לכם חשבון?{" "}
+            Already have an account?{" "}
             <button
               type="button"
               onClick={handleSwitchToSignIn}
               className="text-orange-500 hover:text-orange-400 font-semibold transition"
             >
-              התחברו כאן
+              Sign in
             </button>
           </p>
         </div>

--- a/apps/web/components/auth/SignInForm.tsx
+++ b/apps/web/components/auth/SignInForm.tsx
@@ -48,16 +48,16 @@ export function SignInForm({ variant = "modal", onSuccess, onSwitchToSignUp }: S
       const error = err as { message?: string };
       const errorMessage = error.message || "";
       if (errorMessage.includes("InvalidSecret")) {
-        setError("הסיסמה שהוזנה שגויה");
+        setError("Incorrect password. Please try again.");
       } else if (
         errorMessage.includes("InvalidAccountId") ||
         errorMessage.includes("Could not find")
       ) {
-        setError("לא נמצא חשבון עם כתובת הדואר האלקטרוני הזו");
+        setError("No account found with that email address.");
       } else if (errorMessage.includes("TooManyRequests")) {
-        setError("יותר מדי ניסיונות התחברות. אנא נסו שוב מאוחר יותר");
+        setError("Too many sign-in attempts. Please try again later.");
       } else {
-        setError("התחברות נכשלה. אנא בדקו את הפרטים ונסו שוב");
+        setError("Sign-in failed. Please check your details and try again.");
       }
     } finally {
       setIsLoading(false);
@@ -73,20 +73,20 @@ export function SignInForm({ variant = "modal", onSuccess, onSwitchToSignUp }: S
   const labelClass = isPage ? "mb-2 block text-sm font-medium text-foreground" : "block text-sm font-medium text-gray-300 mb-2";
 
   return (
-    <div className={isPage ? "w-full max-w-md" : ""} dir="rtl">
+    <div className={isPage ? "w-full max-w-md" : ""}>
       {isPage && (
         <div className="mb-8 text-center">
           <h1 className="font-heading text-4xl font-semibold tracking-tight text-gradient-primary">
-            התחברות
+            Welcome back
           </h1>
-          <p className="mt-2 text-muted-foreground">ברוכים השבים ל-Tempo Flow</p>
+          <p className="mt-2 text-muted-foreground">Sign in to Tempo Flow</p>
         </div>
       )}
 
       <form onSubmit={handleSubmit} className="space-y-5">
         <div>
           <label htmlFor="signin-email" className={labelClass}>
-            דואר אלקטרוני
+            Email
           </label>
           <input
             id="signin-email"
@@ -94,7 +94,7 @@ export function SignInForm({ variant = "modal", onSuccess, onSwitchToSignUp }: S
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className={inputClass}
-            placeholder="support@temporhythm.app"
+            placeholder="you@example.com"
             required={true}
             disabled={isLoading}
             autoComplete="email"
@@ -103,7 +103,7 @@ export function SignInForm({ variant = "modal", onSuccess, onSwitchToSignUp }: S
 
         <div>
           <label htmlFor="signin-password" className={labelClass}>
-            סיסמה
+            Password
           </label>
           <div className="relative">
             <input
@@ -111,7 +111,7 @@ export function SignInForm({ variant = "modal", onSuccess, onSwitchToSignUp }: S
               type={showPassword ? "text" : "password"}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className={isPage ? `${inputClass} pl-12` : `${inputClass} pl-12`}
+              className={isPage ? `${inputClass} pr-12` : `${inputClass} pr-12`}
               placeholder="••••••••"
               required={true}
               disabled={isLoading}
@@ -122,10 +122,11 @@ export function SignInForm({ variant = "modal", onSuccess, onSwitchToSignUp }: S
               onClick={() => setShowPassword(!showPassword)}
               className={
                 isPage
-                  ? "absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  : "absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-300 transition"
+                  ? "absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  : "absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-300 transition"
               }
               tabIndex={-1}
+              aria-label={showPassword ? "Hide password" : "Show password"}
             >
               {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
             </button>
@@ -146,7 +147,7 @@ export function SignInForm({ variant = "modal", onSuccess, onSwitchToSignUp }: S
             disabled={isLoading}
           />
           <label htmlFor="remember-me-signin" className={`cursor-pointer text-sm ${isPage ? "text-foreground" : "text-gray-300"}`}>
-            זכור אותי
+            Remember me
           </label>
         </div>
 
@@ -157,6 +158,7 @@ export function SignInForm({ variant = "modal", onSuccess, onSwitchToSignUp }: S
                 ? "rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive"
                 : "bg-red-500/10 border border-red-500/50 text-red-400 px-4 py-3 rounded-lg text-sm"
             }
+            role="alert"
           >
             {error}
           </div>
@@ -174,19 +176,19 @@ export function SignInForm({ variant = "modal", onSuccess, onSwitchToSignUp }: S
           {isLoading ? (
             <span className="flex items-center justify-center gap-2">
               <span className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
-              מתחבר...
+              Signing in…
             </span>
           ) : (
-            "התחבר"
+            "Sign in"
           )}
         </button>
       </form>
 
       <p className={`mt-6 text-center text-sm ${isPage ? "text-muted-foreground" : "text-gray-400"}`}>
-        עדיין אין לכם חשבון?{" "}
+        Don&apos;t have an account?{" "}
         {isPage ? (
           <Link href="/sign-up" className="font-semibold text-primary hover:underline">
-            הירשמו כאן
+            Create one
           </Link>
         ) : (
           <button
@@ -194,7 +196,7 @@ export function SignInForm({ variant = "modal", onSuccess, onSwitchToSignUp }: S
             onClick={() => onSwitchToSignUp?.()}
             className="font-semibold text-orange-500 transition hover:text-orange-400"
           >
-            הירשמו כאן
+            Create one
           </button>
         )}
       </p>

--- a/apps/web/components/auth/SignUpForm.tsx
+++ b/apps/web/components/auth/SignUpForm.tsx
@@ -36,7 +36,7 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!consentAccepted) {
-      setError("אנא קראו ואשרו קודם את תנאי השימוש ומדיניות הפרטיות");
+      setError("Please accept the Terms of Service and Privacy Policy to continue.");
       return;
     }
     setIsLoading(true);
@@ -56,15 +56,15 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
         errorMessage.includes("already exists") ||
         errorMessage.includes("AccountAlreadyExists")
       ) {
-        setError("כתובת הדואר האלקטרוני כבר רשומה במערכת");
+        setError("An account with that email already exists. Try signing in instead.");
       } else if (errorMessage.includes("password") && errorMessage.includes("weak")) {
-        setError("הסיסמה חלשה מדי. אנא בחרו סיסמה חזקה יותר");
+        setError("Password is too weak. Please choose a stronger password.");
       } else if (errorMessage.includes("TooManyRequests")) {
-        setError("יותר מדי ניסיונות. אנא נסו שוב מאוחר יותר");
+        setError("Too many attempts. Please try again later.");
       } else if (errorMessage.includes("invalid") && errorMessage.includes("email")) {
-        setError("כתובת הדואר האלקטרוני אינה תקינה");
+        setError("That email address doesn't look valid. Please check it.");
       } else {
-        setError("הרשמה נכשלה. אנא בדקו את הפרטים ונסו שוב");
+        setError("Sign-up failed. Please check your details and try again.");
       }
     } finally {
       setIsLoading(false);
@@ -82,20 +82,20 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
     : "block text-sm font-medium text-gray-300 mb-2";
 
   return (
-    <div className={isPage ? "w-full max-w-md" : ""} dir="rtl">
+    <div className={isPage ? "w-full max-w-md" : ""}>
       {isPage && (
         <div className="mb-8 text-center">
           <h1 className="font-heading text-4xl font-semibold tracking-tight text-gradient-primary">
-            הרשמה
+            Create account
           </h1>
-          <p className="mt-2 text-muted-foreground">צרו חשבון והצטרפו ל-Tempo Flow</p>
+          <p className="mt-2 text-muted-foreground">Join Tempo Flow — free to start</p>
         </div>
       )}
 
       <form onSubmit={handleSubmit} className="space-y-5">
         <div>
           <label htmlFor="signup-email" className={labelClass}>
-            דואר אלקטרוני
+            Email
           </label>
           <input
             id="signup-email"
@@ -103,7 +103,7 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             className={inputClass}
-            placeholder="support@temporhythm.app"
+            placeholder="you@example.com"
             required={true}
             disabled={isLoading}
             autoComplete="email"
@@ -112,7 +112,7 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
 
         <div>
           <label htmlFor="signup-password" className={labelClass}>
-            סיסמה
+            Password
           </label>
           <div className="relative">
             <input
@@ -120,7 +120,7 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
               type={showPassword ? "text" : "password"}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className={isPage ? `${inputClass} pl-12` : `${inputClass} pl-12`}
+              className={isPage ? `${inputClass} pr-12` : `${inputClass} pr-12`}
               placeholder="••••••••"
               required={true}
               disabled={isLoading}
@@ -131,10 +131,11 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
               onClick={() => setShowPassword(!showPassword)}
               className={
                 isPage
-                  ? "absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  : "absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-300 transition"
+                  ? "absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  : "absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-300 transition"
               }
               tabIndex={-1}
+              aria-label={showPassword ? "Hide password" : "Show password"}
             >
               {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
             </button>
@@ -158,7 +159,7 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
             htmlFor="remember-me-signup"
             className={`cursor-pointer text-sm ${isPage ? "text-foreground" : "text-gray-300"}`}
           >
-            זכור אותי
+            Remember me
           </label>
         </div>
 
@@ -182,6 +183,7 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
               type="button"
               onClick={() => setConsentAccepted(!consentAccepted)}
               disabled={isLoading}
+              aria-label="Accept terms and privacy policy"
               className={`flex h-5 w-5 items-center justify-center rounded border-2 transition ${
                 consentAccepted
                   ? "border-primary bg-primary"
@@ -194,25 +196,25 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
             </button>
           </div>
           <label htmlFor="signup-consent" className="flex-1 cursor-pointer text-sm text-foreground">
-            אני מסכים ל
+            I agree to the{" "}
             <Link
               href={TERMS_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="mx-1 font-semibold text-primary hover:underline"
+              className="font-semibold text-primary hover:underline"
               onClick={(e) => e.stopPropagation()}
             >
-              תנאי השימוש
-            </Link>
-            ול
+              Terms of Service
+            </Link>{" "}
+            and{" "}
             <Link
               href={PRIVACY_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="mr-1 font-semibold text-primary hover:underline"
+              className="font-semibold text-primary hover:underline"
               onClick={(e) => e.stopPropagation()}
             >
-              מדיניות הפרטיות
+              Privacy Policy
             </Link>
           </label>
         </div>
@@ -224,6 +226,7 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
                 ? "rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive"
                 : "bg-red-500/10 border border-red-500/50 text-red-400 px-4 py-3 rounded-lg text-sm"
             }
+            role="alert"
           >
             {error}
           </div>
@@ -241,19 +244,19 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
           {isLoading ? (
             <span className="flex items-center justify-center gap-2">
               <span className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
-              יוצר חשבון...
+              Creating account…
             </span>
           ) : (
-            "צור חשבון"
+            "Create account"
           )}
         </button>
       </form>
 
       <p className={`mt-6 text-center text-sm ${isPage ? "text-muted-foreground" : "text-gray-400"}`}>
-        כבר יש לכם חשבון?{" "}
+        Already have an account?{" "}
         {isPage ? (
           <Link href="/sign-in" className="font-semibold text-primary hover:underline">
-            התחברו כאן
+            Sign in
           </Link>
         ) : (
           <button
@@ -261,7 +264,7 @@ export function SignUpForm({ variant = "modal", onSuccess, onSwitchToSignIn }: S
             onClick={() => onSwitchToSignIn?.()}
             className="font-semibold text-orange-500 transition hover:text-orange-400"
           >
-            התחברו כאן
+            Sign in
           </button>
         )}
       </p>

--- a/apps/web/components/brain-dump/BrainDumpScreen.tsx
+++ b/apps/web/components/brain-dump/BrainDumpScreen.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useConvexAuth, useMutation } from "convex/react";
+import { Loader2, Sparkles } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { SoftCard } from "@/components/soft-editorial/SoftCard";
+import { Button } from "@/components/ui/button";
+import { api } from "@/convex/_generated/api";
+
+const CONFIRM_TTL_MS = 4_000;
+
+export function BrainDumpScreen() {
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const createNote = useMutation(api.notes.create);
+
+  const [text, setText] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [confirmation, setConfirmation] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const confirmTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (confirmTimerRef.current) {
+        clearTimeout(confirmTimerRef.current);
+      }
+    };
+  }, []);
+
+  if (isAuthLoading) {
+    return (
+      <div className="container mx-auto max-w-3xl px-6 py-12 space-y-6">
+        <div className="h-12 w-60 animate-pulse rounded-xl bg-muted" />
+        <div className="h-80 animate-pulse rounded-2xl bg-muted" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="container mx-auto max-w-3xl px-6 py-16 text-center">
+        <SoftCard className="mx-auto max-w-xl">
+          <h1 className="font-heading text-2xl font-semibold text-foreground">Sign in required</h1>
+          <p className="mt-3 text-muted-foreground">
+            Sign in to save your brain dump to your notes.
+          </p>
+          <Button asChild className="mt-6">
+            <Link href="/sign-in">Sign in</Link>
+          </Button>
+        </SoftCard>
+      </div>
+    );
+  }
+
+  const submit = async () => {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      setError("Write something before capturing — even a single word is fine.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    const today = new Date().toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+    const title = `Brain dump — ${today}`;
+
+    try {
+      await createNote({ title, body: trimmed });
+      setText("");
+      setConfirmation("Captured. Find it in Notes.");
+      if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+      confirmTimerRef.current = window.setTimeout(
+        () => setConfirmation(null),
+        CONFIRM_TTL_MS,
+      );
+    } catch {
+      setError("Couldn't capture that right now. Give it another try.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-3xl px-6 py-12">
+      <header className="space-y-3 mb-8">
+        <p className="text-sm font-medium text-muted-foreground">Flow</p>
+        <h1 className="font-heading text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
+          Brain dump
+        </h1>
+        <p className="max-w-2xl text-lg text-muted-foreground">
+          Everything floating around, down here. No structure required. We'll save it to Notes so
+          nothing gets lost.
+        </p>
+      </header>
+
+      <textarea
+        value={text}
+        onChange={(event) => {
+          setText(event.target.value);
+          if (error) setError(null);
+        }}
+        disabled={isSubmitting}
+        placeholder="What's on your mind? Dump it all here."
+        rows={14}
+        className="min-h-[320px] w-full resize-y rounded-2xl border border-border/80 bg-card/60 p-5 text-base leading-relaxed text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] outline-none focus:ring-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-70"
+        aria-label="Brain dump text"
+      />
+
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-h-6 text-sm">
+          {error ? (
+            <p className="text-destructive">{error}</p>
+          ) : confirmation ? (
+            <p className="inline-flex items-center gap-2 text-emerald-600 dark:text-emerald-300">
+              <Sparkles className="h-4 w-4" aria-hidden />
+              {confirmation}
+            </p>
+          ) : (
+            <p className="text-muted-foreground">
+              We'll tuck it into Notes as "Brain dump — today's date".
+            </p>
+          )}
+        </div>
+
+        <Button
+          type="button"
+          onClick={() => void submit()}
+          disabled={isSubmitting}
+          className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl px-6"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Capturing…
+            </>
+          ) : (
+            <>
+              <Sparkles className="h-4 w-4" aria-hidden />
+              Capture
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/coach/CoachScreen.tsx
+++ b/apps/web/components/coach/CoachScreen.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useAction, useConvexAuth } from "convex/react";
+import { Loader2, Send, Sparkles } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { SoftCard } from "@/components/soft-editorial/SoftCard";
+import { Button } from "@/components/ui/button";
+import { api } from "@/convex/_generated/api";
+import { cn } from "@/lib/utils";
+
+type ChatRole = "user" | "assistant" | "system";
+
+type ChatMessage = {
+  id: string;
+  role: ChatRole;
+  content: string;
+};
+
+const INTRO: ChatMessage = {
+  id: "intro",
+  role: "assistant",
+  content: "Hey — what's on your mind today?",
+};
+
+// Keep the send payload short so we don't blow through tokens on long sessions.
+const HISTORY_WINDOW = 10;
+
+export function CoachScreen() {
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const respond = useAction(api.coachActions.respond);
+
+  const [messages, setMessages] = useState<ChatMessage[]>([INTRO]);
+  const [input, setInput] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const endRef = useRef<HTMLLIElement>(null);
+
+  // Scroll to the newest message whenever messages change.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll side effect intentionally keys on message count + typing indicator
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [messages.length, isSending]);
+
+  const visibleMessages = useMemo(
+    () => messages.filter((m) => m.role !== "system"),
+    [messages],
+  );
+
+  if (isAuthLoading) {
+    return (
+      <div className="container mx-auto max-w-3xl px-6 py-12 space-y-6">
+        <div className="h-12 w-60 animate-pulse rounded-xl bg-muted" />
+        <div className="h-64 animate-pulse rounded-2xl bg-muted" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="container mx-auto max-w-3xl px-6 py-16 text-center">
+        <SoftCard className="mx-auto max-w-xl">
+          <h1 className="font-heading text-2xl font-semibold text-foreground">Sign in required</h1>
+          <p className="mt-3 text-muted-foreground">Sign in to chat with the coach.</p>
+          <Button asChild className="mt-6">
+            <Link href="/sign-in">Sign in</Link>
+          </Button>
+        </SoftCard>
+      </div>
+    );
+  }
+
+  const send = async () => {
+    const text = input.trim();
+    if (!text || isSending) return;
+
+    const userMsg: ChatMessage = {
+      id: `u-${Date.now()}`,
+      role: "user",
+      content: text,
+    };
+
+    // Snapshot history BEFORE adding the user message so the action gets the
+    // state the assistant already saw.
+    const historyForAction = messages
+      .slice(-HISTORY_WINDOW)
+      .filter((m) => m.role !== "system")
+      .map((m) => ({ role: m.role, content: m.content }));
+
+    setMessages((prev) => [...prev, userMsg]);
+    setInput("");
+    setError(null);
+    setIsSending(true);
+
+    try {
+      const { reply } = await respond({ message: text, history: historyForAction });
+      const assistantMsg: ChatMessage = {
+        id: `a-${Date.now()}`,
+        role: "assistant",
+        content: reply.trim() || "I heard you. What's one small next step?",
+      };
+      setMessages((prev) => [...prev, assistantMsg]);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "unknown";
+      setError(
+        message.includes("OPENROUTER_API_KEY") || message.includes("401")
+          ? "The coach is offline right now. The OpenRouter key isn't wired yet — try again once it's set."
+          : "Something knocked the coach offline for a moment. Try again in a minute.",
+      );
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-[calc(100vh-7rem)] flex-col">
+      <div className="container mx-auto w-full max-w-3xl px-6 pt-10 pb-4">
+        <header className="space-y-3">
+          <p className="text-sm font-medium text-muted-foreground">Flow</p>
+          <h1 className="font-heading text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
+            Coach
+          </h1>
+          <p className="max-w-2xl text-lg text-muted-foreground">
+            A calm place to think out loud. One small next step at a time.
+          </p>
+        </header>
+      </div>
+
+      <div className="container mx-auto flex w-full max-w-3xl flex-1 flex-col gap-4 px-6 pb-4">
+        <ul className="flex-1 space-y-3" aria-live="polite">
+          {visibleMessages.map((msg) => (
+            <li
+              key={msg.id}
+              className={cn("flex", msg.role === "user" ? "justify-end" : "justify-start")}
+            >
+              <div
+                className={cn(
+                  "max-w-[85%] rounded-2xl px-4 py-3 text-base leading-relaxed shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]",
+                  msg.role === "user"
+                    ? "bg-primary text-primary-foreground"
+                    : "border border-border/80 bg-card text-foreground",
+                )}
+              >
+                {msg.content}
+              </div>
+            </li>
+          ))}
+
+          {isSending && (
+            <li className="flex justify-start">
+              <div className="flex items-center gap-2 rounded-2xl border border-border/80 bg-card px-4 py-3 text-muted-foreground">
+                <Sparkles className="h-4 w-4 animate-pulse" aria-hidden />
+                <output className="flex items-center gap-1" aria-label="Coach is typing">
+                  <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted-foreground" />
+                  <span
+                    className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted-foreground"
+                    style={{ animationDelay: "120ms" }}
+                  />
+                  <span
+                    className="h-1.5 w-1.5 animate-bounce rounded-full bg-muted-foreground"
+                    style={{ animationDelay: "240ms" }}
+                  />
+                </output>
+              </div>
+            </li>
+          )}
+
+          <li ref={endRef} />
+        </ul>
+
+        {error && (
+          <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+      </div>
+
+      <div className="sticky bottom-0 z-10 border-t border-border bg-background/95 backdrop-blur">
+        <div className="container mx-auto w-full max-w-3xl px-6 py-4">
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <textarea
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.shiftKey && !event.metaKey && !event.ctrlKey) {
+                  event.preventDefault();
+                  void send();
+                }
+              }}
+              disabled={isSending}
+              placeholder="Share what's on your mind…"
+              rows={2}
+              className="min-h-12 flex-1 resize-none rounded-xl border border-border bg-background px-4 py-3 text-foreground shadow-[inset_0_1px_2px_rgba(0,0,0,0.06)] outline-none transition focus:ring-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-70"
+            />
+            <Button
+              type="button"
+              onClick={() => void send()}
+              disabled={isSending || !input.trim()}
+              className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl px-5"
+            >
+              {isSending ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                  Thinking…
+                </>
+              ) : (
+                <>
+                  <Send className="h-4 w-4" aria-hidden />
+                  Send
+                </>
+              )}
+            </Button>
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Shift+Enter for a new line · Enter to send
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/journal/JournalScreen.tsx
+++ b/apps/web/components/journal/JournalScreen.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { SoftCard } from "@/components/soft-editorial/SoftCard";
+import { Button } from "@/components/ui/button";
+import { api } from "@/convex/_generated/api";
+import { formatLongDate, getLocalDateKey } from "@/lib/localDay";
+
+const AUTOSAVE_DELAY_MS = 1_000;
+
+export function JournalScreen() {
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const dateKey = useMemo(() => getLocalDateKey(), []);
+  const heading = useMemo(() => formatLongDate(), []);
+
+  const entry = useQuery(
+    api.journal.getByDate,
+    isAuthenticated ? { dateKey } : "skip",
+  );
+  const upsertByDate = useMutation(api.journal.upsertByDate);
+
+  const [body, setBody] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
+  const hydratedRef = useRef(false);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (entry === undefined || hydratedRef.current) return;
+    if (entry) {
+      setBody(entry.body);
+      setLastSavedAt(entry.updatedAt);
+    }
+    hydratedRef.current = true;
+  }, [entry]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const scheduleSave = (next: string) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(async () => {
+      try {
+        setIsSaving(true);
+        await upsertByDate({ dateKey, body: next });
+        setLastSavedAt(Date.now());
+      } catch {
+        // silent — next save attempt will retry
+      } finally {
+        setIsSaving(false);
+      }
+    }, AUTOSAVE_DELAY_MS);
+  };
+
+  const flushSave = async () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    try {
+      setIsSaving(true);
+      await upsertByDate({ dateKey, body });
+      setLastSavedAt(Date.now());
+    } catch {
+      // silent
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isAuthLoading || (isAuthenticated && entry === undefined)) {
+    return (
+      <div className="container mx-auto max-w-3xl px-6 py-12 space-y-6">
+        <div className="h-12 w-60 animate-pulse rounded-xl bg-muted" />
+        <div className="h-64 animate-pulse rounded-2xl bg-muted" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="container mx-auto max-w-3xl px-6 py-16 text-center">
+        <SoftCard className="mx-auto max-w-xl">
+          <h1 className="font-heading text-2xl font-semibold text-foreground">Sign in required</h1>
+          <p className="mt-3 text-muted-foreground">Sign in to open today's journal.</p>
+          <Button asChild className="mt-6">
+            <Link href="/sign-in">Sign in</Link>
+          </Button>
+        </SoftCard>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl px-6 py-12">
+      <header className="space-y-3 mb-8">
+        <p className="text-sm font-medium text-muted-foreground">Library</p>
+        <h1 className="font-heading text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
+          {heading}
+        </h1>
+        <div className="flex items-center gap-3 text-sm text-muted-foreground">
+          <p>A quiet page for today.</p>
+          <span aria-hidden>·</span>
+          <div className="inline-flex items-center gap-2">
+            {isSaving ? (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+                <span>Saving…</span>
+              </>
+            ) : lastSavedAt ? (
+              <span>Saved · {formatRelative(lastSavedAt)}</span>
+            ) : (
+              <span>Unsaved</span>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <textarea
+        value={body}
+        onChange={(event) => {
+          const next = event.target.value;
+          setBody(next);
+          scheduleSave(next);
+        }}
+        onBlur={() => void flushSave()}
+        placeholder="How are you feeling? Anything at all — a sentence is enough."
+        rows={16}
+        className="min-h-[360px] w-full resize-y rounded-2xl border border-border/80 bg-card/60 p-5 text-base leading-relaxed text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] outline-none focus:ring-2 focus:ring-primary"
+        aria-label={`Journal entry for ${dateKey}`}
+      />
+    </div>
+  );
+}
+
+function formatRelative(ms: number): string {
+  const delta = Date.now() - ms;
+  const seconds = Math.round(delta / 1_000);
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  return new Date(ms).toLocaleTimeString();
+}

--- a/apps/web/components/notes/NoteEditor.tsx
+++ b/apps/web/components/notes/NoteEditor.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { ChevronLeft, Loader2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+import { SoftCard } from "@/components/soft-editorial/SoftCard";
+import { Button } from "@/components/ui/button";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+
+const AUTOSAVE_DELAY_MS = 1_000;
+
+type NoteEditorProps = {
+  noteId: Id<"notes">;
+};
+
+export function NoteEditor({ noteId }: NoteEditorProps) {
+  const router = useRouter();
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const note = useQuery(api.notes.get, isAuthenticated ? { noteId } : "skip");
+  const updateNote = useMutation(api.notes.update);
+
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
+  const hydratedRef = useRef(false);
+  const titleSaveRef = useRef<number | null>(null);
+  const bodySaveRef = useRef<number | null>(null);
+
+  // Hydrate local state from server once the note arrives.
+  useEffect(() => {
+    if (!note || hydratedRef.current) return;
+    setTitle(note.title);
+    setBody(note.body);
+    setLastSavedAt(note.updatedAt);
+    hydratedRef.current = true;
+  }, [note]);
+
+  const scheduleSave = (patch: { title?: string; body?: string }) => {
+    // Clear existing timers for whichever field we're updating.
+    if (patch.title !== undefined && titleSaveRef.current) {
+      clearTimeout(titleSaveRef.current);
+    }
+    if (patch.body !== undefined && bodySaveRef.current) {
+      clearTimeout(bodySaveRef.current);
+    }
+
+    const run = async () => {
+      try {
+        setIsSaving(true);
+        await updateNote({ noteId, ...patch });
+        setLastSavedAt(Date.now());
+      } catch {
+        // Silent — the next save attempt will retry automatically.
+      } finally {
+        setIsSaving(false);
+      }
+    };
+
+    const id = window.setTimeout(() => void run(), AUTOSAVE_DELAY_MS);
+    if (patch.title !== undefined) titleSaveRef.current = id;
+    if (patch.body !== undefined) bodySaveRef.current = id;
+  };
+
+  // Flush any pending save on unmount.
+  useEffect(() => {
+    return () => {
+      if (titleSaveRef.current) clearTimeout(titleSaveRef.current);
+      if (bodySaveRef.current) clearTimeout(bodySaveRef.current);
+    };
+  }, []);
+
+  if (isAuthLoading || (isAuthenticated && note === undefined)) {
+    return (
+      <div className="container mx-auto max-w-3xl px-6 py-12 space-y-6">
+        <div className="h-8 w-24 animate-pulse rounded-xl bg-muted" />
+        <div className="h-12 w-80 animate-pulse rounded-xl bg-muted" />
+        <div className="h-64 animate-pulse rounded-2xl bg-muted" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="container mx-auto max-w-3xl px-6 py-16 text-center">
+        <SoftCard className="mx-auto max-w-xl">
+          <h1 className="font-heading text-2xl font-semibold text-foreground">Sign in required</h1>
+          <p className="mt-3 text-muted-foreground">Sign in to edit your notes.</p>
+          <Button asChild className="mt-6">
+            <Link href="/sign-in">Sign in</Link>
+          </Button>
+        </SoftCard>
+      </div>
+    );
+  }
+
+  if (note === null) {
+    return (
+      <div className="container mx-auto max-w-3xl px-6 py-16 text-center">
+        <SoftCard className="mx-auto max-w-xl">
+          <h1 className="font-heading text-2xl font-semibold text-foreground">
+            We couldn't find that note
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            It may have been removed. You can still browse the rest of your notes.
+          </p>
+          <Button className="mt-6" onClick={() => router.push("/notes")}>
+            Back to Notes
+          </Button>
+        </SoftCard>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-3xl px-6 py-12">
+      <div className="mb-6 flex items-center justify-between">
+        <Link
+          href="/notes"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground transition hover:text-foreground"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden />
+          All notes
+        </Link>
+
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          {isSaving ? (
+            <>
+              <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+              Saving…
+            </>
+          ) : lastSavedAt ? (
+            <span>Saved · {formatRelative(lastSavedAt)}</span>
+          ) : null}
+        </div>
+      </div>
+
+      <input
+        type="text"
+        value={title}
+        onChange={(event) => {
+          const next = event.target.value;
+          setTitle(next);
+          scheduleSave({ title: next });
+        }}
+        placeholder="Untitled"
+        className="mb-4 w-full border-0 bg-transparent font-heading text-4xl font-semibold tracking-tight text-foreground outline-none focus:ring-0 md:text-5xl"
+        aria-label="Note title"
+      />
+
+      <textarea
+        value={body}
+        onChange={(event) => {
+          const next = event.target.value;
+          setBody(next);
+          scheduleSave({ body: next });
+        }}
+        placeholder="Start writing…"
+        className="min-h-[320px] w-full resize-y rounded-2xl border border-border/80 bg-card/60 p-5 text-base leading-relaxed text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] outline-none focus:ring-2 focus:ring-primary"
+      />
+    </div>
+  );
+}
+
+function formatRelative(ms: number): string {
+  const delta = Date.now() - ms;
+  const seconds = Math.round(delta / 1_000);
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  return new Date(ms).toLocaleTimeString();
+}

--- a/apps/web/components/notes/NotesScreen.tsx
+++ b/apps/web/components/notes/NotesScreen.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { Loader2, Plus } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { SoftCard } from "@/components/soft-editorial/SoftCard";
+import { Button } from "@/components/ui/button";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { cn } from "@/lib/utils";
+
+type NoteRow = {
+  _id: Id<"notes">;
+  title: string;
+  body: string;
+  pinned: boolean;
+  updatedAt: number;
+};
+
+export function NotesScreen() {
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const notes = useQuery(api.notes.list, isAuthenticated ? {} : "skip");
+
+  if (isAuthLoading) {
+    return <NotesSkeleton />;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="container mx-auto max-w-4xl px-6 py-16 text-center">
+        <SoftCard className="mx-auto max-w-xl">
+          <h1 className="font-heading text-2xl font-semibold text-foreground">Sign in required</h1>
+          <p className="mt-3 text-muted-foreground">Sign in to see your notes.</p>
+          <Button asChild className="mt-6">
+            <Link href="/sign-in">Sign in</Link>
+          </Button>
+        </SoftCard>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-4xl px-6 py-12">
+      <header className="space-y-3 mb-8">
+        <p className="text-sm font-medium text-muted-foreground">Library</p>
+        <h1 className="font-heading text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
+          Notes
+        </h1>
+        <p className="max-w-2xl text-lg text-muted-foreground">
+          Anything you want to remember. Write once, find it later.
+        </p>
+      </header>
+
+      <NoteQuickCreate />
+
+      {notes === undefined ? (
+        <div className="mt-8">
+          <NotesListSkeleton />
+        </div>
+      ) : notes.length === 0 ? (
+        <section className="mt-8 rounded-3xl border border-dashed border-border bg-muted/30 px-6 py-12 text-center">
+          <p className="text-base text-foreground">No notes yet.</p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            What would you like to remember? Give it a title above to begin.
+          </p>
+        </section>
+      ) : (
+        <NoteList notes={notes as NoteRow[]} />
+      )}
+    </div>
+  );
+}
+
+function NoteQuickCreate() {
+  const createNote = useMutation(api.notes.create);
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [hint, setHint] = useState("");
+
+  const submit = async () => {
+    const trimmed = title.trim();
+    if (!trimmed) {
+      setHint("Give the note a title so you can find it later.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setHint("");
+
+    try {
+      const noteId = await createNote({ title: trimmed, body: "" });
+      setTitle("");
+      router.push(`/notes/${noteId}`);
+    } catch {
+      setHint("Could not create that note. Try again?");
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-border/80 bg-card/70 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]">
+      <div className="mb-3">
+        <label htmlFor="notes-quick-create" className="text-sm font-medium text-foreground">
+          New note
+        </label>
+        <p className="mt-1 text-sm text-muted-foreground">A single line is enough to begin.</p>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <input
+          id="notes-quick-create"
+          type="text"
+          value={title}
+          onChange={(event) => {
+            setTitle(event.target.value);
+            if (hint) setHint("");
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              setTitle("");
+              setHint("");
+            }
+            if (event.key === "Enter" && !event.metaKey && !event.ctrlKey) {
+              event.preventDefault();
+              void submit();
+            }
+          }}
+          disabled={isSubmitting}
+          placeholder="Reading list, meeting notes, a small reflection…"
+          className="min-h-12 flex-1 rounded-xl border border-border bg-background px-4 py-3 text-foreground shadow-[inset_0_1px_2px_rgba(0,0,0,0.06)] outline-none transition focus:ring-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-70"
+        />
+        <Button
+          type="button"
+          onClick={() => void submit()}
+          disabled={isSubmitting}
+          className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl px-5"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Creating…
+            </>
+          ) : (
+            <>
+              <Plus className="h-4 w-4" aria-hidden />
+              Create
+            </>
+          )}
+        </Button>
+      </div>
+
+      <div className="mt-2 min-h-5">
+        {hint ? <p className="text-sm text-muted-foreground">{hint}</p> : null}
+      </div>
+    </div>
+  );
+}
+
+function NoteList({ notes }: { notes: NoteRow[] }) {
+  return (
+    <ul className="mt-8 space-y-3">
+      {notes.map((note) => (
+        <li key={note._id}>
+          <Link
+            href={`/notes/${note._id}`}
+            className={cn(
+              "block rounded-2xl border border-border/80 bg-background/70 px-5 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition hover:border-primary/40 hover:bg-card",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+            )}
+          >
+            <div className="flex flex-wrap items-baseline justify-between gap-3">
+              <p className="font-heading text-lg font-semibold text-foreground">
+                {note.title || "Untitled"}
+              </p>
+              <span className="text-xs text-muted-foreground">
+                {formatRelative(note.updatedAt)}
+              </span>
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
+              {note.body.trim() ? truncate(note.body, 140) : "No body yet."}
+            </p>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function truncate(text: string, max: number): string {
+  const clean = text.replace(/\s+/g, " ").trim();
+  if (clean.length <= max) return clean;
+  return `${clean.slice(0, max - 1).trimEnd()}…`;
+}
+
+function formatRelative(ms: number): string {
+  const delta = Date.now() - ms;
+  const minutes = Math.round(delta / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days} d ago`;
+  return new Date(ms).toLocaleDateString();
+}
+
+function NotesSkeleton() {
+  return (
+    <div className="container mx-auto max-w-4xl px-6 py-12 space-y-6">
+      <div className="h-12 w-48 animate-pulse rounded-xl bg-muted" />
+      <div className="h-28 animate-pulse rounded-2xl bg-muted" />
+      <NotesListSkeleton />
+    </div>
+  );
+}
+
+function NotesListSkeleton() {
+  return (
+    <ul className="space-y-3">
+      {[0, 1, 2].map((i) => (
+        <li key={i} className="h-20 animate-pulse rounded-2xl bg-muted" />
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/components/payments/PaywallModal.tsx
+++ b/apps/web/components/payments/PaywallModal.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 // ============================================================================
-// מודל Paywall (תשלום)
+// Paywall modal
 // ============================================================================
-// המודל הזה מציג למשתמש 3 תוכניות (חינם/חודשי/שנתי) בעיצוב דומה לצילום.
+// Shows three plan cards (Free / Monthly / Yearly).
 //
-// התנהגות:
-// - בחירת "חינם" תאפשר להמשיך בלי Checkout.
-// - בחירת תוכנית בתשלום תנסה לבצע Redirect ל-Polar Checkout.
-// - אם מערכת התשלומים עדיין כבויה או חסרים Product IDs, נציג הודעת Preview.
+// Behaviour:
+// - Choosing "Free" closes the modal without a checkout call.
+// - Choosing a paid plan redirects to Polar Checkout.
+// - If the payments system is off or product IDs are missing, we show a preview message.
 
-import { Check, ChevronRight } from "lucide-react";
+import { Check, ChevronLeft } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
@@ -32,19 +32,19 @@ export type PaywallPlanId = "free" | "monthly" | "yearly";
 type PaywallModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  // מאפשר למצב בדיקה "להעלות" את המשתמש ל-paid בלי Polar
+  // Mock upgrade hook — lets the dev console bump a user to `paid` without Polar.
   onMockUpgradeToPaid?: () => Promise<void> | void;
-  // מאפשר פתיחה במצב Preview (מטרת דיבאג)
+  // Preview mode (for the debug console).
   preview?: boolean;
 };
 
-const FEATURES_FREE: string[] = ["תכונה בסיסית אחת (להתחלה)"];
+const FEATURES_FREE: string[] = ["One starter feature to begin with"];
 
 const FEATURES_PAID: string[] = [
-  "שיחות והתראות",
-  "אפליקציות iOS ו-Android",
-  "10+ סוגי ניטור",
-  "מדיניות הסלמה ותורנות",
+  "Calls and smart alerts",
+  "iOS and Android apps",
+  "10+ kinds of check-ins",
+  "Escalation rules and on-call rotations",
 ];
 
 function getPolarProductId(plan: PaywallPlanId): string {
@@ -69,7 +69,6 @@ export default function PaywallModal({
 
   const isPreviewMode = Boolean(preview && IS_DEV_MODE);
 
-  // פונקציה לחזרה לעמוד הקודם
   const handleBack = () => {
     onOpenChange(false);
     router.back();
@@ -77,27 +76,24 @@ export default function PaywallModal({
 
   const continueLabel = useMemo(() => {
     if (selectedPlan === "free") {
-      return "המשך בחינם";
+      return "Continue for free";
     }
-    return "המשך";
+    return "Continue";
   }, [selectedPlan]);
 
   const handleContinue = async () => {
     setError("");
 
-    // בחירה בחינם = לא מבצעים checkout
     if (selectedPlan === "free") {
       onOpenChange(false);
       return;
     }
 
-    // מצב Preview או מערכת תשלומים כבויה
     if (isPreviewMode || !PAYMENT_SYSTEM_ENABLED) {
       setError(
-        "מצב תצוגה מקדימה: מערכת התשלומים כבויה כרגע. ניתן להפעיל אותה דרך appConfig.ts לאחר הגדרה מלאה."
+        "Preview mode: payments are currently disabled. Flip the flag in appConfig.ts once everything is configured.",
       );
 
-      // אם רוצים לבדוק "שדרוג" בלי Polar
       if (MOCK_PAYMENTS && onMockUpgradeToPaid) {
         await onMockUpgradeToPaid();
         onOpenChange(false);
@@ -106,16 +102,14 @@ export default function PaywallModal({
       return;
     }
 
-    // מערכת תשלומים פעילה — חייבים Product ID
     const productId = getPolarProductId(selectedPlan);
     if (!productId) {
       setError(
-        "לא הוגדרו מזהי מוצרים (Product IDs) ב-Polar עבור התוכנית שנבחרה. הגדר NEXT_PUBLIC_POLAR_MONTHLY_PRODUCT_ID / NEXT_PUBLIC_POLAR_YEARLY_PRODUCT_ID."
+        "No Polar product IDs configured for that plan. Set NEXT_PUBLIC_POLAR_MONTHLY_PRODUCT_ID / NEXT_PUBLIC_POLAR_YEARLY_PRODUCT_ID first.",
       );
       return;
     }
 
-    // Redirect ל-Polar Checkout דרך השרת
     const checkoutUrl = new URL("/checkout", window.location.origin);
     checkoutUrl.searchParams.set("products", productId);
     window.location.href = checkoutUrl.toString();
@@ -123,35 +117,33 @@ export default function PaywallModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      {/* הסתרת כפתור X ברירת מחדל - מוצג רק במצב Preview */}
       <DialogContent
         className="sm:max-w-3xl bg-linear-to-br from-gray-900 via-gray-800 to-black border-gray-700 p-0"
         hideCloseButton={!isPreviewMode}
       >
-        <div className="rounded-2xl bg-gray-900/40 backdrop-blur-sm p-6" dir="rtl">
+        <div className="rounded-2xl bg-gray-900/40 backdrop-blur-sm p-6">
           <DialogHeader className="mb-6">
             <div className="flex items-center justify-between">
-              {/* כפתור חזרה - מחזיר לעמוד הקודם */}
               <button
                 type="button"
                 onClick={handleBack}
                 className="flex items-center gap-1 text-gray-400 hover:text-gray-200 transition"
-                aria-label="חזור"
+                aria-label="Back"
               >
-                <ChevronRight className="h-5 w-5" />
-                <span className="text-sm">חזור</span>
+                <ChevronLeft className="h-5 w-5" />
+                <span className="text-sm">Back</span>
               </button>
               <DialogTitle className="text-3xl font-bold text-white text-center flex-1">
-                בחר תוכנית לצוות שלך
+                Pick a plan
               </DialogTitle>
-              {/* ריווח לאיזון הכותרת */}
               <div className="w-16" />
             </div>
-            <p className="text-gray-400 text-center mt-2">תוכל לשדרג בכל עת. בטל מתי שתרצה.</p>
+            <p className="text-gray-400 text-center mt-2">
+              Upgrade anytime. Cancel whenever — no hard feelings.
+            </p>
           </DialogHeader>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {/* חינם */}
             <PlanCard
               planId="free"
               title={PLAN_DISPLAY.free.title}
@@ -161,7 +153,6 @@ export default function PaywallModal({
               features={FEATURES_FREE}
             />
 
-            {/* חודשי */}
             <PlanCard
               planId="monthly"
               title={PLAN_DISPLAY.monthly.title}
@@ -172,7 +163,6 @@ export default function PaywallModal({
               features={FEATURES_PAID}
             />
 
-            {/* שנתי */}
             <PlanCard
               planId="yearly"
               title={PLAN_DISPLAY.yearly.title}
@@ -187,7 +177,7 @@ export default function PaywallModal({
 
           {isPreviewMode && (
             <div className="mt-5 rounded-lg border border-yellow-500/40 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-200">
-              מצב תצוגה מקדימה פעיל — רכישות מושבתות
+              Preview mode is active — purchases are disabled.
             </div>
           )}
 
@@ -207,11 +197,10 @@ export default function PaywallModal({
             </button>
 
             <p className="mt-3 text-center text-xs text-gray-500">
-              המשך עם התחייבות להחזר כספי (דוגמה). את הטקסט הזה אפשר לשנות לפי הצורך.
+              Plans renew at the end of each period. Change your mind? Cancel in Settings at any time.
             </p>
           </div>
 
-          {/* קישורים תחתונים */}
           <div className="mt-6 flex items-center justify-center gap-6 text-sm">
             <Link
               href={TERMS_URL}
@@ -219,7 +208,7 @@ export default function PaywallModal({
               rel="noopener noreferrer"
               className="text-gray-500 hover:text-gray-300 transition-colors"
             >
-              תנאי שימוש
+              Terms of use
             </Link>
             <span className="text-gray-600">•</span>
             <Link
@@ -228,7 +217,7 @@ export default function PaywallModal({
               rel="noopener noreferrer"
               className="text-gray-500 hover:text-gray-300 transition-colors"
             >
-              פרטיות
+              Privacy
             </Link>
           </div>
         </div>
@@ -265,22 +254,21 @@ function PlanCard({
       type="button"
       onClick={() => onSelect(planId)}
       className={cn(
-        "relative rounded-2xl border bg-gray-900/40 p-5 text-right transition",
+        "relative rounded-2xl border bg-gray-900/40 p-5 text-left transition",
         "hover:bg-gray-900/55",
-        isSelected ? "border-orange-500/80 ring-1 ring-orange-500/30" : "border-gray-700"
+        isSelected ? "border-orange-500/80 ring-1 ring-orange-500/30" : "border-gray-700",
       )}
     >
       {isRecommended && (
-        <div className="absolute -top-3 right-4 rounded-full bg-orange-500 px-3 py-1 text-xs font-bold text-white">
-          מומלץ
+        <div className="absolute -top-3 left-4 rounded-full bg-orange-500 px-3 py-1 text-xs font-bold text-white">
+          Recommended
         </div>
       )}
 
-      {/* אינדיקטור בחירה */}
       <div
         className={cn(
-          "absolute left-4 top-4 flex h-6 w-6 items-center justify-center rounded-full border",
-          isSelected ? "border-orange-500 bg-orange-500" : "border-gray-600"
+          "absolute right-4 top-4 flex h-6 w-6 items-center justify-center rounded-full border",
+          isSelected ? "border-orange-500 bg-orange-500" : "border-gray-600",
         )}
         aria-hidden="true"
       >

--- a/apps/web/components/payments/PremiumGate.tsx
+++ b/apps/web/components/payments/PremiumGate.tsx
@@ -3,15 +3,14 @@
 // ============================================================================
 // PremiumGate
 // ============================================================================
-// רכיב מעטפת שמאפשר "לנעול" תוכן למשתמשים חינמיים.
+// Wrapper that locks content behind a paywall for free users.
 //
-// מתי נציג Paywall?
-// - PAYWALL_ENABLED דולק
-// - המשתמש מחובר
-// - המשתמש אינו בתשלום (userType !== 'paid')
+// Paywall opens when:
+// - PAYWALL_ENABLED is on
+// - The user is signed in
+// - The user is not on a paid plan (userType !== 'paid')
 //
-// הערה:
-// - אם PAYWALL_ENABLED כבוי — אנחנו לא נפריע למשתמש ונציג את התוכן.
+// Note: if PAYWALL_ENABLED is off, we render the content without gating.
 
 import { useMutation, useQuery } from "convex/react";
 import { useEffect, useMemo, useState } from "react";
@@ -22,7 +21,7 @@ import { api } from "@/convex/_generated/api";
 
 type PremiumGateProps = {
   children: React.ReactNode;
-  // מאפשר Preview ידני (למשל מהדיבאג)
+  // Force preview mode (used by the dev console).
   forcePreview?: boolean;
 };
 
@@ -36,13 +35,13 @@ export default function PremiumGate({ children, forcePreview }: PremiumGateProps
     return user?.userType === "paid";
   }, [user?.userType]);
 
-  // פתיחה אוטומטית של Paywall כשהעמוד "נעול"
+  // Auto-open the paywall when the page is locked.
   useEffect(() => {
     if (!PAYWALL_ENABLED) {
       return;
     }
 
-    // forcePreview: לא תלוי בסטטוס משתמש (מטרת דיבאג)
+    // forcePreview: open regardless of user status (debug helper).
     if (forcePreview) {
       setPaywallOpen(true);
       return;
@@ -58,7 +57,7 @@ export default function PremiumGate({ children, forcePreview }: PremiumGateProps
       return;
     }
 
-    // מצב בדיקה: מאפשר לסמן את המשתמש כ-paid בלי Checkout אמיתי
+    // Dev-only: mark the user as paid without running checkout.
     await updateUserType({ userType: "paid" });
   };
 
@@ -66,17 +65,16 @@ export default function PremiumGate({ children, forcePreview }: PremiumGateProps
     return <>{children}</>;
   }
 
-  // אם המשתמש עדיין נטען, נמתין (לא נציג תוכן כדי למנוע "פלאש" של תוכן חינמי)
+  // Hold while the user is loading so free content doesn't flash.
   if (user === undefined) {
-    return <div className="min-h-[60vh]" />; // מצב טעינה
+    return <div className="min-h-[60vh]" />;
   }
 
-  // אם המשתמש לא מחובר, נציג את התוכן (ההגנה על נתיבים מתבצעת ב-middleware)
+  // Signed-out users see content — route protection happens in middleware.
   if (user === null) {
     return <>{children}</>;
   }
 
-  // אם המשתמש בתשלום, נציג את התוכן
   if (isPaid) {
     return <>{children}</>;
   }
@@ -90,7 +88,7 @@ export default function PremiumGate({ children, forcePreview }: PremiumGateProps
         preview={Boolean(forcePreview)}
       />
 
-      {/* במצב נעול אנחנו לא מציגים את התוכן מאחורי Paywall */}
+      {/* Content stays hidden behind the paywall until the user continues. */}
       <div className="min-h-[60vh]" />
     </>
   );

--- a/apps/web/components/providers/providers.tsx
+++ b/apps/web/components/providers/providers.tsx
@@ -4,15 +4,14 @@ import { ConvexAuthNextjsProvider } from "@convex-dev/auth/nextjs";
 import { ConvexReactClient } from "convex/react";
 import type React from "react";
 
-// אתחול לקוח Convex עם כתובת השרת
+// Initialise the Convex client with the deployment URL.
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 interface ProvidersProps {
   children: React.ReactNode;
 }
 
-// רכיב ספקים (Providers) העוטף את האפליקציה
-// מספק את הקונטקסט של Convex Auth לכל הרכיבים בתוך האפליקציה
+// Providers — wraps the app and supplies Convex Auth context to every child.
 export function Providers({ children }: ProvidersProps) {
   return <ConvexAuthNextjsProvider client={convex}>{children}</ConvexAuthNextjsProvider>;
 }

--- a/apps/web/components/tasks/TasksScreen.tsx
+++ b/apps/web/components/tasks/TasksScreen.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { CheckCircle2, Circle, Loader2, Plus } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { SoftCard } from "@/components/soft-editorial/SoftCard";
+import { Button } from "@/components/ui/button";
+import type { Id } from "@/convex/_generated/dataModel";
+import { api } from "@/convex/_generated/api";
+import { cn } from "@/lib/utils";
+
+type TaskStatus = "todo" | "in_progress" | "done" | "cancelled";
+type TaskPriority = "low" | "medium" | "high";
+
+type TaskRow = {
+  _id: Id<"tasks">;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+};
+
+const priorityClass: Record<TaskPriority, string> = {
+  high: "bg-destructive/10 text-destructive border-destructive/30",
+  medium: "bg-primary/10 text-primary border-primary/30",
+  low: "bg-muted text-muted-foreground border-border",
+};
+
+const priorityLabel: Record<TaskPriority, string> = {
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+const statusLabel: Record<TaskStatus, string> = {
+  todo: "To do",
+  in_progress: "In progress",
+  done: "Done",
+  cancelled: "Cancelled",
+};
+
+const statusClass: Record<TaskStatus, string> = {
+  todo: "bg-muted text-foreground border-border",
+  in_progress: "bg-primary/10 text-primary border-primary/30",
+  done: "bg-emerald-500/10 text-emerald-600 border-emerald-500/30 dark:text-emerald-300",
+  cancelled: "bg-muted text-muted-foreground border-border",
+};
+
+export function TasksScreen() {
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const tasks = useQuery(api.tasks.list, isAuthenticated ? {} : "skip");
+
+  if (isAuthLoading) {
+    return <TasksSkeleton />;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="container mx-auto max-w-4xl px-6 py-16 text-center">
+        <SoftCard className="mx-auto max-w-xl">
+          <h1 className="font-heading text-2xl font-semibold text-foreground">Sign in required</h1>
+          <p className="mt-3 text-muted-foreground">
+            Sign in to pick up your task list where you left off.
+          </p>
+          <Button asChild className="mt-6">
+            <Link href="/sign-in">Sign in</Link>
+          </Button>
+        </SoftCard>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-4xl px-6 py-12">
+      <header className="space-y-3 mb-8">
+        <p className="text-sm font-medium text-muted-foreground">Library</p>
+        <h1 className="font-heading text-4xl font-semibold tracking-tight text-foreground md:text-5xl">
+          Tasks
+        </h1>
+        <p className="max-w-2xl text-lg text-muted-foreground">
+          Everything on your plate — today, later, all of it. One small step at a time.
+        </p>
+      </header>
+
+      <TaskQuickAdd />
+
+      {tasks === undefined ? (
+        <div className="mt-8">
+          <TasksListSkeleton />
+        </div>
+      ) : tasks.length === 0 ? (
+        <section className="mt-8 rounded-3xl border border-dashed border-border bg-muted/30 px-6 py-12 text-center">
+          <p className="text-base text-foreground">No tasks yet. Add your first one above.</p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Starting tiny still counts — a single line is enough.
+          </p>
+        </section>
+      ) : (
+        <TaskList tasks={tasks} />
+      )}
+    </div>
+  );
+}
+
+function TaskQuickAdd() {
+  const createQuick = useMutation(api.tasks.createQuick);
+  const [title, setTitle] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [hint, setHint] = useState("");
+
+  const submit = async () => {
+    const trimmed = title.trim();
+    if (!trimmed) {
+      setHint("Add a few words so you know what this is.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setHint("");
+
+    try {
+      await createQuick({ title: trimmed });
+      setTitle("");
+    } catch {
+      setHint("Could not add that right now. Try again?");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-border/80 bg-card/70 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]">
+      <div className="mb-3">
+        <label htmlFor="tasks-quick-add" className="text-sm font-medium text-foreground">
+          Add a task
+        </label>
+        <p className="mt-1 text-sm text-muted-foreground">
+          No due date needed — just get it out of your head.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <input
+          id="tasks-quick-add"
+          type="text"
+          value={title}
+          onChange={(event) => {
+            setTitle(event.target.value);
+            if (hint) setHint("");
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              setTitle("");
+              setHint("");
+            }
+            if (event.key === "Enter" && !event.metaKey && !event.ctrlKey) {
+              event.preventDefault();
+              void submit();
+            }
+          }}
+          disabled={isSubmitting}
+          placeholder="Send invoice, book appointment, reply to Alex…"
+          className="min-h-12 flex-1 rounded-xl border border-border bg-background px-4 py-3 text-foreground shadow-[inset_0_1px_2px_rgba(0,0,0,0.06)] outline-none transition focus:ring-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-70"
+        />
+        <Button
+          type="button"
+          onClick={() => void submit()}
+          disabled={isSubmitting}
+          className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl px-5"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Adding…
+            </>
+          ) : (
+            <>
+              <Plus className="h-4 w-4" aria-hidden />
+              Add
+            </>
+          )}
+        </Button>
+      </div>
+
+      <div className="mt-2 min-h-5">
+        {hint ? <p className="text-sm text-muted-foreground">{hint}</p> : null}
+      </div>
+    </div>
+  );
+}
+
+function TaskList({ tasks }: { tasks: TaskRow[] }) {
+  const toggleCompletion = useMutation(api.tasks.toggleCompletion);
+  const active = tasks.filter((t) => t.status !== "done" && t.status !== "cancelled");
+  const done = tasks.filter((t) => t.status === "done");
+
+  return (
+    <section className="mt-8 space-y-8">
+      <div>
+        <div className="mb-3 flex items-baseline justify-between">
+          <h2 className="font-heading text-xl font-semibold text-foreground">
+            {active.length > 0 ? "Open" : "All caught up"}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {active.length} open · {done.length} done
+          </p>
+        </div>
+        <ul className="space-y-3">
+          {active.map((task) => (
+            <TaskItem
+              key={task._id}
+              task={task}
+              onToggle={() => void toggleCompletion({ taskId: task._id })}
+            />
+          ))}
+        </ul>
+      </div>
+
+      {done.length > 0 && (
+        <div>
+          <h2 className="mb-3 font-heading text-xl font-semibold text-muted-foreground">
+            Done today
+          </h2>
+          <ul className="space-y-3">
+            {done.map((task) => (
+              <TaskItem
+                key={task._id}
+                task={task}
+                onToggle={() => void toggleCompletion({ taskId: task._id })}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function TaskItem({ task, onToggle }: { task: TaskRow; onToggle: () => void }) {
+  const isDone = task.status === "done";
+
+  return (
+    <li
+      className={cn(
+        "rounded-2xl border border-border/80 bg-background/70 px-4 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition",
+        isDone && "opacity-75",
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <button
+          type="button"
+          onClick={onToggle}
+          className={cn(
+            "mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+            isDone
+              ? "border-primary bg-primary text-primary-foreground"
+              : "border-border bg-card text-muted-foreground",
+          )}
+          aria-label={isDone ? `Mark ${task.title} as not done` : `Mark ${task.title} complete`}
+        >
+          {isDone ? (
+            <CheckCircle2 className="h-4 w-4" aria-hidden />
+          ) : (
+            <Circle className="h-4 w-4" aria-hidden />
+          )}
+        </button>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p
+              className={cn(
+                "font-medium text-foreground",
+                isDone && "text-muted-foreground line-through",
+              )}
+            >
+              {task.title}
+            </p>
+            <span
+              className={cn(
+                "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold uppercase tracking-wide",
+                priorityClass[task.priority],
+              )}
+            >
+              {priorityLabel[task.priority]}
+            </span>
+            <span
+              className={cn(
+                "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium",
+                statusClass[task.status],
+              )}
+            >
+              {statusLabel[task.status]}
+            </span>
+          </div>
+
+          {task.description ? (
+            <p className="mt-1 text-sm text-muted-foreground">{task.description}</p>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function TasksSkeleton() {
+  return (
+    <div className="container mx-auto max-w-4xl px-6 py-12 space-y-6">
+      <div className="h-12 w-48 animate-pulse rounded-xl bg-muted" />
+      <div className="h-32 animate-pulse rounded-2xl bg-muted" />
+      <TasksListSkeleton />
+    </div>
+  );
+}
+
+function TasksListSkeleton() {
+  return (
+    <ul className="space-y-3">
+      {[0, 1, 2].map((i) => (
+        <li key={i} className="h-16 animate-pulse rounded-2xl bg-muted" />
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/components/tempo/MobileNav.tsx
+++ b/apps/web/components/tempo/MobileNav.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+import { BrandMark, Wordmark } from "@tempo/ui/brand";
+import { TempoIcon } from "@tempo/ui/icons";
+import { X } from "lucide-react";
+import {
+  CATEGORIES,
+  screensByCategory,
+  type TempoCategory,
+} from "@/lib/tempo-nav";
+
+type MobileNavProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+/**
+ * Mobile-only drawer that mirrors the desktop sidebar.
+ * Rendered from the TempoShell; hidden on lg+ where the fixed Sidebar takes over.
+ */
+export function MobileNav({ open, onClose }: MobileNavProps) {
+  const pathname = usePathname();
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  // Lock body scroll while open.
+  useEffect(() => {
+    if (!open) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex lg:hidden" role="dialog" aria-modal="true">
+      <button
+        type="button"
+        aria-label="Close navigation"
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      <aside className="relative ml-0 flex h-full w-72 max-w-[85vw] flex-col bg-background border-r border-border-soft shadow-xl">
+        <div className="flex items-center justify-between px-5 h-14 border-b border-border-soft">
+          <div className="flex items-center gap-2">
+            <BrandMark size={26} />
+            <Wordmark size={18} />
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close navigation"
+            className="flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground hover:bg-surface-sunken hover:text-foreground transition-colors"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <nav className="flex-1 overflow-y-auto scroll-subtle px-3 py-4 flex flex-col gap-6">
+          {CATEGORIES.map((cat: TempoCategory) => (
+            <div key={cat} className="flex flex-col gap-0.5">
+              <div className="font-eyebrow px-2 pb-1.5">{cat}</div>
+              {screensByCategory(cat).map((screen) => {
+                const Icon = screen.icon ? TempoIcon[screen.icon] : null;
+                const active =
+                  pathname === screen.route ||
+                  pathname?.startsWith(`${screen.route}/`);
+                return (
+                  <Link
+                    key={screen.slug}
+                    href={screen.route}
+                    onClick={onClose}
+                    className={[
+                      "flex items-center gap-2.5 px-2.5 py-2.5 rounded-md text-small transition-colors min-h-11",
+                      active
+                        ? "bg-surface-sunken text-foreground"
+                        : "text-muted-foreground hover:bg-surface-sunken hover:text-foreground",
+                    ].join(" ")}
+                  >
+                    {Icon ? <Icon size={16} /> : null}
+                    <span>{screen.title}</span>
+                  </Link>
+                );
+              })}
+            </div>
+          ))}
+        </nav>
+      </aside>
+    </div>
+  );
+}

--- a/apps/web/components/tempo/TempoShell.tsx
+++ b/apps/web/components/tempo/TempoShell.tsx
@@ -2,15 +2,17 @@
 
 import { useEffect, useState, type ReactNode } from "react";
 import { CommandPalette } from "./CommandPalette";
+import { MobileNav } from "./MobileNav";
 import { Sidebar } from "./Sidebar";
 import { Topbar } from "./Topbar";
 
 /**
  * TempoShell — wraps the (tempo) route group: sidebar + topbar + page.
- * Owns the ⌘K listener.
+ * Owns the ⌘K listener and the mobile-nav drawer state.
  */
 export function TempoShell({ children }: { children: ReactNode }) {
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -28,10 +30,14 @@ export function TempoShell({ children }: { children: ReactNode }) {
     <div className="flex min-h-screen bg-background text-foreground">
       <Sidebar />
       <div className="flex flex-1 flex-col min-w-0">
-        <Topbar onOpenPalette={() => setPaletteOpen(true)} />
+        <Topbar
+          onOpenPalette={() => setPaletteOpen(true)}
+          onOpenMobileNav={() => setMobileNavOpen(true)}
+        />
         <main className="flex-1 overflow-y-auto scroll-subtle">{children}</main>
       </div>
       <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+      <MobileNav open={mobileNavOpen} onClose={() => setMobileNavOpen(false)} />
     </div>
   );
 }

--- a/apps/web/components/tempo/Topbar.tsx
+++ b/apps/web/components/tempo/Topbar.tsx
@@ -2,18 +2,19 @@
 
 import { usePathname } from "next/navigation";
 import { findScreen, TEMPO_SCREENS } from "@/lib/tempo-nav";
-import { Command, Moon, Search, Sun } from "@tempo/ui/icons";
+import { Command, Menu, Moon, Search, Sun } from "@tempo/ui/icons";
 import { useTheme } from "@/components/providers/ThemeProvider";
 
 type Props = {
   onOpenPalette: () => void;
+  onOpenMobileNav: () => void;
 };
 
 /**
- * Topbar — breadcrumb, search shortcut, theme toggle, account.
+ * Topbar — breadcrumb, mobile-menu button, search shortcut, theme toggle.
  * @source docs/design/claude-export/design-system/components.jsx (Topbar)
  */
-export function Topbar({ onOpenPalette }: Props) {
+export function Topbar({ onOpenPalette, onOpenMobileNav }: Props) {
   const pathname = usePathname() ?? "/";
   const screen =
     TEMPO_SCREENS.find((s) => s.route === pathname) ??
@@ -24,7 +25,17 @@ export function Topbar({ onOpenPalette }: Props) {
 
   return (
     <header className="flex items-center h-14 px-5 border-b border-border-soft bg-background sticky top-0 z-10">
-      <h1 className="text-small font-medium text-foreground">
+      {/* Mobile menu button — hidden on lg+ where the sidebar is visible. */}
+      <button
+        type="button"
+        onClick={onOpenMobileNav}
+        aria-label="Open navigation"
+        className="mr-2 flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground hover:bg-surface-sunken hover:text-foreground transition-colors lg:hidden"
+      >
+        <Menu size={18} />
+      </button>
+
+      <h1 className="text-small font-medium text-foreground truncate">
         {screen?.title ?? "Tempo Flow"}
       </h1>
 
@@ -48,7 +59,7 @@ export function Topbar({ onOpenPalette }: Props) {
           type="button"
           onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
           aria-label={`Switch to ${resolvedTheme === "dark" ? "light" : "dark"} mode`}
-          className="flex items-center justify-center w-8 h-8 rounded-md text-muted-foreground hover:bg-surface-sunken hover:text-foreground transition-colors"
+          className="flex items-center justify-center w-10 h-10 rounded-md text-muted-foreground hover:bg-surface-sunken hover:text-foreground transition-colors"
         >
           {resolvedTheme === "dark" ? <Sun size={16} /> : <Moon size={16} />}
         </button>

--- a/apps/web/components/today/TodayGreeting.tsx
+++ b/apps/web/components/today/TodayGreeting.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+type TodayGreetingProps = {
+  greetingName: string | undefined;
+};
+
+export function TodayGreeting({ greetingName }: TodayGreetingProps) {
+  const safeName = greetingName?.trim() || "there";
+
+  return (
+    <header className="space-y-3">
+      <p className="text-sm font-medium text-muted-foreground">Today</p>
+      <h1
+        aria-live="polite"
+        className={cn(
+          "font-heading text-4xl font-semibold tracking-tight text-foreground md:text-5xl",
+        )}
+      >
+        Hi, <span className="text-gradient-primary">{safeName}</span>
+      </h1>
+      <p className="max-w-2xl text-lg text-muted-foreground">
+        One calm screen to start from. A single small step is enough for now.
+      </p>
+    </header>
+  );
+}

--- a/apps/web/components/today/TodayQuickAdd.tsx
+++ b/apps/web/components/today/TodayQuickAdd.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useMutation } from "convex/react";
+import { Loader2, Plus } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { api } from "@/convex/_generated/api";
+
+type TodayQuickAddProps = {
+  /** Any timestamp inside the current local calendar day; used so the task shows in Today immediately. */
+  dueAt: number;
+};
+
+export function TodayQuickAdd({ dueAt }: TodayQuickAddProps) {
+  const createQuick = useMutation(api.tasks.createQuick);
+  const [title, setTitle] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [hint, setHint] = useState("");
+
+  const inputId = useMemo(() => "today-quick-add", []);
+
+  const submit = async () => {
+    const trimmed = title.trim();
+    if (!trimmed) {
+      setHint("Add a few words so you know what this is.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setHint("");
+
+    try {
+      await createQuick({
+        title: trimmed,
+        dueAt,
+      });
+      setTitle("");
+    } catch {
+      setHint("Could not add that right now. Try again?");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-border/80 bg-card/70 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]">
+      <div className="mb-3">
+        <label htmlFor={inputId} className="text-sm font-medium text-foreground">
+          Add something small for today
+        </label>
+        <p className="mt-1 text-sm text-muted-foreground">Starting tiny still counts.</p>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <input
+          id={inputId}
+          type="text"
+          value={title}
+          onChange={(event) => {
+            setTitle(event.target.value);
+            if (hint) setHint("");
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              setTitle("");
+              setHint("");
+            }
+            if (event.key === "Enter" && !event.metaKey && !event.ctrlKey) {
+              event.preventDefault();
+              void submit();
+            }
+          }}
+          disabled={isSubmitting}
+          placeholder="Reply to Sam, pay one bill, fold one shirt…"
+          className="min-h-12 flex-1 rounded-xl border border-border bg-background px-4 py-3 text-foreground shadow-[inset_0_1px_2px_rgba(0,0,0,0.06)] outline-none transition focus:ring-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-70"
+        />
+
+        <Button
+          type="button"
+          onClick={() => void submit()}
+          disabled={isSubmitting}
+          className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl px-5"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Adding…
+            </>
+          ) : (
+            <>
+              <Plus className="h-4 w-4" aria-hidden />
+              Add
+            </>
+          )}
+        </Button>
+      </div>
+
+      <div className="mt-2 min-h-5">
+        {hint ? <p className="text-sm text-muted-foreground">{hint}</p> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/today/TodayScreen.tsx
+++ b/apps/web/components/today/TodayScreen.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useConvexAuth, useQuery } from "convex/react";
+import Link from "next/link";
+import { useMemo } from "react";
+import { SoftCard } from "@/components/soft-editorial/SoftCard";
+import { Button } from "@/components/ui/button";
+import { api } from "@/convex/_generated/api";
+import { getLocalDayBoundsMs } from "@/lib/todayBounds";
+import { TodayGreeting } from "./TodayGreeting";
+import { TodayQuickAdd } from "./TodayQuickAdd";
+import { TodayTaskList } from "./TodayTaskList";
+
+export function TodayScreen() {
+  const bounds = useMemo(() => getLocalDayBoundsMs(), []);
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const profile = useQuery(api.users.getProfile, isAuthenticated ? {} : "skip");
+  const todayTasks = useQuery(api.tasks.listToday, isAuthenticated ? bounds : "skip");
+
+  const isLoading =
+    isAuthLoading ||
+    (isAuthenticated && (profile === undefined || todayTasks === undefined));
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto max-w-5xl px-6 py-12">
+        <div className="space-y-6">
+          <div className="h-12 w-64 animate-pulse rounded-xl bg-muted" />
+          <div className="h-32 animate-pulse rounded-2xl bg-muted" />
+          <div className="h-64 animate-pulse rounded-2xl bg-muted" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated || !profile || !todayTasks) {
+    return (
+      <div className="container mx-auto max-w-5xl px-6 py-16 text-center">
+        <SoftCard className="mx-auto max-w-xl">
+          <h1 className="font-heading text-2xl font-semibold text-foreground">Sign in required</h1>
+          <p className="mt-3 text-muted-foreground">
+            We could not load your session. Sign in again to pick up where you left off.
+          </p>
+          <Button asChild className="mt-6">
+            <Link href="/sign-in">Sign in</Link>
+          </Button>
+        </SoftCard>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-5xl px-6 py-12">
+      <div className="space-y-8">
+        <TodayGreeting greetingName={profile.greetingName} />
+        <TodayQuickAdd dueAt={bounds.endMs - 1} />
+        <TodayTaskList tasks={todayTasks} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/today/TodayScreen.tsx
+++ b/apps/web/components/today/TodayScreen.tsx
@@ -53,7 +53,7 @@ export function TodayScreen() {
     <div className="container mx-auto max-w-5xl px-6 py-12">
       <div className="space-y-8">
         <TodayGreeting greetingName={profile.greetingName} />
-        <TodayQuickAdd dueAt={bounds.endMs - 1} />
+        <TodayQuickAdd dueAt={bounds.dueTo - 1} />
         <TodayTaskList tasks={todayTasks} />
       </div>
     </div>

--- a/apps/web/components/today/TodayTaskList.tsx
+++ b/apps/web/components/today/TodayTaskList.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import type { Id } from "@/convex/_generated/dataModel";
+import { useMutation } from "convex/react";
+import { CheckCircle2, Circle, ListTodo } from "lucide-react";
+import { api } from "@/convex/_generated/api";
+import { cn } from "@/lib/utils";
+
+type TodayTask = {
+  _id: Id<"tasks">;
+  title: string;
+  description?: string;
+  status: "todo" | "in_progress" | "done" | "cancelled";
+  priority: "low" | "medium" | "high";
+};
+
+type TodayTaskListProps = {
+  tasks: TodayTask[];
+};
+
+const priorityClass: Record<TodayTask["priority"], string> = {
+  high: "text-destructive",
+  medium: "text-primary",
+  low: "text-muted-foreground",
+};
+
+const priorityLabel: Record<TodayTask["priority"], string> = {
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+export function TodayTaskList({ tasks }: TodayTaskListProps) {
+  const toggleCompletion = useMutation(api.tasks.toggleCompletion);
+
+  const activeTasks = tasks.filter((task) => task.status !== "done");
+
+  return (
+    <section
+      className="rounded-3xl border border-border/80 bg-card/90 p-6 shadow-[0_10px_30px_rgba(26,25,23,0.08)]"
+      aria-labelledby="today-task-list-heading"
+    >
+      <div className="mb-6 flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-linear-to-br from-[#D97757] to-[#E8A87C] text-primary-foreground shadow-inner">
+          <ListTodo className="h-5 w-5" aria-hidden />
+        </div>
+        <div>
+          <h2
+            id="today-task-list-heading"
+            className="font-heading text-2xl font-semibold text-foreground"
+          >
+            Today
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {tasks.length === 0
+              ? "Nothing on the plan yet."
+              : `${activeTasks.length} still open today.`}
+          </p>
+        </div>
+      </div>
+
+      {tasks.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-border bg-muted/30 px-5 py-10 text-center">
+          <p className="text-base text-foreground">Nothing on the plan yet. Want to add one?</p>
+          <p className="mt-2 text-sm text-muted-foreground">A small next step is enough.</p>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {tasks.map((task) => {
+            const isDone = task.status === "done";
+
+            return (
+              <li
+                key={task._id}
+                className={cn(
+                  "rounded-2xl border border-border/80 bg-background/70 px-4 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] transition",
+                  isDone && "opacity-75",
+                )}
+              >
+                <div className="flex items-start gap-3">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void toggleCompletion({ taskId: task._id });
+                    }}
+                    className={cn(
+                      "mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+                      isDone
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border bg-card text-muted-foreground",
+                    )}
+                    aria-label={
+                      isDone ? `Mark ${task.title} as not done` : `Mark ${task.title} complete`
+                    }
+                  >
+                    {isDone ? (
+                      <CheckCircle2 className="h-4 w-4" aria-hidden />
+                    ) : (
+                      <Circle className="h-4 w-4" aria-hidden />
+                    )}
+                  </button>
+
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p
+                        className={cn(
+                          "font-medium text-foreground",
+                          isDone && "text-muted-foreground line-through",
+                        )}
+                      >
+                        {task.title}
+                      </p>
+                      <span
+                        className={cn(
+                          "text-xs font-semibold uppercase tracking-wide",
+                          priorityClass[task.priority],
+                        )}
+                      >
+                        {priorityLabel[task.priority]}
+                      </span>
+                    </div>
+
+                    {task.description ? (
+                      <p className="mt-1 text-sm text-muted-foreground">{task.description}</p>
+                    ) : null}
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -28,7 +28,7 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-// הוספת אפשרות להסתיר את כפתור הסגירה הברירת-מחדלי
+// Adds the option to hide the default close button.
 type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
   hideCloseButton?: boolean;
 };

--- a/apps/web/config/appConfig.ts
+++ b/apps/web/config/appConfig.ts
@@ -1,57 +1,57 @@
 // ============================================================================
-// קונפיגורציית האפליקציה (Web)
+// App configuration (Web)
 // ============================================================================
-// קובץ קונפיגורציה מרכזי שמאפשר לשלוט בהתנהגות האפליקציה דרך דגלים.
-// המטרה: לאפשר להדליק/לכבות פיצ'רים (כמו Paywall ותשלומים) בצורה בטוחה.
+// Central config file that governs app behaviour through feature flags.
+// Goal: safely turn features (e.g. Paywall, payments) on or off.
 //
-// חשוב:
-// - אל תתן לאוטומציה לשנות ערכים "קריטיים" בלי פעולה מכוונת.
-// - שמור על שמות ברורים כדי שמפתחים ימצאו מהר את מה שהם מחפשים.
+// Important:
+// - Do not let automation change "critical" values without an intentional action.
+// - Keep names explicit so developers can find what they need quickly.
 
 // ============================================================================
-// מצב סביבה
+// Environment mode
 // ============================================================================
 
-// 🚨 קריטי: דגל זה מכריח מצב ייצור (Production)
-// ⚠️ אל תתן לאוטומציה לשנות את זה
-// 👤 נדרשת פעולת משתמש: הגדר ידנית ל-true/false לפי הצורך
+// 🚨 CRITICAL: forces production mode when true.
+// ⚠️ Do not let automation change this.
+// 👤 User action required: set manually to true/false as needed.
 export const FORCE_PROD_MODE = false;
 
-// דגל מצב פיתוח נגזר - מכבד את דריסת FORCE_PROD_MODE
+// Derived dev-mode flag — respects the FORCE_PROD_MODE override above.
 export const IS_DEV_MODE = FORCE_PROD_MODE ? false : process.env.NODE_ENV !== "production";
 
-// סוג סביבת האפליקציה
+// App environment type.
 export type AppEnv = "dev" | "prod";
 
-// סביבת האפליקציה הנוכחית
+// Current app environment.
 export const APP_ENV: AppEnv = IS_DEV_MODE ? "dev" : "prod";
 
 // ============================================================================
-// Paywall (מסך תשלום) ותשלומים
+// Paywall + payments
 // ============================================================================
 
-// 🚨 קריטי: דגל זה קובע האם ה-Paywall פעיל (נעילת עמודים והצגת מודל תשלום)
-// אם false: עמודים נעולים יוצגו רגיל (ללא Paywall)
-// אם true: Paywall יוצג למשתמשים חינמיים, והתנהגות התשלום תיקבע לפי הדגלים למטה
+// 🚨 CRITICAL: controls whether the paywall is active (locked pages + checkout modal).
+// false → locked pages render normally (no paywall).
+// true  → free users see the paywall; checkout behaviour follows the flags below.
 export const PAYWALL_ENABLED = true;
 
-// דגל תשלומים מדומים (רק לפיתוח)
-// אם true: לחיצה על "המשך" בתוכנית בתשלום תדמה שדרוג ל"בתשלום" בלי Polar Checkout
-// אם false: לחיצה על "המשך" תנסה לבצע Redirect ל-Polar Checkout (אם PAYMENT_SYSTEM_ENABLED דולק)
+// Mock-payments flag (development only).
+// true  → clicking "Continue" on a paid plan simulates an upgrade without Polar Checkout.
+// false → clicking "Continue" redirects to Polar Checkout (if PAYMENT_SYSTEM_ENABLED is on).
 export const MOCK_PAYMENTS = true;
 
-// 🚨 קריטי: דגל זה קובע האם מערכת התשלומים האמיתית פעילה
-// אם false: לחיצה על "המשך" תציג הודעת Preview (או תדמה שדרוג אם MOCK_PAYMENTS דולק)
-// אם true: לחיצה על "המשך" תבצע Redirect ל-Polar Checkout (דורש הגדרת Product IDs)
-// הערה: Paywall יוצג בכל מקרה אם PAYWALL_ENABLED דולק - הדגל הזה רק קובע מה קורה בלחיצה
+// 🚨 CRITICAL: controls whether the real payment system is active.
+// false → clicking "Continue" shows a Preview message (or mocks an upgrade if MOCK_PAYMENTS is on).
+// true  → clicking "Continue" redirects to Polar Checkout (requires Product IDs).
+// Note: the paywall still renders whenever PAYWALL_ENABLED is on — this flag only controls click behaviour.
 export const PAYMENT_SYSTEM_ENABLED = false;
 
 // ============================================================================
-// קישורי תנאי שימוש ומדיניות פרטיות
+// Terms & Privacy links
 // ============================================================================
 
-// 👤 נדרשת פעולת משתמש: עדכן את הקישורים לדפי תנאי השימוש ומדיניות הפרטיות שלך
-// הקישורים צריכים להוביל לדפי Landing Page שלך או לדפים באפליקציה
+// 👤 User action required: point these at your real Terms / Privacy pages.
+// They can resolve to landing-page URLs or internal app routes.
 export const TERMS_URL = process.env.NEXT_PUBLIC_TERMS_URL || "/terms";
 export const PRIVACY_URL = process.env.NEXT_PUBLIC_PRIVACY_URL || "/privacy";
 export const APP_NAME = "Tempo Rhythm";

--- a/apps/web/config/planDisplay.ts
+++ b/apps/web/config/planDisplay.ts
@@ -1,22 +1,22 @@
 // ============================================================================
-// טקסטים לתצוגת תוכניות (Paywall)
+// Plan display strings (Paywall)
 // ============================================================================
-// קובץ זה מכיל את הטקסטים והמחירים לתצוגה בלבד עבור תוכניות התשלום.
-// הערה: המחיר בפועל נקבע ב-Polar Dashboard, הטקסט כאן הוא רק לתצוגה.
+// Display-only copy and pricing for the paid plans.
+// Note: the real price is set in the Polar dashboard; this is purely cosmetic.
 
 export const PLAN_DISPLAY = {
   free: {
-    title: "חינם",
-    subtitle: "כל מה שצריך כדי להתחיל",
+    title: "Free",
+    subtitle: "Everything you need to start.",
   },
   monthly: {
-    title: "חודשי",
-    priceLine: "₪29",
-    subtitle: "למשתמש לחודש",
+    title: "Monthly",
+    priceLine: "$9",
+    subtitle: "per user / month",
   },
   yearly: {
-    title: "שנתי",
-    priceLine: "₪290",
-    subtitle: "למשתמש לשנה",
+    title: "Yearly",
+    priceLine: "$90",
+    subtitle: "per user / year",
   },
 } as const;

--- a/apps/web/config/polarConfig.ts
+++ b/apps/web/config/polarConfig.ts
@@ -1,14 +1,13 @@
 // ============================================================================
-// קונפיגורציית Polar (Checkout)
+// Polar (Checkout) configuration
 // ============================================================================
-// קובץ זה מכיל את כל ההגדרות הקשורות ל-Polar Checkout.
-// מזהי מוצרים, סביבת עבודה, וכו'.
+// All settings related to Polar Checkout: product IDs, environment, etc.
 
-// סביבת Polar: sandbox לבדיקות, production לייצור
+// Polar environment: sandbox for testing, production for live.
 export const POLAR_SERVER: "sandbox" | "production" = "sandbox";
 
-// מזהי מוצר (Product IDs) ב-Polar עבור תוכניות בתשלום
-// מומלץ להגדיר דרך משתני סביבה ולהשאיר כאן fallback ריק.
+// Polar product IDs for paid plans.
+// Prefer setting these via environment variables; leave the fallback empty.
 export const POLAR_MONTHLY_PRODUCT_ID = process.env.NEXT_PUBLIC_POLAR_MONTHLY_PRODUCT_ID || "";
 
 export const POLAR_YEARLY_PRODUCT_ID = process.env.NEXT_PUBLIC_POLAR_YEARLY_PRODUCT_ID || "";

--- a/apps/web/lib/localDay.ts
+++ b/apps/web/lib/localDay.ts
@@ -1,3 +1,8 @@
+/**
+ * Local calendar-day helpers. These respect the user's browser timezone so
+ * "today" means the user's local today, not UTC.
+ */
+
 /** Start of local calendar day (ms). */
 export function startOfLocalDayMs(d = new Date()): number {
   const x = new Date(d);
@@ -20,6 +25,19 @@ export function startOfLocalWeekMondayMs(d = new Date()): number {
   return x.getTime();
 }
 
-export function endOfLocalWeekMondayMs(d = new Date()): number {
-  return startOfLocalWeekMondayMs(d) + 7 * 24 * 60 * 60 * 1000;
+/** YYYY-MM-DD string for the given local date (default: now). */
+export function getLocalDateKey(d = new Date()): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/** Human-friendly heading for a date — e.g. "Wednesday, April 22". */
+export function formatLongDate(d = new Date()): string {
+  return d.toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
 }

--- a/apps/web/lib/todayBounds.ts
+++ b/apps/web/lib/todayBounds.ts
@@ -1,6 +1,8 @@
-/** Start/end of the local calendar day as Unix ms; `endMs` is exclusive. */
-export function getLocalDayBoundsMs(d = new Date()): { startMs: number; endMs: number } {
+/**
+ * Start/end of the local calendar day as Unix ms; `dueTo` is exclusive.
+ * Shape matches `api.tasks.listToday` args (`{ dueFrom, dueTo }`).
+ */
+export function getLocalDayBoundsMs(d = new Date()): { dueFrom: number; dueTo: number } {
   const start = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-  const end = start + 24 * 60 * 60 * 1000;
-  return { startMs: start, endMs: end };
+  return { dueFrom: start, dueTo: start + 86_400_000 };
 }

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,8 +1,8 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-// פונקציית עזר למיזוג מחלקות CSS/Tailwind
-// משלבת את clsx (לניהול תנאים) ו-tailwind-merge (למניעת התנגשויות)
+// Helper for merging CSS / Tailwind class names.
+// Combines clsx (conditional classes) with tailwind-merge (conflict resolution).
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,8 +44,6 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.4.22",
-    "eslint": "^9.39.2",
-    "eslint-plugin-tailwind-canonical-classes": "^1.0.8",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -5,7 +5,6 @@ import {
 } from "@convex-dev/auth/nextjs/server";
 import type { NextRequest } from "next/server";
 
-// הגדרת נתיבים ציבוריים (שלא דורשים אימות)
 const isPublicRoute = createRouteMatcher([
   "/",
   "/sign-in",
@@ -16,23 +15,25 @@ const isPublicRoute = createRouteMatcher([
   "/success",
 ]);
 
-// Middleware לבדיקת אימות והפניות
 export default convexAuthNextjsMiddleware(async (request: NextRequest, ctx) => {
   const { convexAuth } = ctx;
+  let isAuthenticated = false;
+  try {
+    isAuthenticated = await convexAuth.isAuthenticated();
+  } catch {
+    isAuthenticated = false;
+  }
 
-  // אם הנתיב אינו ציבורי והמשתמש לא מחובר -> הפניה לדף התחברות
-  if (!(isPublicRoute(request) || (await convexAuth.isAuthenticated()))) {
+  if (!(isPublicRoute(request) || isAuthenticated)) {
     return nextjsMiddlewareRedirect(request, "/sign-in");
   }
 
-  // אופציונלי: הפניה של משתמשים מחוברים מדפי אימות
-  if (isPublicRoute(request) && (await convexAuth.isAuthenticated())) {
-    // return nextjsMiddlewareRedirect(request, "/");
+  if (isPublicRoute(request) && isAuthenticated) {
+    // Optional: redirect signed-in users away from marketing/auth-only routes.
   }
 });
 
 export const config = {
-  // הגדרת ה-Matcher כדי שה-Middleware ירוץ על כל הנתיבים הרלוונטיים
   matcher: [
     "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
     "/(api|trpc)(.*)",

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
         "@types/node": "^20.19.0",
+        "playwright": "^1.59.1",
         "turbo": "^2.3.3",
       },
     },
@@ -1094,7 +1095,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1415,6 +1416,10 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
@@ -1888,6 +1893,8 @@
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -1925,6 +1932,8 @@
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -97,13 +97,15 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "autoprefixer": "^10.4.22",
-        "eslint": "^9.39.2",
-        "eslint-plugin-tailwind-canonical-classes": "^1.0.8",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
         "ultracite": "6.3.10",
       },
+    },
+    "packages/config": {
+      "name": "@tempo/config",
+      "version": "0.0.1",
     },
     "packages/types": {
       "name": "@tempo/types",
@@ -404,24 +406,6 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
 
-    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
-
-    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
-
-    "@eslint/config-array": ["@eslint/config-array@0.21.2", "", { "dependencies": { "@eslint/object-schema": "^2.1.7", "debug": "^4.3.1", "minimatch": "^3.1.5" } }, "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw=="],
-
-    "@eslint/config-helpers": ["@eslint/config-helpers@0.4.2", "", { "dependencies": { "@eslint/core": "^0.17.0" } }, "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw=="],
-
-    "@eslint/core": ["@eslint/core@0.17.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ=="],
-
-    "@eslint/eslintrc": ["@eslint/eslintrc@3.3.5", "", { "dependencies": { "ajv": "^6.14.0", "debug": "^4.3.2", "espree": "^10.0.1", "globals": "^14.0.0", "ignore": "^5.2.0", "import-fresh": "^3.2.1", "js-yaml": "^4.1.1", "minimatch": "^3.1.5", "strip-json-comments": "^3.1.1" } }, "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg=="],
-
-    "@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
-
-    "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
-
-    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
-
     "@expo/cli": ["@expo/cli@54.0.23", "", { "dependencies": { "@0no-co/graphql.web": "^1.0.8", "@expo/code-signing-certificates": "^0.0.6", "@expo/config": "~12.0.13", "@expo/config-plugins": "~54.0.4", "@expo/devcert": "^1.2.1", "@expo/env": "~2.0.8", "@expo/image-utils": "^0.8.8", "@expo/json-file": "^10.0.8", "@expo/metro": "~54.2.0", "@expo/metro-config": "~54.0.14", "@expo/osascript": "^2.3.8", "@expo/package-manager": "^1.9.10", "@expo/plist": "^0.4.8", "@expo/prebuild-config": "^54.0.8", "@expo/schema-utils": "^0.1.8", "@expo/spawn-async": "^1.7.2", "@expo/ws-tunnel": "^1.0.1", "@expo/xcpretty": "^4.3.0", "@react-native/dev-middleware": "0.81.5", "@urql/core": "^5.0.6", "@urql/exchange-retry": "^1.3.0", "accepts": "^1.3.8", "arg": "^5.0.2", "better-opn": "~3.0.2", "bplist-creator": "0.1.0", "bplist-parser": "^0.3.1", "chalk": "^4.0.0", "ci-info": "^3.3.0", "compression": "^1.7.4", "connect": "^3.7.0", "debug": "^4.3.4", "env-editor": "^0.4.1", "expo-server": "^1.0.5", "freeport-async": "^2.0.0", "getenv": "^2.0.0", "glob": "^13.0.0", "lan-network": "^0.1.6", "minimatch": "^9.0.0", "node-forge": "^1.3.3", "npm-package-arg": "^11.0.0", "ora": "^3.4.0", "picomatch": "^3.0.1", "pretty-bytes": "^5.6.0", "pretty-format": "^29.7.0", "progress": "^2.0.3", "prompts": "^2.3.2", "qrcode-terminal": "0.11.0", "require-from-string": "^2.0.2", "requireg": "^0.2.2", "resolve": "^1.22.2", "resolve-from": "^5.0.0", "resolve.exports": "^2.0.3", "semver": "^7.6.0", "send": "^0.19.0", "slugify": "^1.3.4", "source-map-support": "~0.5.21", "stacktrace-parser": "^0.1.10", "structured-headers": "^0.4.1", "tar": "^7.5.2", "terminal-link": "^2.1.1", "undici": "^6.18.2", "wrap-ansi": "^7.0.0", "ws": "^8.12.1" }, "peerDependencies": { "expo": "*", "expo-router": "*", "react-native": "*" }, "optionalPeers": ["expo-router", "react-native"], "bin": { "expo-internal": "build/bin/cli" } }, "sha512-km0h72SFfQCmVycH/JtPFTVy69w6Lx1cHNDmfLfQqgKFYeeHTjx7LVDP4POHCtNxFP2UeRazrygJhlh4zz498g=="],
 
     "@expo/code-signing-certificates": ["@expo/code-signing-certificates@0.0.6", "", { "dependencies": { "node-forge": "^1.3.3" } }, "sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w=="],
@@ -471,14 +455,6 @@
     "@expo/ws-tunnel": ["@expo/ws-tunnel@1.0.6", "", {}, "sha512-nDRbLmSrJar7abvUjp3smDwH8HcbZcoOEa5jVPUv9/9CajgmWw20JNRwTuBRzWIWIkEJDkz20GoNA+tSwUqk0Q=="],
 
     "@expo/xcpretty": ["@expo/xcpretty@4.4.1", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "chalk": "^4.1.0", "js-yaml": "^4.1.0" }, "bin": { "excpretty": "build/cli.js" } }, "sha512-KZNxZvnGCtiM2aYYZ6Wz0Ix5r47dAvpNLApFtZWnSoERzAdOMzVBOPysBoM0JlF6FKWZ8GPqgn6qt3dV/8Zlpg=="],
-
-    "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
-
-    "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
-
-    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
-
-    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -595,8 +571,6 @@
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
-
-    "@pkgr/core": ["@pkgr/core@0.1.2", "", {}, "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ=="],
 
     "@polar-sh/adapter-utils": ["@polar-sh/adapter-utils@0.4.4", "", { "dependencies": { "@polar-sh/sdk": "^0.46.0" } }, "sha512-0fvscT82EMoo+otgnw7YsbzxmatxTpc457DytZY9Lr+6B9XNBI/wP7THK0nV3Qdaipd66Pp9hyZI9Dzusj1KzQ=="],
 
@@ -742,6 +716,8 @@
 
     "@tailwindcss/typography": ["@tailwindcss/typography@0.5.19", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1" } }, "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg=="],
 
+    "@tempo/config": ["@tempo/config@workspace:packages/config"],
+
     "@tempo/types": ["@tempo/types@workspace:packages/types"],
 
     "@tempo/ui": ["@tempo/ui@workspace:packages/ui"],
@@ -770,8 +746,6 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
-
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
 
     "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
@@ -779,8 +753,6 @@
     "@types/istanbul-lib-report": ["@types/istanbul-lib-report@3.0.3", "", { "dependencies": { "@types/istanbul-lib-coverage": "*" } }, "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA=="],
 
     "@types/istanbul-reports": ["@types/istanbul-reports@3.0.4", "", { "dependencies": { "@types/istanbul-lib-report": "*" } }, "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ=="],
-
-    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@20.19.37", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw=="],
 
@@ -808,11 +780,7 @@
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
-    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
-
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
-
-    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "anser": ["anser@1.4.10", "", {}, "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww=="],
 
@@ -898,8 +866,6 @@
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
-    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
-
     "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
@@ -984,8 +950,6 @@
 
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
-    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
-
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
@@ -1040,25 +1004,7 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@9.39.4", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.5", "@eslint/js": "9.39.4", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ=="],
-
-    "eslint-plugin-tailwind-canonical-classes": ["eslint-plugin-tailwind-canonical-classes@1.2.0", "", { "dependencies": { "@tailwindcss/node": "^4.0.0", "synckit": "^0.9.3" }, "peerDependencies": { "eslint": ">=8.0.0" } }, "sha512-kp7wpwv0kxPeJp+fCQoRD8z9qbCMP1fenY4qeI3CURGygPDD3MNMwLqcs4srb/U4sQ2+W6OIexN4/sKONxuuYA=="],
-
-    "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
-
-    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
-
-    "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
-
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
-
-    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
-
-    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
-
-    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
-
-    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
@@ -1116,8 +1062,6 @@
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
-    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
-
     "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
@@ -1130,19 +1074,13 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
-
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "filter-obj": ["filter-obj@1.1.0", "", {}, "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="],
 
     "finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
 
-    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
-
-    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
-
-    "flatted": ["flatted@3.4.1", "", {}, "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ=="],
+    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "flow-enums-runtime": ["flow-enums-runtime@0.0.6", "", {}, "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw=="],
 
@@ -1174,8 +1112,6 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
-    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
-
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -1199,8 +1135,6 @@
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "image-size": ["image-size@1.2.1", "", { "dependencies": { "queue": "6.0.2" }, "bin": { "image-size": "bin/image-size.js" } }, "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw=="],
-
-    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
@@ -1274,27 +1208,17 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
-    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
-
-    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
-
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jwt-decode": ["jwt-decode@4.0.0", "", {}, "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="],
 
-    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
-
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "lan-network": ["lan-network@0.1.7", "", { "bin": { "lan-network": "dist/lan-network-cli.js" } }, "sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
-
-    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
     "lighthouse-logger": ["lighthouse-logger@1.4.2", "", { "dependencies": { "debug": "^2.6.9", "marky": "^1.2.2" } }, "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g=="],
 
@@ -1326,11 +1250,9 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
-    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
-
-    "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
     "lodash.throttle": ["lodash.throttle@4.1.1", "", {}, "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="],
 
@@ -1418,8 +1340,6 @@
 
     "nativewind": ["nativewind@4.2.2", "", { "dependencies": { "comment-json": "^4.2.5", "debug": "^4.3.7", "react-native-css-interop": "0.2.2" }, "peerDependencies": { "tailwindcss": ">3.3.0" } }, "sha512-kUGbUamKUWdnAIjfBuhIrtDHFtMyL1pEE3AEbCuKeg656pHuB0KtJRk6Lrie/+8haj8hCSlwOleQFJLrE1sZgA=="],
 
-    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
-
     "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
     "nested-error-stacks": ["nested-error-stacks@2.0.1", "", {}, "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A=="],
@@ -1462,17 +1382,13 @@
 
     "open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
 
-    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
-
     "ora": ["ora@3.4.0", "", { "dependencies": { "chalk": "^2.4.2", "cli-cursor": "^2.1.0", "cli-spinners": "^2.0.0", "log-symbols": "^2.2.0", "strip-ansi": "^5.2.0", "wcwidth": "^1.0.1" } }, "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
-    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
-
-    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-png": ["parse-png@2.1.0", "", { "dependencies": { "pngjs": "^3.3.0" } }, "sha512-Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ=="],
 
@@ -1521,8 +1437,6 @@
     "preact": ["preact@10.24.3", "", {}, "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA=="],
 
     "preact-render-to-string": ["preact-render-to-string@6.5.11", "", { "peerDependencies": { "preact": ">=10" } }, "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw=="],
-
-    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
@@ -1708,7 +1622,7 @@
 
     "strip-ansi": ["strip-ansi@5.2.0", "", { "dependencies": { "ansi-regex": "^4.1.0" } }, "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA=="],
 
-    "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "structured-headers": ["structured-headers@0.4.1", "", {}, "sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg=="],
 
@@ -1723,8 +1637,6 @@
     "supports-hyperlinks": ["supports-hyperlinks@2.3.0", "", { "dependencies": { "has-flag": "^4.0.0", "supports-color": "^7.0.0" } }, "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
-
-    "synckit": ["synckit@0.9.3", "", { "dependencies": { "@pkgr/core": "^0.1.0", "tslib": "^2.6.2" } }, "sha512-JJoOEKTfL1urb1mDoEblhD9NhEbWmq9jHEMEnxoC4ujUaZ4itA8vKgwkFAyNClgxplLi9tsUKX+EduK0p/l7sg=="],
 
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
@@ -1770,8 +1682,6 @@
 
     "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
 
-    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
-
     "type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
 
     "type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
@@ -1797,8 +1707,6 @@
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
-
-    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
@@ -1839,8 +1747,6 @@
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wonka": ["wonka@6.3.5", "", {}, "sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw=="],
-
-    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -1892,12 +1798,6 @@
 
     "@babel/traverse--for-generate-function-map/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
-    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
-
-    "@eslint/config-array/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
-    "@eslint/eslintrc/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
     "@expo/cli/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@expo/config-plugins/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -1931,8 +1831,6 @@
     "@expo/xcpretty/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@istanbuljs/load-nyc-config/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
-
-    "@istanbuljs/load-nyc-config/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
@@ -1998,10 +1896,6 @@
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "eslint/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
     "expo-modules-autolinking/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "expo-modules-autolinking/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
@@ -2029,8 +1923,6 @@
     "glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -2090,11 +1982,11 @@
 
     "ora/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
+    "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
-
-    "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
@@ -2168,15 +2060,9 @@
 
     "@babel/highlight/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
-    "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
-
-    "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
-
     "@expo/metro/metro-source-map/ob1": ["ob1@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA=="],
 
     "@expo/metro/metro-source-map/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
-
-    "@istanbuljs/load-nyc-config/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
@@ -2221,8 +2107,6 @@
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
-    "eslint/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -2290,8 +2174,6 @@
 
     "@babel/highlight/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
-    "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
     "@react-native/codegen/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "@react-native/community-cli-plugin/metro/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
@@ -2315,8 +2197,6 @@
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "@babel/highlight/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
-
-    "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "log-symbols/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,11 +11,13 @@
 import type * as analytics from "../analytics.js";
 import type * as auth from "../auth.js";
 import type * as coach from "../coach.js";
+import type * as coachActions from "../coachActions.js";
 import type * as conversations from "../conversations.js";
 import type * as goals from "../goals.js";
 import type * as habits from "../habits.js";
 import type * as http from "../http.js";
 import type * as journal from "../journal.js";
+import type * as lib_ai from "../lib/ai.js";
 import type * as lib_requireUser from "../lib/requireUser.js";
 import type * as memories from "../memories.js";
 import type * as messages from "../messages.js";
@@ -35,11 +37,13 @@ declare const fullApi: ApiFromModules<{
   analytics: typeof analytics;
   auth: typeof auth;
   coach: typeof coach;
+  coachActions: typeof coachActions;
   conversations: typeof conversations;
   goals: typeof goals;
   habits: typeof habits;
   http: typeof http;
   journal: typeof journal;
+  "lib/ai": typeof lib_ai;
   "lib/requireUser": typeof lib_requireUser;
   memories: typeof memories;
   messages: typeof messages;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as conversations from "../conversations.js";
 import type * as goals from "../goals.js";
 import type * as habits from "../habits.js";
 import type * as http from "../http.js";
+import type * as journal from "../journal.js";
 import type * as lib_requireUser from "../lib/requireUser.js";
 import type * as memories from "../memories.js";
 import type * as messages from "../messages.js";
@@ -38,6 +39,7 @@ declare const fullApi: ApiFromModules<{
   goals: typeof goals;
   habits: typeof habits;
   http: typeof http;
+  journal: typeof journal;
   "lib/requireUser": typeof lib_requireUser;
   memories: typeof memories;
   messages: typeof messages;

--- a/convex/coach.ts
+++ b/convex/coach.ts
@@ -2,24 +2,30 @@ import { v } from "convex/values";
 import { mutation } from "./_generated/server";
 import { requireUser } from "./lib/requireUser";
 
+/**
+ * Template-only coach replies. Used as a graceful fallback when OpenRouter is
+ * unavailable, and as the source of the historical `sendMessage` behaviour.
+ * Real AI replies live in `convex/coachActions.ts#respond`.
+ */
 const REPLIES: Record<string, string> = {
   pomodoro:
-    "נסה מקטע של 25 דקות עם טיימר אחד בלבד. אחרי הפסקה של 5 דקות, החלט אם להמשיך עוד מקטע או לעבור למשימה הבאה.",
+    "Try a 25-minute block with a single timer. After a 5-minute break, decide whether to run another block or move on.",
   body_double:
-    "עבוד לצד מישהו (או בשיחת וידאו שקטה) בלי לדבר על המשימה — הנוכחות לבד מורידה הסחות דעת.",
+    "Work next to someone — in person or on a quiet video call — without talking about the task. The shared presence alone reduces pull to distract.",
   eat_the_frog:
-    "בחר את המשימה הכי כבדה היום והתחל ממנה לפני כל השאר. רק צעד ראשון קטן עכשיו.",
+    "Pick the heaviest task of the day and start with it before anything else. Just one small first step, right now.",
   time_blocking:
-    "חסום ביומן חלון קצר לכל משימה והגדר התראה אחת לסוף החלון — לא לשינוי תוכנית באמצע.",
+    "Block a short window on your calendar for the task and set one alert for the end of the window. Don't renegotiate the plan mid-block.",
   two_minute:
-    "אם זה באמת מתחת לשתי דקות — עשה עכשיו. אם לא, הפוך את זה לצעד קטן שמתחיל בשנייה אחת.",
+    "If it's honestly under two minutes, do it now. If not, reshape it into a tiny step that begins in one second.",
   general:
-    "מה הצעד הקטן ביותר שאפשר לעשות בלי התנגדות? התחל משם בלבד.",
+    "What's the smallest step that would move with zero resistance? Start there and nowhere else.",
 };
 
 /**
  * Append a user message and a coach reply (template by conversation technique).
- * Does not silently change tasks or notes — only chat rows.
+ * Does not silently change tasks or notes — only chat rows. Real AI lives in
+ * `coachActions.respond`; this mutation is kept for the offline demo surface.
  */
 export const sendMessage = mutation({
   args: {
@@ -46,8 +52,7 @@ export const sendMessage = mutation({
     });
 
     const technique = conv.technique ?? "general";
-    const assistantBody =
-      REPLIES[technique] ?? REPLIES.general;
+    const assistantBody = REPLIES[technique] ?? REPLIES.general;
 
     await ctx.db.insert("messages", {
       conversationId: args.conversationId,

--- a/convex/coachActions.ts
+++ b/convex/coachActions.ts
@@ -1,0 +1,71 @@
+"use node";
+
+/**
+ * Coach actions — live AI replies via OpenRouter.
+ *
+ * Lives in its own `"use node"` file because Convex forbids mixing mutations
+ * (in coach.ts) with node-only actions. The web app calls
+ * `api.coachActions.respond` per the /coach screen.
+ *
+ * HARD_RULES §6:
+ * - All LLM calls through OpenRouter via native fetch (convex/lib/ai.ts).
+ * - Messages are ephemeral — we do not persist coach transcripts here.
+ * - The system prompt mirrors Tempo's anti-shame, concrete-next-step brand
+ *   voice (see docs/brain/brand/voice.md + do-and-dont.md).
+ */
+
+import { v } from "convex/values";
+import { action } from "./_generated/server";
+import { callAI, type AiMessage } from "./lib/ai";
+
+const SYSTEM_PROMPT = `You are Tempo's coach — warm, calm, and concrete.
+
+Voice:
+- Anti-shame. Never imply failure, laziness, or "falling behind".
+- Short replies (2–4 sentences) unless the user explicitly asks for depth.
+- Concrete next step. Always offer one small, do-able move — not a lecture.
+- Respect overwhelm. If the user sounds overloaded, slow down and narrow the ask.
+- Never silently change anything in the user's system; suggest, don't assume.
+
+When the user lists many things, do NOT recap them. Pick one small step and name it.
+When the user asks a yes/no question, answer in one sentence and offer one follow-up.
+`;
+
+const ROLE_VALIDATOR = v.union(
+  v.literal("user"),
+  v.literal("assistant"),
+  v.literal("system"),
+);
+
+export const respond = action({
+  args: {
+    message: v.string(),
+    history: v.optional(
+      v.array(
+        v.object({
+          role: ROLE_VALIDATOR,
+          content: v.string(),
+        }),
+      ),
+    ),
+  },
+  handler: async (_ctx, { message, history }) => {
+    const text = message.trim();
+    if (!text) {
+      throw new Error("Message is empty");
+    }
+
+    const fullHistory: AiMessage[] = [
+      { role: "system", content: SYSTEM_PROMPT },
+      ...(history ?? []),
+    ];
+
+    const { text: reply, model } = await callAI({
+      task: "coach_response",
+      prompt: text,
+      history: fullHistory,
+    });
+
+    return { reply, model };
+  },
+});

--- a/convex/journal.ts
+++ b/convex/journal.ts
@@ -1,0 +1,70 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { requireUser } from "./lib/requireUser";
+
+/**
+ * Journal is one row per user per local calendar date. `dateKey` is a
+ * YYYY-MM-DD string derived on the client so it always respects the
+ * user's timezone (HARD_RULES §5 — no Date.now() in queries).
+ */
+
+const moodValidator = v.union(
+  v.literal("low"),
+  v.literal("ok"),
+  v.literal("good"),
+);
+
+export const getByDate = query({
+  args: { dateKey: v.string() },
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const entry = await ctx.db
+      .query("journalEntries")
+      .withIndex("by_userId_dateKey", (q) =>
+        q.eq("userId", user._id).eq("dateKey", args.dateKey),
+      )
+      .unique();
+    if (!entry || entry.deletedAt !== undefined) {
+      return null;
+    }
+    return entry;
+  },
+});
+
+export const upsertByDate = mutation({
+  args: {
+    dateKey: v.string(),
+    body: v.string(),
+    mood: v.optional(moodValidator),
+  },
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("journalEntries")
+      .withIndex("by_userId_dateKey", (q) =>
+        q.eq("userId", user._id).eq("dateKey", args.dateKey),
+      )
+      .unique();
+
+    if (existing && existing.deletedAt === undefined) {
+      await ctx.db.patch(existing._id, {
+        body: args.body,
+        mood: args.mood ?? existing.mood,
+        updatedAt: now,
+      });
+      return existing._id;
+    }
+
+    // If the row is soft-deleted, restore it by writing a new one and
+    // ignoring the tombstoned row.
+    return ctx.db.insert("journalEntries", {
+      userId: user._id,
+      dateKey: args.dateKey,
+      body: args.body,
+      mood: args.mood,
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});

--- a/convex/lib/ai.ts
+++ b/convex/lib/ai.ts
@@ -1,0 +1,91 @@
+"use node";
+
+/**
+ * OpenRouter router for Tempo Flow.
+ *
+ * HARD_RULES §6.1 forbids direct provider SDKs (openai, @anthropic-ai/sdk,
+ * @google/generative-ai). Every LLM call goes through OpenRouter over native
+ * fetch. Keep the surface tiny so we can swap implementations later without
+ * touching callers.
+ */
+
+export type AiTask = "routine_write" | "coach_response" | "extract" | "plan";
+
+export type AiMessage = {
+  role: "user" | "assistant" | "system";
+  content: string;
+};
+
+export type CallAIArgs = {
+  task: AiTask;
+  prompt: string;
+  history?: AiMessage[];
+  temperature?: number;
+};
+
+export type CallAIResult = {
+  text: string;
+  model: string;
+};
+
+/**
+ * Task → model mapping. Per HARD_RULES §6.1 we default to fast Gemma for
+ * routine writes + extraction, and mid-tier Mistral for conversational + plan
+ * surfaces.
+ */
+const MODEL_FOR_TASK: Record<AiTask, string> = {
+  routine_write: "google/gemma-2-9b-it",
+  extract: "google/gemma-2-9b-it",
+  coach_response: "mistralai/mistral-small-3.1-24b-instruct",
+  plan: "mistralai/mistral-small-3.1-24b-instruct",
+};
+
+const OPENROUTER_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions";
+
+/**
+ * Call OpenRouter with the appropriate model for the task.
+ * Throws a friendly Error on non-2xx so callers can surface it verbatim.
+ */
+export async function callAI({
+  task,
+  prompt,
+  history,
+  temperature = 0.6,
+}: CallAIArgs): Promise<CallAIResult> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    throw new Error("AI unavailable: OPENROUTER_API_KEY missing");
+  }
+
+  const model = MODEL_FOR_TASK[task];
+  const messages: AiMessage[] = [
+    ...(history ?? []),
+    { role: "user", content: prompt },
+  ];
+
+  let res: Response;
+  try {
+    res = await fetch(OPENROUTER_ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "X-Title": "Tempo Flow",
+      },
+      body: JSON.stringify({ model, messages, temperature }),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "network error";
+    throw new Error(`AI unavailable: ${message}`);
+  }
+
+  if (!res.ok) {
+    throw new Error(`AI unavailable: ${res.status}`);
+  }
+
+  const data = (await res.json()) as {
+    choices?: { message?: { content?: string } }[];
+  };
+  const text = data.choices?.[0]?.message?.content ?? "";
+  return { text, model };
+}

--- a/convex/lib/requireUser.ts
+++ b/convex/lib/requireUser.ts
@@ -1,22 +1,43 @@
+import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 
 /**
  * Resolve the authenticated app user (users table row) from Convex Auth identity.
+ *
+ * Convex Auth's `identity.subject` packs two ids separated by `|` — the exact
+ * shape varies across auth versions (`authAccountId|userId`,
+ * `authSessionId|userId`, etc.). We can't rely on the order, so we iterate all
+ * parts and use `ctx.db.normalizeId("users", part)` to find the one that is
+ * actually a users row. `identity.email` is not always set.
  */
-export async function requireUser(ctx: QueryCtx | MutationCtx) {
+export async function requireUser(
+  ctx: QueryCtx | MutationCtx,
+): Promise<Doc<"users">> {
   const identity = await ctx.auth.getUserIdentity();
-  if (!identity?.email) {
+  if (!identity) {
     throw new Error("Not authenticated");
   }
 
-  const user = await ctx.db
-    .query("users")
-    .withIndex("by_email", (q) => q.eq("email", identity.email!))
-    .unique();
-
-  if (!user) {
-    throw new Error("User not found");
+  const subjectParts = identity.subject.split("|");
+  for (const part of subjectParts) {
+    const normalized: Id<"users"> | null = ctx.db.normalizeId("users", part);
+    if (normalized) {
+      const row = await ctx.db.get(normalized);
+      if (row) return row;
+    }
   }
 
-  return user;
+  // Fallback — email lookup. This is rarely reached in practice because the
+  // Password provider does not populate `identity.email`, but keep it for other
+  // providers that may.
+  const email = identity.email;
+  if (email) {
+    const fromEmail = await ctx.db
+      .query("users")
+      .withIndex("by_email", (q) => q.eq("email", email))
+      .unique();
+    if (fromEmail) return fromEmail;
+  }
+
+  throw new Error("Not authenticated");
 }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -153,4 +153,21 @@ export default defineSchema({
     .index("by_userId", ["userId"])
     .index("by_userId_status", ["userId", "status"])
     .index("by_userId_deletedAt", ["userId", "deletedAt"]),
+
+  // One-row-per-day journal entries. `dateKey` is the user's local date as
+  // YYYY-MM-DD — derived client-side so the boundary respects the user's
+  // timezone. HARD_RULES §5: soft-delete only, by_userId index mandatory.
+  journalEntries: defineTable({
+    userId: v.id("users"),
+    dateKey: v.string(),
+    body: v.string(),
+    mood: v.optional(
+      v.union(v.literal("low"), v.literal("ok"), v.literal("good")),
+    ),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    deletedAt: v.optional(v.number()),
+  })
+    .index("by_userId_dateKey", ["userId", "dateKey"])
+    .index("by_userId_deletedAt", ["userId", "deletedAt"]),
 });

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -155,3 +155,63 @@ export const remove = mutation({
     return { success: true };
   },
 });
+
+/** Quick-add a task for today — minimal args, sensible defaults. */
+export const createQuick = mutation({
+  args: {
+    title: v.string(),
+    dueAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const now = Date.now();
+    return ctx.db.insert("tasks", {
+      userId: user._id,
+      title: args.title.trim(),
+      status: "todo",
+      priority: "medium",
+      dueAt: args.dueAt,
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+/** Tasks due within a local-day window — used by the Today screen. */
+export const listToday = query({
+  args: {
+    dueFrom: v.number(),
+    dueTo: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const rows = await ctx.db
+      .query("tasks")
+      .withIndex("by_userId", (q) => q.eq("userId", user._id))
+      .collect();
+    return rows
+      .filter(
+        (t) =>
+          t.dueAt !== undefined &&
+          t.dueAt >= args.dueFrom &&
+          t.dueAt < args.dueTo &&
+          t.status !== "cancelled",
+      )
+      .sort((a, b) => (a.dueAt ?? 0) - (b.dueAt ?? 0));
+  },
+});
+
+/** Toggle a task between todo and done. */
+export const toggleCompletion = mutation({
+  args: { taskId: v.id("tasks") },
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const task = await ctx.db.get(args.taskId);
+    if (!task || task.userId !== user._id) {
+      throw new Error("Task not found");
+    }
+    const next = task.status === "done" ? "todo" : "done";
+    await ctx.db.patch(args.taskId, { status: next, updatedAt: Date.now() });
+    return { taskId: args.taskId, status: next };
+  },
+});

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
     "@types/node": "^20.19.0",
+    "playwright": "^1.59.1",
     "turbo": "^2.3.3"
   }
 }

--- a/packages/config/biome.json
+++ b/packages/config/biome.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "performance": {
+        "noAccumulatingSpread": "error"
+      },
+      "style": {
+        "useConst": "warn",
+        "noNonNullAssertion": "off",
+        "useBlockStatements": "off",
+        "noImplicitBoolean": "off"
+      },
+      "suspicious": {
+        "noAsyncPromiseExecutor": "error",
+        "noCatchAssign": "error",
+        "noDoubleEquals": "error",
+        "noDuplicateObjectKeys": "error",
+        "noMisleadingCharacterClass": "error",
+        "noPrototypeBuiltins": "error",
+        "noRedeclare": "error",
+        "noSelfCompare": "error",
+        "noUnsafeNegation": "error",
+        "noConsole": "warn",
+        "noArrayIndexKey": "off",
+        "noUnknownAtRules": "off",
+        "noExplicitAny": "off"
+      },
+      "correctness": {
+        "noConstAssign": "error",
+        "noConstantCondition": "error",
+        "noEmptyCharacterClassInRegex": "error",
+        "noEmptyPattern": "error",
+        "noInnerDeclarations": "error",
+        "noInvalidConstructorSuper": "error",
+        "noInvalidUseBeforeDeclaration": "error",
+        "noPrecisionLoss": "error",
+        "noSelfAssign": "error",
+        "noSetterReturn": "error",
+        "noUndeclaredVariables": "error",
+        "noUnreachable": "error",
+        "noUnsafeFinally": "error",
+        "useIsNan": "error",
+        "useValidForDirection": "error",
+        "useUniqueElementIds": "off"
+      },
+      "a11y": {
+        "noSvgWithoutTitle": "off"
+      },
+      "complexity": {
+        "noForEach": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "jsxQuoteStyle": "double",
+      "trailingCommas": "es5",
+      "semicolons": "always",
+      "arrowParentheses": "always"
+    }
+  },
+  "json": {
+    "formatter": {
+      "indentStyle": "space",
+      "indentWidth": 2
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["*.tsx", "*.ts", "*.jsx", "*.js"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "useExhaustiveDependencies": "warn"
+          }
+        }
+      }
+    }
+  ],
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@tempo/config",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Shared tooling config for the Tempo Flow monorepo"
+}

--- a/scripts/mobile-audit.mjs
+++ b/scripts/mobile-audit.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// Mobile-viewport audit of the live /today loop.
+// Run AFTER a web dev server is up at http://localhost:3000 and Convex at :3210.
+// Saves screenshots to /tmp/mobile_audit/.
+
+import { mkdirSync } from "node:fs";
+import { chromium, devices } from "playwright";
+
+const BASE = process.env.AUDIT_BASE ?? "http://localhost:3000";
+const OUT = "/tmp/mobile_audit";
+mkdirSync(OUT, { recursive: true });
+
+const email = `audit+${Date.now()}@example.com`;
+const password = "Tempo!Flow-0007";
+
+async function shot(page, name) {
+  await page.waitForLoadState("networkidle", { timeout: 15_000 }).catch(() => {});
+  await page.screenshot({ path: `${OUT}/${name}.png`, fullPage: true });
+  console.log(`saved ${name}.png`);
+}
+
+const iphone = devices["iPhone 14 Pro"] ?? {
+  viewport: { width: 393, height: 852 },
+  deviceScaleFactor: 3,
+  isMobile: true,
+  hasTouch: true,
+  userAgent:
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+};
+
+const browser = await chromium.launch();
+const context = await browser.newContext(iphone);
+const page = await context.newPage();
+
+try {
+  // Landing — signed out
+  await page.goto(`${BASE}/`);
+  await shot(page, "01-landing-signed-out");
+
+  // Sign-in
+  await page.goto(`${BASE}/sign-in`);
+  await shot(page, "02-sign-in");
+
+  // Sign-up
+  await page.goto(`${BASE}/sign-up`);
+  await shot(page, "03-sign-up");
+
+  // Create an account
+  await page.fill('input[type="email"]', email);
+  await page.fill('input[type="password"]', password);
+  // Accept terms if present
+  const consentBtn = page.locator('button[aria-label*="Accept terms"], button[aria-label*="Consent"]').first();
+  if (await consentBtn.count()) await consentBtn.click();
+  const submit = page.locator('button[type="submit"]').first();
+  await submit.click();
+
+  // Wait for /today
+  await page.waitForURL(/\/today$/, { timeout: 20_000 }).catch(() => {});
+  await page.waitForTimeout(1_500);
+  await shot(page, "04-today-signed-in");
+
+  // Open mobile nav to screenshot the drawer
+  const menuBtn = page.getByLabel("Open navigation").first();
+  if (await menuBtn.count()) {
+    await menuBtn.click();
+    await page.waitForTimeout(400);
+    await shot(page, "05-today-mobile-nav-open");
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(200);
+  }
+
+  // Quick-add a task
+  const quickAdd = page.locator('#today-quick-add');
+  if (await quickAdd.count()) {
+    await quickAdd.fill("Audit task one");
+    await page.getByRole("button", { name: /add/i }).first().click();
+    await page.waitForTimeout(1_000);
+    await quickAdd.fill("Audit task two");
+    await page.getByRole("button", { name: /add/i }).first().click();
+    await page.waitForTimeout(1_000);
+    await shot(page, "06-today-with-tasks");
+  }
+
+  // Tasks
+  await page.goto(`${BASE}/tasks`);
+  await page.waitForTimeout(1_500);
+  await shot(page, "07-tasks");
+
+  // Notes
+  await page.goto(`${BASE}/notes`);
+  await page.waitForTimeout(1_000);
+  await shot(page, "08-notes-empty");
+
+  // Brain dump
+  await page.goto(`${BASE}/brain-dump`);
+  await page.waitForTimeout(1_000);
+  await shot(page, "09-brain-dump");
+
+  // Journal
+  await page.goto(`${BASE}/journal`);
+  await page.waitForTimeout(1_000);
+  await shot(page, "10-journal");
+
+  // Coach
+  await page.goto(`${BASE}/coach`);
+  await page.waitForTimeout(1_000);
+  await shot(page, "11-coach");
+
+  console.log("audit done");
+} catch (err) {
+  console.error("audit failed:", err);
+  await shot(page, "zz-failure");
+  process.exitCode = 1;
+} finally {
+  await context.close();
+  await browser.close();
+}

--- a/scripts/qa_auth_flow.py
+++ b/scripts/qa_auth_flow.py
@@ -1,0 +1,134 @@
+"""
+Tempo Flow — targeted auth flow test.
+Handles terms consent, verifies sign-up and sign-in end to end.
+"""
+import os
+import time
+from playwright.sync_api import sync_playwright, Page
+
+BASE_URL = "http://localhost:3000"
+SCREENSHOT_DIR = "/tmp/tempo_qa"
+os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+
+def shot(page: Page, name: str):
+    path = f"{SCREENSHOT_DIR}/{name}.png"
+    page.screenshot(path=path, full_page=True)
+    print(f"  screenshot: {path}")
+
+def log(msg):
+    print(f"\n{'='*60}\n{msg}\n{'='*60}")
+
+def run():
+    ts = int(time.time())
+    test_email = f"qa_{ts}@tempo.test"
+    test_password = "QAtest123!"
+    print(f"Test account: {test_email}")
+
+    console_errors = []
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(viewport={"width": 1280, "height": 800})
+        page = context.new_page()
+
+        page.on("console", lambda msg: console_errors.append(f"[{msg.type}] {msg.text}") if msg.type == "error" else None)
+
+        # ── SIGN-UP ──────────────────────────────────────────────────────
+        log("SIGN-UP FLOW")
+        page.goto(f"{BASE_URL}/sign-up", wait_until="networkidle", timeout=20000)
+        shot(page, "before_signup")
+
+        # Fill email + password
+        page.locator("#signup-email").fill(test_email)
+        page.locator("#signup-password").fill(test_password)
+
+        # Accept terms — the consent checkbox is a custom button (#signup-consent → button)
+        consent_btn = page.locator("button[aria-label='Accept terms and privacy policy']")
+        print(f"  Consent button visible: {consent_btn.is_visible()}")
+        consent_btn.click()
+        page.wait_for_timeout(300)
+        shot(page, "signup_consent_checked")
+
+        # Submit should now be enabled
+        submit = page.locator("button[type='submit']")
+        print(f"  Submit enabled: {submit.is_enabled()}")
+        submit.click()
+
+        try:
+            page.wait_for_url(lambda url: "/sign-up" not in url, timeout=12000)
+            print(f"  Sign-up success -> landed at: {page.url}")
+            shot(page, "after_signup")
+            signup_ok = True
+        except Exception as e:
+            print(f"  Sign-up redirect failed: {e}")
+            # Check for error message on page
+            errors = page.locator("[role='alert']").all_text_contents()
+            print(f"  Error messages: {errors}")
+            shot(page, "signup_failed")
+            signup_ok = False
+
+        # ── SIGN-OUT then SIGN-IN ────────────────────────────────────────
+        log("SIGN-IN FLOW (fresh context)")
+        ctx2 = browser.new_context(viewport={"width": 1280, "height": 800})
+        p2 = ctx2.new_page()
+        p2.on("console", lambda msg: console_errors.append(f"[{msg.type}] {msg.text}") if msg.type == "error" else None)
+
+        p2.goto(f"{BASE_URL}/sign-in", wait_until="networkidle", timeout=20000)
+        shot(p2, "before_signin")
+
+        p2.locator("#signin-email").fill(test_email)
+        p2.locator("#signin-password").fill(test_password)
+        shot(p2, "signin_filled")
+        p2.locator("button[type='submit']").click()
+
+        try:
+            p2.wait_for_url(lambda url: "/sign-in" not in url, timeout=12000)
+            landed = p2.url
+            print(f"  Sign-in success -> landed at: {landed}")
+            shot(p2, "after_signin")
+
+            # ── AUTHENTICATED ROUTES ─────────────────────────────────────
+            log("AUTHENTICATED ROUTES")
+            for route in ["/today", "/dashboard", "/tasks"]:
+                p2.goto(f"{BASE_URL}{route}", wait_until="networkidle", timeout=15000)
+                final = p2.url
+                gated = "/sign-in" in final
+                print(f"  GET {route} -> {final}  {'[AUTH REQUIRED - not authed??]' if gated else '[OK - loaded]'}")
+                h_texts = p2.locator("h1, h2").all_text_contents()
+                print(f"    headings: {h_texts[:4]}")
+                shot(p2, f"auth_{route.lstrip('/')}")
+
+        except Exception as e:
+            print(f"  Sign-in redirect failed: {e}")
+            errors = p2.locator("[role='alert']").all_text_contents()
+            print(f"  Error messages: {errors}")
+            shot(p2, "signin_failed")
+
+        ctx2.close()
+
+        # ── SIGN-IN ERROR STATE ──────────────────────────────────────────
+        log("SIGN-IN BAD PASSWORD (error state test)")
+        ctx3 = browser.new_context(viewport={"width": 1280, "height": 800})
+        p3 = ctx3.new_page()
+        p3.goto(f"{BASE_URL}/sign-in", wait_until="networkidle", timeout=15000)
+        p3.locator("#signin-email").fill(test_email)
+        p3.locator("#signin-password").fill("wrongpassword")
+        p3.locator("button[type='submit']").click()
+        p3.wait_for_timeout(3000)
+        errors = p3.locator("[role='alert']").all_text_contents()
+        print(f"  Error displayed: {errors}")
+        shot(p3, "signin_bad_password")
+        ctx3.close()
+
+        # ── SUMMARY ──────────────────────────────────────────────────────
+        log("SUMMARY")
+        print(f"Console errors ({len(console_errors)}):")
+        for e in console_errors[:8]:
+            print(f"  {e}")
+        print(f"\nSign-up: {'OK' if signup_ok else 'FAILED'}")
+
+        browser.close()
+        print(f"\nScreenshots in {SCREENSHOT_DIR}")
+
+if __name__ == "__main__":
+    run()

--- a/scripts/qa_local.py
+++ b/scripts/qa_local.py
@@ -1,0 +1,224 @@
+"""
+Tempo Flow — local QA script
+Tests auth flow, main routes, and /today slice.
+"""
+import os
+import sys
+import time
+from playwright.sync_api import sync_playwright, Page, expect
+
+BASE_URL = "http://localhost:3000"
+SCREENSHOT_DIR = "/tmp/tempo_qa"
+os.makedirs(SCREENSHOT_DIR, exist_ok=True)
+
+console_errors = []
+network_errors = []
+
+def shot(page: Page, name: str):
+    path = f"{SCREENSHOT_DIR}/{name}.png"
+    page.screenshot(path=path, full_page=True)
+    print(f"  📸 {path}")
+    return path
+
+def log(msg):
+    print(f"\n{'='*60}\n{msg}\n{'='*60}")
+
+def check_for_hebrew(page: Page, route: str):
+    content = page.content()
+    # Basic Hebrew unicode range U+0590–U+05FF
+    hebrew_chars = [c for c in content if '\u0590' <= c <= '\u05ff']
+    if hebrew_chars:
+        print(f"  ⚠️  HEBREW DETECTED on {route}: {len(hebrew_chars)} chars — first 3: {''.join(hebrew_chars[:3])}")
+    else:
+        print(f"  ✅ No Hebrew on {route}")
+
+def run_qa():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            viewport={"width": 1280, "height": 800},
+            record_video_dir=SCREENSHOT_DIR,
+        )
+        page = context.new_page()
+
+        # Capture console errors
+        def on_console(msg):
+            if msg.type in ("error", "warning"):
+                console_errors.append(f"[{msg.type}] {msg.text}")
+
+        def on_response(response):
+            if response.status >= 400:
+                network_errors.append(f"HTTP {response.status} — {response.url}")
+
+        page.on("console", on_console)
+        page.on("response", on_response)
+
+        # ── 1. ROOT / → where does it go? ─────────────────────────────────
+        log("1. Root redirect")
+        page.goto(BASE_URL, wait_until="networkidle", timeout=30000)
+        print(f"  URL after load: {page.url}")
+        shot(page, "01_root")
+        check_for_hebrew(page, "/")
+
+        # ── 2. SIGN-IN page ───────────────────────────────────────────────
+        log("2. /sign-in page load")
+        page.goto(f"{BASE_URL}/sign-in", wait_until="networkidle", timeout=20000)
+        print(f"  URL: {page.url}")
+        shot(page, "02_sign_in")
+        check_for_hebrew(page, "/sign-in")
+
+        # Inspect the sign-in form
+        inputs = page.locator("input").all()
+        print(f"  Inputs found: {len(inputs)}")
+        for i, inp in enumerate(inputs):
+            t = inp.get_attribute("type") or "text"
+            ph = inp.get_attribute("placeholder") or ""
+            print(f"    input[{i}] type={t} placeholder={ph!r}")
+
+        buttons = page.locator("button").all()
+        print(f"  Buttons found: {len(buttons)}")
+        for b in buttons:
+            print(f"    button: {b.inner_text().strip()!r}")
+
+        # ── 3. SIGN-UP flow ──────────────────────────────────────────────
+        log("3. /sign-up — navigate and inspect")
+        page.goto(f"{BASE_URL}/sign-up", wait_until="networkidle", timeout=20000)
+        print(f"  URL: {page.url}")
+        shot(page, "03_sign_up")
+        check_for_hebrew(page, "/sign-up")
+
+        signup_inputs = page.locator("input").all()
+        print(f"  Inputs found: {len(signup_inputs)}")
+        for i, inp in enumerate(signup_inputs):
+            t = inp.get_attribute("type") or "text"
+            ph = inp.get_attribute("placeholder") or ""
+            print(f"    input[{i}] type={t} placeholder={ph!r}")
+
+        # ── 4. Attempt sign-up with test user ────────────────────────────
+        log("4. Sign-up attempt with test@tempo.local")
+        ts = int(time.time())
+        test_email = f"qa_{ts}@tempo.test"
+        test_password = "QAtest123!"
+
+        email_input = page.locator("input[type='email'], input[name='email'], input[placeholder*='mail' i]").first
+        pw_input = page.locator("input[type='password']").first
+
+        try:
+            email_input.fill(test_email)
+            pw_input.fill(test_password)
+            shot(page, "04_signup_filled")
+            submit = page.locator("button[type='submit'], button:has-text('Sign up'), button:has-text('Create'), button:has-text('Register')").first
+            submit.click()
+            page.wait_for_url(lambda url: "/sign-in" not in url and "/sign-up" not in url, timeout=10000)
+            print(f"  ✅ Sign-up redirected to: {page.url}")
+            shot(page, "05_after_signup")
+        except Exception as e:
+            print(f"  ❌ Sign-up failed: {e}")
+            shot(page, "05_signup_error")
+            # Fall through to sign-in attempt
+
+        # ── 5. Sign-in attempt ───────────────────────────────────────────
+        log("5. Sign-in attempt")
+        page.goto(f"{BASE_URL}/sign-in", wait_until="networkidle", timeout=20000)
+        try:
+            email_in = page.locator("input[type='email'], input[name='email'], input[placeholder*='mail' i]").first
+            pw_in = page.locator("input[type='password']").first
+            email_in.fill(test_email)
+            pw_in.fill(test_password)
+            shot(page, "06_signin_filled")
+            submit = page.locator("button[type='submit'], button:has-text('Sign in'), button:has-text('Login')").first
+            submit.click()
+            page.wait_for_url(lambda url: "/sign-in" not in url, timeout=10000)
+            print(f"  ✅ Sign-in redirected to: {page.url}")
+            shot(page, "07_after_signin")
+            check_for_hebrew(page, "post-signin")
+        except Exception as e:
+            print(f"  ❌ Sign-in failed: {e}")
+            shot(page, "07_signin_error")
+
+        # ── 6. Protected routes check (unauthenticated) ──────────────────
+        log("6. Protected route test (fresh context, unauthenticated)")
+        ctx2 = browser.new_context(viewport={"width": 1280, "height": 800})
+        p2 = ctx2.new_page()
+        for route in ["/today", "/dashboard", "/tasks"]:
+            p2.goto(f"{BASE_URL}{route}", wait_until="networkidle", timeout=15000)
+            final_url = p2.url
+            protected = "/sign-in" in final_url or "/sign-up" in final_url or final_url == BASE_URL + "/"
+            status = "✅ redirected" if protected else f"⚠️  landed at {final_url} (not gated?)"
+            print(f"  GET {route} → {final_url}  [{status}]")
+        ctx2.close()
+
+        # ── 7. Authenticated routes ──────────────────────────────────────
+        log("7. Authenticated route tests")
+        current_url = page.url
+        if "/sign-in" in current_url or "/sign-up" in current_url:
+            print("  ⚠️  Not authenticated — skipping authenticated route tests")
+        else:
+            for route in ["/today", "/dashboard", "/tasks"]:
+                try:
+                    page.goto(f"{BASE_URL}{route}", wait_until="networkidle", timeout=15000)
+                    print(f"  GET {route} → {page.url}")
+                    shot(page, f"auth_{route.lstrip('/')}")
+                    check_for_hebrew(page, route)
+
+                    # Check empty state / loading state
+                    has_spinner = page.locator("[class*='spin'], [class*='load'], [aria-busy='true']").count() > 0
+                    has_empty   = page.locator("[class*='empty'], [data-empty]").count() > 0
+                    h1s = page.locator("h1, h2").all_text_contents()
+                    print(f"    h1/h2: {h1s[:3]}")
+                    print(f"    spinner: {has_spinner}  empty-state: {has_empty}")
+                except Exception as e:
+                    print(f"  ❌ {route} error: {e}")
+                    shot(page, f"err_{route.lstrip('/')}")
+
+        # ── 8. /today quick-add task (if present) ───────────────────────
+        log("8. /today quick-add test")
+        if "/sign-in" not in page.url and "/sign-up" not in page.url:
+            page.goto(f"{BASE_URL}/today", wait_until="networkidle", timeout=15000)
+            qa_input = page.locator(
+                "input[placeholder*='add' i], input[placeholder*='task' i], "
+                "input[placeholder*='quick' i], textarea[placeholder*='add' i]"
+            ).first
+            if qa_input.count():
+                qa_input.fill("QA test task from Playwright")
+                shot(page, "today_quick_add_filled")
+                qa_input.press("Enter")
+                page.wait_for_timeout(1500)
+                shot(page, "today_quick_add_result")
+                # Check task appears
+                task_visible = page.locator("text=QA test task from Playwright").count() > 0
+                print(f"  Task appeared after add: {task_visible}")
+            else:
+                print("  ⚠️  No quick-add input found on /today")
+                # List all inputs
+                all_inputs = page.locator("input, textarea").all()
+                for inp in all_inputs:
+                    ph = inp.get_attribute("placeholder") or ""
+                    print(f"    input placeholder={ph!r}")
+        else:
+            print("  ⚠️  Skipped — not authenticated")
+
+        # ── 9. Mobile viewport check ─────────────────────────────────────
+        log("9. Mobile viewport (375px)")
+        ctx3 = browser.new_context(viewport={"width": 375, "height": 812})
+        p3 = ctx3.new_page()
+        p3.goto(f"{BASE_URL}/sign-in", wait_until="networkidle", timeout=15000)
+        shot(p3, "mobile_sign_in")
+        p3.goto(f"{BASE_URL}/", wait_until="networkidle", timeout=15000)
+        shot(p3, "mobile_root")
+        ctx3.close()
+
+        # ── Summary ──────────────────────────────────────────────────────
+        log("SUMMARY")
+        print(f"Console errors ({len(console_errors)}):")
+        for e in console_errors[:10]:
+            print(f"  {e}")
+        print(f"\nNetwork errors ({len(network_errors)}):")
+        for e in network_errors[:10]:
+            print(f"  {e}")
+
+        browser.close()
+        print(f"\n✅ QA complete — screenshots in {SCREENSHOT_DIR}")
+
+if __name__ == "__main__":
+    run_qa()

--- a/scripts/qa_localhost.py
+++ b/scripts/qa_localhost.py
@@ -1,0 +1,340 @@
+"""
+Local QA script for Tempo web app at http://localhost:3000
+Tests: auth flow, protected routes, /today, /dashboard, /tasks
+"""
+
+import os
+import sys
+import time
+from playwright.sync_api import sync_playwright, Page, Browser
+
+BASE = "http://localhost:3000"
+SCREENSHOTS = "/tmp/tempo_qa"
+os.makedirs(SCREENSHOTS, exist_ok=True)
+
+FINDINGS = []
+
+def shot(page: Page, name: str):
+    path = f"{SCREENSHOTS}/{name}.png"
+    page.screenshot(path=path, full_page=True)
+    print(f"  📸 {path}")
+    return path
+
+def log(severity: str, msg: str, detail: str = ""):
+    tag = {"CRIT": "🔴", "HIGH": "🟠", "MED": "🟡", "INFO": "🔵", "PASS": "✅"}.get(severity, "•")
+    line = f"{tag} [{severity}] {msg}"
+    if detail:
+        line += f"\n       {detail}"
+    print(line)
+    FINDINGS.append((severity, msg, detail))
+
+def get_console_errors(page: Page):
+    errors = []
+    page.on("console", lambda msg: errors.append((msg.type, msg.text)) if msg.type == "error" else None)
+    return errors
+
+def wait_and_shot(page: Page, name: str, wait_ms: int = 2000):
+    page.wait_for_timeout(wait_ms)
+    try:
+        page.wait_for_load_state("networkidle", timeout=8000)
+    except Exception:
+        pass
+    return shot(page, name)
+
+def run_qa():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True, args=["--no-sandbox"])
+        context = browser.new_context(viewport={"width": 1280, "height": 800})
+        page = context.new_page()
+
+        console_errors = []
+        page.on("console", lambda m: console_errors.append(m.text) if m.type == "error" else None)
+        network_fails = []
+        page.on("response", lambda r: network_fails.append(f"{r.status} {r.url}") if r.status >= 400 else None)
+
+        # ─── 1. Root redirect ───────────────────────────────────────────────
+        print("\n=== 1. Root URL redirect ===")
+        try:
+            page.goto(BASE, timeout=15000)
+            page.wait_for_timeout(3000)
+            try:
+                page.wait_for_load_state("networkidle", timeout=8000)
+            except Exception:
+                pass
+            url = page.url
+            title = page.title()
+            shot(page, "01_root")
+            print(f"  Landed at: {url}")
+            print(f"  Title: {title}")
+            if "/sign-in" in url or "/login" in url:
+                log("PASS", f"Root → sign-in redirect works ({url})")
+            elif "/today" in url or "/dashboard" in url:
+                log("PASS", f"Root → authenticated landing ({url})")
+            else:
+                log("MED", f"Root landed at unexpected URL: {url}")
+        except Exception as e:
+            log("CRIT", "Root URL failed to load", str(e))
+            browser.close()
+            return
+
+        # ─── 2. Sign-in page ────────────────────────────────────────────────
+        print("\n=== 2. Sign-in page ===")
+        page.goto(f"{BASE}/sign-in", timeout=15000)
+        page.wait_for_timeout(2000)
+        try:
+            page.wait_for_load_state("networkidle", timeout=8000)
+        except Exception:
+            pass
+        shot(page, "02_signin_page")
+        signin_url = page.url
+        print(f"  URL: {signin_url}")
+
+        # Check for Hebrew / RTL text
+        content = page.content()
+        hebrew_chars = [c for c in content if '\u0590' <= c <= '\u05FF']
+        if hebrew_chars:
+            log("HIGH", f"Hebrew text detected on sign-in page ({len(hebrew_chars)} chars)")
+        else:
+            log("PASS", "No Hebrew text on sign-in page")
+
+        # Find email + password inputs
+        email_input = page.locator("input[type=email], input[name=email], input[placeholder*='mail' i]").first
+        pass_input = page.locator("input[type=password]").first
+
+        email_visible = email_input.is_visible() if email_input.count() > 0 else False
+        pass_visible = pass_input.is_visible() if pass_input.count() > 0 else False
+
+        print(f"  Email input visible: {email_visible}")
+        print(f"  Password input visible: {pass_visible}")
+
+        if not email_visible:
+            log("HIGH", "No email input found on /sign-in")
+        if not pass_visible:
+            log("HIGH", "No password input found on /sign-in")
+
+        # Check buttons
+        buttons = page.locator("button").all()
+        btn_texts = []
+        for b in buttons:
+            try:
+                btn_texts.append(b.inner_text().strip())
+            except Exception:
+                pass
+        print(f"  Buttons: {btn_texts}")
+
+        # ─── 3. Sign-up flow ────────────────────────────────────────────────
+        print("\n=== 3. Sign-up attempt ===")
+        test_email = f"qa-test-{int(time.time())}@tempo.test"
+        test_pass = "TestPass123!"
+        page.goto(f"{BASE}/sign-up", timeout=15000)
+        page.wait_for_timeout(2000)
+        try:
+            page.wait_for_load_state("networkidle", timeout=8000)
+        except Exception:
+            pass
+        shot(page, "03_signup_page")
+        signup_url = page.url
+        print(f"  URL: {signup_url}")
+
+        signup_email = page.locator("input[type=email], input[name=email]").first
+        signup_pass = page.locator("input[type=password]").first
+
+        if signup_email.count() > 0 and signup_pass.count() > 0:
+            try:
+                signup_email.fill(test_email)
+                signup_pass.fill(test_pass)
+                shot(page, "03b_signup_filled")
+                # Find submit button
+                submit = page.locator("button[type=submit], button:has-text('Sign up'), button:has-text('Create'), button:has-text('Register')").first
+                if submit.count() > 0:
+                    submit.click()
+                    page.wait_for_timeout(4000)
+                    try:
+                        page.wait_for_load_state("networkidle", timeout=10000)
+                    except Exception:
+                        pass
+                    post_signup_url = page.url
+                    shot(page, "04_post_signup")
+                    print(f"  Post-signup URL: {post_signup_url}")
+                    if "/today" in post_signup_url or "/dashboard" in post_signup_url:
+                        log("PASS", f"Sign-up succeeded → {post_signup_url}")
+                        authenticated = True
+                    elif "/sign-in" in post_signup_url or "/sign-up" in post_signup_url:
+                        # Check for error message
+                        page_text = page.inner_text("body")
+                        error_snippets = [l for l in page_text.split("\n") if any(w in l.lower() for w in ["error", "invalid", "failed", "already"])]
+                        log("HIGH", f"Sign-up did not redirect to app (still at {post_signup_url})", f"Errors found: {error_snippets[:3]}")
+                        authenticated = False
+                    else:
+                        log("MED", f"Sign-up landed at unexpected URL: {post_signup_url}")
+                        authenticated = False
+                else:
+                    log("HIGH", "No submit button found on sign-up page")
+                    authenticated = False
+            except Exception as e:
+                log("HIGH", "Sign-up form interaction failed", str(e))
+                authenticated = False
+        else:
+            log("HIGH", "Sign-up page has no email/password inputs")
+            authenticated = False
+
+        # ─── 4. Sign-in with credentials ────────────────────────────────────
+        if not authenticated:
+            print("\n=== 4. Sign-in attempt (fallback) ===")
+            page.goto(f"{BASE}/sign-in", timeout=15000)
+            page.wait_for_timeout(2000)
+            try:
+                page.wait_for_load_state("networkidle", timeout=8000)
+            except Exception:
+                pass
+            email_inp = page.locator("input[type=email], input[name=email]").first
+            pass_inp = page.locator("input[type=password]").first
+            if email_inp.count() > 0 and pass_inp.count() > 0:
+                email_inp.fill(test_email)
+                pass_inp.fill(test_pass)
+                submit = page.locator("button[type=submit], button:has-text('Sign in'), button:has-text('Login')").first
+                if submit.count() > 0:
+                    submit.click()
+                    page.wait_for_timeout(4000)
+                    try:
+                        page.wait_for_load_state("networkidle", timeout=10000)
+                    except Exception:
+                        pass
+                    post_signin_url = page.url
+                    shot(page, "04b_post_signin")
+                    print(f"  Post-signin URL: {post_signin_url}")
+                    if "/today" in post_signin_url or "/dashboard" in post_signin_url:
+                        log("PASS", f"Sign-in succeeded → {post_signin_url}")
+                        authenticated = True
+                    else:
+                        page_text = page.inner_text("body")
+                        log("CRIT", f"Sign-in did not redirect to app (at {post_signin_url})")
+        
+        # ─── 5. Protected route enforcement ─────────────────────────────────
+        print("\n=== 5. Protected route test (/today while not authed) ===")
+        context2 = browser.new_context(viewport={"width": 1280, "height": 800})
+        page2 = context2.new_page()
+        page2.goto(f"{BASE}/today", timeout=15000)
+        page2.wait_for_timeout(2000)
+        try:
+            page2.wait_for_load_state("networkidle", timeout=8000)
+        except Exception:
+            pass
+        protected_url = page2.url
+        shot(page2, "05_protected_route")
+        print(f"  Unauthenticated /today landed at: {protected_url}")
+        if "/sign-in" in protected_url or "/login" in protected_url:
+            log("PASS", "Protected route correctly redirects unauthenticated users to sign-in")
+        else:
+            log("HIGH", f"Protected route /today NOT redirecting unauthenticated users (at {protected_url})")
+        page2.close()
+        context2.close()
+
+        # ─── 6. Authenticated app routes ────────────────────────────────────
+        if authenticated:
+            for route, name in [("/today", "06_today"), ("/dashboard", "07_dashboard"), ("/tasks", "08_tasks")]:
+                print(f"\n=== Route: {route} ===")
+                page.goto(f"{BASE}{route}", timeout=15000)
+                page.wait_for_timeout(3000)
+                try:
+                    page.wait_for_load_state("networkidle", timeout=10000)
+                except Exception:
+                    pass
+                final_url = page.url
+                shot(page, name)
+                print(f"  Final URL: {final_url}")
+
+                if "/sign-in" in final_url:
+                    log("CRIT", f"{route} → redirected to sign-in (auth lost?)")
+                    continue
+
+                # Check for 404 / error
+                body_text = page.inner_text("body")
+                if "404" in body_text[:200] or "not found" in body_text.lower()[:200]:
+                    log("HIGH", f"{route} shows 404/not found")
+                elif "error" in body_text.lower()[:500]:
+                    snippets = [l for l in body_text.split("\n") if "error" in l.lower()][:3]
+                    log("MED", f"{route} may have error state", str(snippets))
+                else:
+                    log("PASS", f"{route} loaded ({len(body_text)} chars)")
+
+                # Hebrew check
+                html = page.content()
+                heb = [c for c in html if '\u0590' <= c <= '\u05FF']
+                if heb:
+                    log("HIGH", f"Hebrew text on {route} ({len(heb)} chars)")
+
+                # Check mobile width
+                page.set_viewport_size({"width": 375, "height": 812})
+                page.wait_for_timeout(800)
+                shot(page, f"{name}_mobile")
+                page.set_viewport_size({"width": 1280, "height": 800})
+
+        # ─── 7. /today quick-add task ────────────────────────────────────────
+        if authenticated:
+            print("\n=== 7. /today quick-add task flow ===")
+            page.goto(f"{BASE}/today", timeout=15000)
+            page.wait_for_timeout(3000)
+            try:
+                page.wait_for_load_state("networkidle", timeout=10000)
+            except Exception:
+                pass
+
+            if "/today" in page.url:
+                # Look for quick-add input
+                quick_add = page.locator(
+                    "input[placeholder*='add' i], input[placeholder*='task' i], input[placeholder*='capture' i], "
+                    "input[placeholder*='what' i], textarea[placeholder*='add' i], textarea[placeholder*='task' i]"
+                ).first
+
+                if quick_add.count() > 0:
+                    quick_add.fill("QA test task from Playwright")
+                    page.keyboard.press("Enter")
+                    page.wait_for_timeout(2000)
+                    shot(page, "09_today_task_added")
+                    body = page.inner_text("body")
+                    if "QA test task from Playwright" in body:
+                        log("PASS", "/today quick-add: task appears immediately after submit")
+                    else:
+                        log("MED", "/today quick-add: task not visible after submit (may need Convex subscription)")
+                else:
+                    log("MED", "/today: no quick-add input found — slice may not be present yet")
+                    shot(page, "09_today_no_quickadd")
+            else:
+                log("CRIT", "/today redirected away when authenticated")
+
+        # ─── 8. Console errors summary ───────────────────────────────────────
+        print("\n=== Console errors captured ===")
+        if console_errors:
+            for e in console_errors[:10]:
+                log("HIGH", "Console error", e)
+        else:
+            log("PASS", "No console errors during session")
+
+        # Network failures
+        relevant_fails = [f for f in network_fails if not any(x in f for x in ["favicon", "hot-update", "_next/static"])]
+        if relevant_fails:
+            for f in relevant_fails[:5]:
+                log("MED", "Network failure", f)
+        else:
+            log("PASS", "No significant network failures")
+
+        browser.close()
+
+    # ─── Summary ──────────────────────────────────────────────────────────────
+    print("\n" + "="*60)
+    print("QA FINDINGS SUMMARY")
+    print("="*60)
+    severity_order = {"CRIT": 0, "HIGH": 1, "MED": 2, "INFO": 3, "PASS": 4}
+    sorted_findings = sorted(FINDINGS, key=lambda x: severity_order.get(x[0], 5))
+    for sev, msg, detail in sorted_findings:
+        tag = {"CRIT": "🔴", "HIGH": "🟠", "MED": "🟡", "INFO": "🔵", "PASS": "✅"}.get(sev, "•")
+        print(f"{tag} [{sev}] {msg}")
+        if detail:
+            print(f"       {detail}")
+    
+    print(f"\nScreenshots saved to: {SCREENSHOTS}/")
+    return sorted_findings
+
+if __name__ == "__main__":
+    run_qa()

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
+  "globalDependencies": ["packages/config/biome.json"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Task

T-0007 — Finish Biome config + document Biome-only lint approach

## Summary

- Created `packages/config/biome.json` as the shared base (≥90% rule overlap between apps)
- `apps/web/biome.json` extends shared config; keeps CSS parser overrides (`tailwindDirectives`, `cssModules`)
- `apps/mobile/biome.json` extends shared config; overrides `lineWidth: 80` and `quoteStyle: "single"`
- Removed `eslint` and `eslint-plugin-tailwind-canonical-classes` from `apps/web/package.json` (forbidden tech per HARD_RULES §2)
- Added `globalDependencies: ["packages/config/biome.json"]` to `turbo.json` so shared config changes invalidate lint caches
- Added `## Linting` section to `README.md` documenting the approach, per-app overrides table, and rationale for disabled Tailwind class sorting

## Acceptance criteria

- [x] Decision documented in `README.md ## Linting`: **shared-config extended** approach
- [x] `packages/config/biome.json` exists and each app's `biome.json` uses `"extends": ["../../packages/config/biome.json"]`
- [x] `bun run lint` succeeds at repo root across all workspaces (5/5, 0 errors)
- [x] `turbo.json` has `lint` pipeline entry with `globalDependencies` for the shared config
- [x] No ESLint, no Prettier anywhere — `eslint` + `eslint-plugin-tailwind-canonical-classes` removed

## Grep proof — no ESLint/Prettier

```
$ grep -r "\"eslint\|\"prettier\|@typescript-eslint" apps/*/package.json packages/*/package.json package.json
(no output)
```

## Test plan

- [x] `bun run lint` at repo root → all 5 workspaces pass
- [x] `bun run lint` in `apps/web` → passes
- [x] `bun run lint` in `apps/mobile` → passes

## Unblocks

T-0020 — GitHub Actions CI (type-check, lint, test, hard-rules scan)

Made with [Cursor](https://cursor.com)