### PR TITLE
chore: add root test script delegating to turbo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    # TODO(Phase 3): root `test` script not yet defined in package.json.
-    # Keeping continue-on-error until the script lands so CI does not block
-    # unrelated PRs. Remove `continue-on-error` once `bun run test` exists.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -62,13 +58,8 @@ jobs:
           bun-version: latest
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Run tests (best-effort until script exists)
-        run: |
-          if node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)" 2>/dev/null; then
-            bun run test
-          else
-            echo "::notice::root 'test' script not yet implemented — Phase 3 will add it"
-          fi
+      - name: Run tests
+        run: bun run test
 
   scan:
     name: Scans (forbidden-tech, ram-only-audit, design-tokens)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "turbo run build",
     "typecheck": "turbo run typecheck",
     "lint": "turbo run lint",
+    "test": "turbo run test",
     "check": "turbo run check",
     "clean": "turbo run clean && rm -rf node_modules",
     "convex:dev": "bun x convex dev",

--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,7 @@
     },
     "test": {
       "dependsOn": ["^test"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": []
     },
     "clean": {

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,10 @@
     "check": {
       "dependsOn": ["^check"]
     },
+    "test": {
+      "dependsOn": ["^test"],
+      "outputs": []
+    },
     "clean": {
       "cache": false
     }


### PR DESCRIPTION
## Summary
Adds a root `test` script (`turbo run test`) and a `test` task in `turbo.json`, then removes the Phase 3 `continue-on-error` workaround on the CI test job.

Until any workspace package defines its own `test` script, `turbo run test` exits 0 with "No tasks were run", so CI stays green. As soon as a package (convex, packages/*, apps/*) adds `test`, turbo picks it up automatically.

Ref: `docs/TASKS.md` → Backlog → Tests → "Add a root `test` script".

## Scope
- Only adds the script + turbo task + CI tightening.
- Writing actual unit tests is explicitly out of scope; tracked separately in the same backlog entry.

## Branch naming note
Branch is `claude/executor-advisor-workflow-mEmTN` per the agent harness spec, which diverges from the repo's `chore/<scope>-<kebab>` convention in HARD_RULES §4. Happy to rename before merge if preferred.

## Test plan
- [ ] CI `test` job runs `bun run test` and passes (no tasks run until a package defines one).
- [ ] CI `typecheck`, `lint`, `scan` jobs unaffected.
- [ ] `turbo run test` locally exits 0 with "No tasks were run".

---
_Generated by [Claude Code](https://claude.ai/code/session_017f5ms5eswWgNL2rp1Jo9BM)_