### PR TITLE
chore(today): PR #21 hardening pass — control-char fix, midnight refresh, packages biome config, unit tests

### DIFF
--- a/apps/web/components/today/TodayScreen.tsx
+++ b/apps/web/components/today/TodayScreen.tsx
@@ -2,18 +2,20 @@
 
 import { useConvexAuth, useQuery } from "convex/react";
 import Link from "next/link";
-import { useMemo } from "react";
 import { SoftCard } from "@/components/soft-editorial/SoftCard";
 import { Button } from "@/components/ui/button";
 import { api } from "@/convex/_generated/api";
-import { getLocalDayBoundsMs } from "@/lib/todayBounds";
+import { useLocalDayBounds } from "@/lib/useLocalDayBounds";
 import { TodayBrainDumpPanel } from "./TodayBrainDumpPanel";
 import { TodayGreeting } from "./TodayGreeting";
 import { TodayQuickAdd } from "./TodayQuickAdd";
 import { TodayTaskList } from "./TodayTaskList";
 
 export function TodayScreen() {
-  const bounds = useMemo(() => getLocalDayBoundsMs(), []);
+  // Reactive bounds: refreshes across local midnight, on visibility change, and
+  // on window focus, so quick-add and brain-dump-to-Today never tag tasks with
+  // yesterday's `dueAt` after a tab is left open overnight.
+  const bounds = useLocalDayBounds();
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
   const profile = useQuery(api.users.getProfile, isAuthenticated ? {} : "skip");
   // Only subscribe after we know the Convex app user exists (getProfile is non-throwing
@@ -22,9 +24,7 @@ export function TodayScreen() {
   const hasConvexUser = profile != null;
   const todayTasks = useQuery(
     api.tasks.listToday,
-    isAuthenticated && hasConvexUser
-      ? { dueFrom: bounds.startMs, dueTo: bounds.endMs }
-      : "skip",
+    isAuthenticated && hasConvexUser ? { dueFrom: bounds.startMs, dueTo: bounds.endMs } : "skip"
   );
 
   const isLoading =

--- a/apps/web/lib/brainDumpPrioritizer.test.ts
+++ b/apps/web/lib/brainDumpPrioritizer.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { prioritizeBrainDump } from "./brainDumpPrioritizer";
+
+describe("prioritizeBrainDump", () => {
+  test("returns empty plan with helpful summary for empty string", () => {
+    const plan = prioritizeBrainDump("");
+    expect(plan.priorities).toEqual([]);
+    expect(plan.summary).toContain("Nothing clear to organize");
+  });
+
+  test("returns empty plan for whitespace-only input", () => {
+    const plan = prioritizeBrainDump("   \n\t\r\n   ");
+    expect(plan.priorities).toEqual([]);
+    expect(plan.summary).toContain("Nothing clear to organize");
+  });
+
+  test("splits a bulleted list into separate priorities", () => {
+    const plan = prioritizeBrainDump("- pay rent\n- call mom\n- send email");
+    expect(plan.priorities.length).toBe(3);
+    const titles = plan.priorities.map((p) => p.title.toLowerCase());
+    expect(titles).toEqual(expect.arrayContaining(["pay rent", "call mom", "send email"]));
+  });
+
+  test("splits a semicolon-delimited list", () => {
+    const plan = prioritizeBrainDump("pay rent; call mom; send email");
+    expect(plan.priorities.length).toBe(3);
+  });
+
+  test("caps total priorities at 6 even with many items", () => {
+    const text = Array.from({ length: 30 }, (_, i) => `task ${i + 1} item to do today`).join("\n");
+    const plan = prioritizeBrainDump(text);
+    expect(plan.priorities.length).toBe(6);
+  });
+
+  test("classifies explicit deadline language as 'now'", () => {
+    const plan = prioritizeBrainDump("URGENT: pay rent today");
+    const top = plan.priorities[0];
+    expect(top).toBeDefined();
+    expect(top?.urgency).toBe("now");
+  });
+
+  test("classifies parking-lot language as 'later'", () => {
+    const plan = prioritizeBrainDump("someday explore Italy");
+    const top = plan.priorities[0];
+    expect(top).toBeDefined();
+    expect(top?.urgency).toBe("later");
+  });
+
+  test("classifies week-scoped follow-up as 'soon'", () => {
+    const plan = prioritizeBrainDump("follow up with Sam tomorrow");
+    const top = plan.priorities[0];
+    expect(top).toBeDefined();
+    expect(top?.urgency).toBe("soon");
+  });
+
+  test("deduplicates identical lines", () => {
+    const plan = prioritizeBrainDump("pay rent\npay rent\npay rent");
+    expect(plan.priorities.length).toBe(1);
+  });
+
+  test("strips control characters from titles", () => {
+    const plan = prioritizeBrainDump("pay\u0000rent\nfinish\u0007report");
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: asserting absence of C0/C1 controls
+    const controlChars = /[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/;
+    for (const priority of plan.priorities) {
+      expect(controlChars.test(priority.title)).toBe(false);
+    }
+    expect(plan.priorities.length).toBeGreaterThan(0);
+  });
+
+  test("trims filler prefixes like 'I need to'", () => {
+    const plan = prioritizeBrainDump("I need to pay rent");
+    expect(plan.priorities.length).toBe(1);
+    const first = plan.priorities[0];
+    expect(first).toBeDefined();
+    expect(first?.title.toLowerCase()).not.toContain("i need to");
+    expect(first?.title.toLowerCase()).toContain("pay rent");
+  });
+
+  test("shortens overly long single-line titles to <= ~80 chars", () => {
+    const plan = prioritizeBrainDump("x".repeat(2000));
+    const first = plan.priorities[0];
+    expect(first).toBeDefined();
+    if (first) {
+      expect(first.title.length).toBeLessThanOrEqual(82);
+    }
+  });
+
+  test("handles very large input without throwing", () => {
+    const text = "task one. ".repeat(1100);
+    const plan = prioritizeBrainDump(text);
+    expect(plan.priorities.length).toBeGreaterThan(0);
+    expect(plan.priorities.length).toBeLessThanOrEqual(6);
+  });
+
+  test("every priority has a non-empty title and reason", () => {
+    const plan = prioritizeBrainDump(
+      "pay rent today, call mom tomorrow, finish report this week, schedule dentist appointment, plan the trip for sunday, fix the bug, pick up the kids",
+    );
+    for (const priority of plan.priorities) {
+      expect(priority.title.trim().length).toBeGreaterThan(0);
+      expect(priority.reason.trim().length).toBeGreaterThan(0);
+      expect(["now", "soon", "later"]).toContain(priority.urgency);
+    }
+  });
+
+  test("summary always references the first priority when one exists", () => {
+    const plan = prioritizeBrainDump("call dentist today\nmaybe plan sunday");
+    expect(plan.priorities.length).toBeGreaterThan(0);
+    const first = plan.priorities[0];
+    expect(first).toBeDefined();
+    if (first) {
+      expect(plan.summary.toLowerCase()).toContain(first.title.toLowerCase());
+    }
+  });
+});

--- a/apps/web/lib/brainDumpPrioritizer.test.ts
+++ b/apps/web/lib/brainDumpPrioritizer.test.ts
@@ -95,7 +95,7 @@ describe("prioritizeBrainDump", () => {
 
   test("every priority has a non-empty title and reason", () => {
     const plan = prioritizeBrainDump(
-      "pay rent today, call mom tomorrow, finish report this week, schedule dentist appointment, plan the trip for sunday, fix the bug, pick up the kids",
+      "pay rent today, call mom tomorrow, finish report this week, schedule dentist appointment, plan the trip for sunday, fix the bug, pick up the kids"
     );
     for (const priority of plan.priorities) {
       expect(priority.title.trim().length).toBeGreaterThan(0);

--- a/apps/web/lib/brainDumpPrioritizer.ts
+++ b/apps/web/lib/brainDumpPrioritizer.ts
@@ -89,19 +89,21 @@ function titleCaseFirst(text: string) {
 }
 
 function normalizeWhitespace(text: string) {
-  return text
-    .replace(/\r\n/g, "\n")
-    .replace(/\t/g, " ")
-    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping C0/C1 control chars is the intent
-    .replace(/[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
+  return (
+    text
+      .replace(/\r\n/g, "\n")
+      .replace(/\t/g, " ")
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping C0/C1 control chars is the intent
+      .replace(/[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/g, "")
+      .replace(/\s+/g, " ")
+      .trim()
+  );
 }
 
 function trimFiller(text: string) {
   return text.replace(
     /^(?:i need to|need to|i should|should|i have to|have to|must|remember to|don't forget to|dont forget to|please|pls|also|and|then|maybe|ugh|omg)\s+/i,
-    "",
+    ""
   );
 }
 
@@ -114,9 +116,7 @@ function shortenTitle(text: string, limit = 78) {
 
 function startsWithAction(text: string) {
   const lowered = text.toLowerCase();
-  return ACTION_HINTS.some(
-    (hint) => lowered.startsWith(`${hint} `) || lowered === hint,
-  );
+  return ACTION_HINTS.some((hint) => lowered.startsWith(`${hint} `) || lowered === hint);
 }
 
 function splitBrainDump(rawText: string) {
@@ -130,7 +130,7 @@ function splitBrainDump(rawText: string) {
     .split("\n")
     .flatMap((line) => line.split(/\s*;\s*/))
     .flatMap((line) =>
-      line.length > 90 ? line.split(/\s*,\s*(?=[a-zA-Z(])/).filter(Boolean) : [line],
+      line.length > 90 ? line.split(/\s*,\s*(?=[a-zA-Z(])/).filter(Boolean) : [line]
     )
     .map((line) => normalizeWhitespace(trimFiller(line)))
     .filter((line) => line.length >= 3);

--- a/apps/web/lib/brainDumpPrioritizer.ts
+++ b/apps/web/lib/brainDumpPrioritizer.ts
@@ -89,7 +89,13 @@ function titleCaseFirst(text: string) {
 }
 
 function normalizeWhitespace(text: string) {
-  return text.replace(/\r\n/g, "\n").replace(/\t/g, " ").replace(/\s+/g, " ").trim();
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/\t/g, " ")
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping C0/C1 control chars is the intent
+    .replace(/[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function trimFiller(text: string) {

--- a/apps/web/lib/todayBounds.test.ts
+++ b/apps/web/lib/todayBounds.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { getLocalDayBoundsMs } from "./todayBounds";
+
+describe("getLocalDayBoundsMs", () => {
+  test("returns a 24h half-open window in local time", () => {
+    const noon = new Date(2026, 3, 15, 12, 30, 45);
+    const bounds = getLocalDayBoundsMs(noon);
+    expect(bounds.endMs - bounds.startMs).toBe(24 * 60 * 60 * 1000);
+    expect(bounds.startMs).toBeLessThanOrEqual(noon.getTime());
+    expect(bounds.endMs).toBeGreaterThan(noon.getTime());
+  });
+
+  test("startMs aligns to local midnight", () => {
+    const sample = new Date(2026, 3, 15, 23, 59, 59, 999);
+    const bounds = getLocalDayBoundsMs(sample);
+    const start = new Date(bounds.startMs);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getSeconds()).toBe(0);
+    expect(start.getMilliseconds()).toBe(0);
+    expect(start.getFullYear()).toBe(sample.getFullYear());
+    expect(start.getMonth()).toBe(sample.getMonth());
+    expect(start.getDate()).toBe(sample.getDate());
+  });
+
+  test("a task with dueAt = endMs - 1 falls inside today's bounds", () => {
+    const bounds = getLocalDayBoundsMs(new Date(2026, 3, 15, 9));
+    const dueAt = bounds.endMs - 1;
+    expect(dueAt).toBeGreaterThanOrEqual(bounds.startMs);
+    expect(dueAt).toBeLessThan(bounds.endMs);
+  });
+
+  test("a task with dueAt = endMs (exclusive) falls outside today's bounds", () => {
+    const bounds = getLocalDayBoundsMs(new Date(2026, 3, 15, 9));
+    const dueAt = bounds.endMs;
+    expect(dueAt < bounds.startMs || dueAt >= bounds.endMs).toBe(true);
+  });
+
+  test("crossing midnight produces non-overlapping consecutive windows", () => {
+    const today = getLocalDayBoundsMs(new Date(2026, 3, 15, 23, 59, 59));
+    const tomorrow = getLocalDayBoundsMs(new Date(2026, 3, 16, 0, 0, 0, 1));
+    expect(today.endMs).toBe(tomorrow.startMs);
+  });
+});

--- a/apps/web/lib/todayBounds.test.ts
+++ b/apps/web/lib/todayBounds.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getLocalDayBoundsMs } from "./todayBounds";
+import { getLocalDayBoundsMs, nextLocalDayRolloverDelayMs } from "./todayBounds";
 
 describe("getLocalDayBoundsMs", () => {
   test("returns a 24h half-open window in local time", () => {
@@ -40,5 +40,50 @@ describe("getLocalDayBoundsMs", () => {
     const today = getLocalDayBoundsMs(new Date(2026, 3, 15, 23, 59, 59));
     const tomorrow = getLocalDayBoundsMs(new Date(2026, 3, 16, 0, 0, 0, 1));
     expect(today.endMs).toBe(tomorrow.startMs);
+  });
+});
+
+describe("nextLocalDayRolloverDelayMs", () => {
+  test("at noon the next rollover is roughly 12 hours away (with 50ms cushion)", () => {
+    const noon = new Date(2026, 3, 15, 12, 0, 0).getTime();
+    const delay = nextLocalDayRolloverDelayMs(noon);
+    const twelveHours = 12 * 60 * 60 * 1000;
+    expect(delay).toBeGreaterThanOrEqual(twelveHours);
+    expect(delay).toBeLessThanOrEqual(twelveHours + 100);
+  });
+
+  test("one second before midnight the delay is ~1050ms (1s + 50ms cushion)", () => {
+    const almostMidnight = new Date(2026, 3, 15, 23, 59, 59).getTime();
+    const delay = nextLocalDayRolloverDelayMs(almostMidnight);
+    expect(delay).toBeGreaterThanOrEqual(1000);
+    expect(delay).toBeLessThanOrEqual(1100);
+  });
+
+  test("exactly at midnight the delay floors to a positive 50ms minimum", () => {
+    const midnight = new Date(2026, 3, 16, 0, 0, 0).getTime();
+    const delay = nextLocalDayRolloverDelayMs(midnight);
+    // At local midnight the previous-day window has just closed; the helper
+    // recomputes against the new day, which gives a full ~24h delay. The key
+    // invariant is that it is strictly positive (>= 50ms) so a stale timer
+    // can never fire-immediately-loop.
+    expect(delay).toBeGreaterThanOrEqual(50);
+  });
+
+  test("delay is always strictly positive", () => {
+    for (const ts of [
+      new Date(2026, 0, 1, 0, 0, 0).getTime(),
+      new Date(2026, 5, 30, 23, 59, 59, 999).getTime(),
+      new Date(2026, 11, 31, 12, 0, 0).getTime(),
+      Date.now(),
+    ]) {
+      expect(nextLocalDayRolloverDelayMs(ts)).toBeGreaterThanOrEqual(50);
+    }
+  });
+
+  test("delay aligns to the day rollover (now + delay >= next-day startMs)", () => {
+    const sample = new Date(2026, 3, 15, 14, 30, 0).getTime();
+    const delay = nextLocalDayRolloverDelayMs(sample);
+    const nextDay = getLocalDayBoundsMs(new Date(sample)).endMs;
+    expect(sample + delay).toBeGreaterThanOrEqual(nextDay);
   });
 });

--- a/apps/web/lib/todayBounds.ts
+++ b/apps/web/lib/todayBounds.ts
@@ -4,3 +4,15 @@ export function getLocalDayBoundsMs(d = new Date()): { startMs: number; endMs: n
   const end = start + 24 * 60 * 60 * 1000;
   return { startMs: start, endMs: end };
 }
+
+/**
+ * Milliseconds from `now` until the moment a `useLocalDayBounds` recompute
+ * should run. Always strictly positive (minimum 50ms) so the timer fires after
+ * the new local day has actually begun, never before.
+ *
+ * Pure / dependency-free for unit testing.
+ */
+export function nextLocalDayRolloverDelayMs(now: number): number {
+  const { endMs } = getLocalDayBoundsMs(new Date(now));
+  return Math.max(50, endMs - now + 50);
+}

--- a/apps/web/lib/useLocalDayBounds.ts
+++ b/apps/web/lib/useLocalDayBounds.ts
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getLocalDayBoundsMs, nextLocalDayRolloverDelayMs } from "./todayBounds";
+
+/**
+ * Reactive version of {@link getLocalDayBoundsMs}.
+ *
+ * Returns the current local-day bounds and refreshes them automatically when:
+ *  - the local day rolls over while the page is open (single `setTimeout`
+ *    scheduled for `endMs - Date.now()`, then re-armed)
+ *  - the tab returns from background (`visibilitychange` → `visible`) so a
+ *    laptop reopened the next morning catches up immediately
+ *  - the window regains focus (covers desktop window-manager edge cases)
+ *
+ * Avoids polling: at most one timer per tab and only a recompute when the
+ * date actually changed. Quick-add and Add-to-Today reads of `bounds.endMs - 1`
+ * therefore stay correct across midnight without a manual reload.
+ */
+export function useLocalDayBounds(): { startMs: number; endMs: number } {
+  const [bounds, setBounds] = useState<{ startMs: number; endMs: number }>(() =>
+    getLocalDayBoundsMs()
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const recompute = () => {
+      if (cancelled) return;
+      const next = getLocalDayBoundsMs();
+      setBounds((prev) =>
+        prev.startMs === next.startMs && prev.endMs === next.endMs ? prev : next
+      );
+    };
+
+    const scheduleNextTick = () => {
+      if (cancelled) return;
+      const delay = nextLocalDayRolloverDelayMs(Date.now());
+      timeoutId = setTimeout(() => {
+        recompute();
+        scheduleNextTick();
+      }, delay);
+    };
+
+    const onVisibilityOrFocus = () => {
+      if (typeof document !== "undefined" && document.hidden) return;
+      recompute();
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      scheduleNextTick();
+    };
+
+    scheduleNextTick();
+
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibilityOrFocus);
+    }
+    if (typeof window !== "undefined") {
+      window.addEventListener("focus", onVisibilityOrFocus);
+    }
+
+    return () => {
+      cancelled = true;
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibilityOrFocus);
+      }
+      if (typeof window !== "undefined") {
+        window.removeEventListener("focus", onVisibilityOrFocus);
+      }
+    };
+  }, []);
+
+  return bounds;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
+        "@types/bun": "^1.3.13",
         "@types/node": "^20.19.0",
         "turbo": "^2.3.3",
       },
@@ -746,6 +747,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@types/graceful-fs": ["@types/graceful-fs@4.1.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ=="],
 
     "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
@@ -863,6 +866,8 @@
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/convex/brain_dump.test.ts
+++ b/convex/brain_dump.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { parsePlanFromModelContent } from "./brain_dump";
+
+describe("parsePlanFromModelContent", () => {
+  test("parses a clean JSON plan", () => {
+    const json = JSON.stringify({
+      summary: "Start with rent, then call mom.",
+      priorities: [
+        { title: "Pay rent", reason: "Deadline tonight.", urgency: "now" },
+        { title: "Call mom", reason: "Promised yesterday.", urgency: "soon" },
+      ],
+    });
+    const plan = parsePlanFromModelContent(json);
+    expect(plan.summary).toContain("rent");
+    expect(plan.priorities.length).toBe(2);
+    expect(plan.priorities[0]?.urgency).toBe("now");
+    expect(plan.priorities[1]?.urgency).toBe("soon");
+  });
+
+  test("unwraps a fenced ```json``` block", () => {
+    const fenced = "```json\n" +
+      JSON.stringify({
+        summary: "All clear.",
+        priorities: [{ title: "Send email", reason: "Open loop.", urgency: "now" }],
+      }) +
+      "\n```";
+    const plan = parsePlanFromModelContent(fenced);
+    expect(plan.priorities.length).toBe(1);
+    expect(plan.priorities[0]?.title).toBe("Send email");
+  });
+
+  test("throws friendly error on non-JSON content", () => {
+    expect(() => parsePlanFromModelContent("hello not json")).toThrow(/plan/i);
+  });
+
+  test("throws on empty summary", () => {
+    const json = JSON.stringify({
+      summary: "   ",
+      priorities: [{ title: "Pay rent", reason: "Deadline.", urgency: "now" }],
+    });
+    expect(() => parsePlanFromModelContent(json)).toThrow(/incomplete/i);
+  });
+
+  test("throws when priorities array is missing", () => {
+    const json = JSON.stringify({ summary: "Plan." });
+    expect(() => parsePlanFromModelContent(json)).toThrow(/incomplete/i);
+  });
+
+  test("throws when no valid priority items remain after filtering", () => {
+    const json = JSON.stringify({
+      summary: "Plan.",
+      priorities: [
+        { title: "", reason: "blank", urgency: "now" },
+        { title: "Title", reason: "", urgency: "now" },
+        { title: "Title", reason: "Reason", urgency: "whenever" },
+      ],
+    });
+    expect(() => parsePlanFromModelContent(json)).toThrow(/no clear items/i);
+  });
+
+  test("caps to 6 priorities even if model returns more", () => {
+    const json = JSON.stringify({
+      summary: "Plan.",
+      priorities: Array.from({ length: 12 }, (_, i) => ({
+        title: `Task ${i}`,
+        reason: "Because.",
+        urgency: "soon",
+      })),
+    });
+    const plan = parsePlanFromModelContent(json);
+    expect(plan.priorities.length).toBe(6);
+  });
+
+  test("skips invalid urgency values but keeps valid ones", () => {
+    const json = JSON.stringify({
+      summary: "Plan.",
+      priorities: [
+        { title: "Bad", reason: "Reason.", urgency: "asap" },
+        { title: "Good", reason: "Reason.", urgency: "later" },
+      ],
+    });
+    const plan = parsePlanFromModelContent(json);
+    expect(plan.priorities.length).toBe(1);
+    expect(plan.priorities[0]?.urgency).toBe("later");
+  });
+
+  test("strips C0 control characters from title and reason", () => {
+    const json = JSON.stringify({
+      summary: "Plan.",
+      priorities: [
+        {
+          title: "Pay\u0000rent\u0001",
+          reason: "Bad\u0007 chars",
+          urgency: "now",
+        },
+      ],
+    });
+    const plan = parsePlanFromModelContent(json);
+    expect(plan.priorities.length).toBe(1);
+    const first = plan.priorities[0];
+    expect(first).toBeDefined();
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: asserting absence of C0/C1 controls
+    const controlChars = /[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/;
+    if (first) {
+      expect(controlChars.test(first.title)).toBe(false);
+      expect(controlChars.test(first.reason)).toBe(false);
+    }
+  });
+
+  test("truncates extremely long titles to <= 200 chars", () => {
+    const json = JSON.stringify({
+      summary: "Plan.",
+      priorities: [
+        {
+          title: "x".repeat(500),
+          reason: "Reason.",
+          urgency: "now",
+        },
+      ],
+    });
+    const plan = parsePlanFromModelContent(json);
+    const first = plan.priorities[0];
+    expect(first).toBeDefined();
+    if (first) {
+      expect(first.title.length).toBeLessThanOrEqual(200);
+    }
+  });
+
+  test("rejects non-object root JSON", () => {
+    expect(() => parsePlanFromModelContent("[1,2,3]")).toThrow(/incomplete/i);
+    expect(() => parsePlanFromModelContent("\"just a string\"")).toThrow(/incomplete/i);
+  });
+});

--- a/convex/brain_dump.ts
+++ b/convex/brain_dump.ts
@@ -44,7 +44,20 @@ function isUrgency(x: unknown): x is BrainDumpUrgency {
   return x === "now" || x === "soon" || x === "later";
 }
 
-function parsePlanFromModelContent(content: string): BrainDumpPlan {
+function sanitizeText(text: string): string {
+  // Strip C0/C1 control characters that could leak through from a malformed model
+  // response, then collapse internal whitespace. We do not change the visible
+  // characters, just remove ones that should never appear in a task title.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping C0/C1 control chars is the intent
+  return text.replace(/[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/g, "").trim();
+}
+
+/**
+ * Exported for unit tests. Pure function that converts a model content string
+ * into a validated {@link BrainDumpPlan}. Throws a friendly Error on invalid
+ * shape. Strips C0/C1 control chars from string fields.
+ */
+export function parsePlanFromModelContent(content: string): BrainDumpPlan {
   const trimmed = content.trim();
   let parsed: unknown;
   try {
@@ -68,7 +81,7 @@ function parsePlanFromModelContent(content: string): BrainDumpPlan {
 
   const obj = parsed as Record<string, unknown>;
   const summary =
-    typeof obj.summary === "string" ? obj.summary.trim() : "";
+    typeof obj.summary === "string" ? sanitizeText(obj.summary) : "";
   if (!summary) {
     throw new Error("Plan response was incomplete. Try again?");
   }
@@ -83,8 +96,8 @@ function parsePlanFromModelContent(content: string): BrainDumpPlan {
     if (priorities.length >= 6) break;
     if (!item || typeof item !== "object" || Array.isArray(item)) continue;
     const row = item as Record<string, unknown>;
-    const title = typeof row.title === "string" ? row.title.trim() : "";
-    const reason = typeof row.reason === "string" ? row.reason.trim() : "";
+    const title = typeof row.title === "string" ? sanitizeText(row.title) : "";
+    const reason = typeof row.reason === "string" ? sanitizeText(row.reason) : "";
     const urgency = row.urgency;
     if (!title || !reason || !isUrgency(urgency)) continue;
     priorities.push({

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -157,6 +157,8 @@ export const remove = mutation({
   },
 });
 
+const QUICK_TITLE_MAX = 280;
+
 /** Quick-add a task for today — minimal args, sensible defaults. */
 export const createQuick = mutation({
   args: {
@@ -165,10 +167,16 @@ export const createQuick = mutation({
   },
   handler: async (ctx, args) => {
     const user = await requireUser(ctx);
+    const trimmed = args.title.trim();
+    if (!trimmed) {
+      throw new Error("Title cannot be empty.");
+    }
+    const title =
+      trimmed.length > QUICK_TITLE_MAX ? `${trimmed.slice(0, QUICK_TITLE_MAX - 3)}...` : trimmed;
     const now = Date.now();
     return ctx.db.insert("tasks", {
       userId: user._id,
-      title: args.title.trim(),
+      title,
       status: "todo",
       priority: "medium",
       dueAt: args.dueAt,

--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -15,7 +15,7 @@
     /* These compiler options are required by Convex */
     "target": "ESNext",
     "lib": ["ES2021", "dom"],
-    "types": ["node"],
+    "types": ["node", "bun"],
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "isolatedModules": true,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typecheck": "turbo run typecheck",
     "lint": "turbo run lint",
     "check": "turbo run check",
+    "test": "bun test",
     "clean": "turbo run clean && rm -rf node_modules",
     "convex:dev": "bun x convex dev",
     "convex:deploy": "bun x convex deploy",
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
+    "@types/bun": "^1.3.13",
     "@types/node": "^20.19.0",
     "turbo": "^2.3.3"
   }

--- a/packages/types/biome.json
+++ b/packages/types/biome.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "extends": ["../config/biome.json"],
+  "vcs": {
+    "useIgnoreFile": false
+  },
+  "files": {
+    "includes": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.json", "!**/node_modules"]
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -28,7 +28,22 @@ export type ConvexDeployment = {
 };
 
 export const CONVEX_DEPLOYMENTS: ConvexDeployment[] = [
-  { name: "tremendous-bass-443", url: "https://tremendous-bass-443.convex.cloud", region: "us", env: "dev" },
-  { name: "ceaseless-dog-617", url: "https://ceaseless-dog-617.convex.cloud", region: "eu", env: "staging" },
-  { name: "precious-wildcat-890", url: "https://precious-wildcat-890.eu-west-1.convex.cloud", region: "eu", env: "prod" },
+  {
+    name: "tremendous-bass-443",
+    url: "https://tremendous-bass-443.convex.cloud",
+    region: "us",
+    env: "dev",
+  },
+  {
+    name: "ceaseless-dog-617",
+    url: "https://ceaseless-dog-617.convex.cloud",
+    region: "eu",
+    env: "staging",
+  },
+  {
+    name: "precious-wildcat-890",
+    url: "https://precious-wildcat-890.eu-west-1.convex.cloud",
+    region: "eu",
+    env: "prod",
+  },
 ];

--- a/packages/ui/biome.json
+++ b/packages/ui/biome.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "extends": ["../config/biome.json"],
+  "vcs": {
+    "useIgnoreFile": false
+  },
+  "files": {
+    "includes": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.json", "!**/node_modules"]
+  }
+}

--- a/packages/ui/src/brand/BrandMark.tsx
+++ b/packages/ui/src/brand/BrandMark.tsx
@@ -26,8 +26,20 @@ export function BrandMark({ size = 28, className }: Props) {
           <stop offset="100%" stopColor="#E8A87C" />
         </linearGradient>
       </defs>
-      <path d="M14 16 H50" stroke={`url(#${id})`} strokeWidth="5" strokeLinecap="round" fill="none" />
-      <path d="M32 16 V46" stroke={`url(#${id})`} strokeWidth="5" strokeLinecap="round" fill="none" />
+      <path
+        d="M14 16 H50"
+        stroke={`url(#${id})`}
+        strokeWidth="5"
+        strokeLinecap="round"
+        fill="none"
+      />
+      <path
+        d="M32 16 V46"
+        stroke={`url(#${id})`}
+        strokeWidth="5"
+        strokeLinecap="round"
+        fill="none"
+      />
       <circle cx="42" cy="44" r="6" fill={`url(#${id})`} />
     </svg>
   );

--- a/packages/ui/src/brand/Wordmark.tsx
+++ b/packages/ui/src/brand/Wordmark.tsx
@@ -8,11 +8,7 @@ type Props = {
  * Wordmark — Tempo + Flow composite.
  * @source docs/design/claude-export/design-system/components.jsx:L106-L110
  */
-export function Wordmark({
-  size = 22,
-  color = "var(--color-foreground)",
-  className,
-}: Props) {
+export function Wordmark({ size = 22, color = "var(--color-foreground)", className }: Props) {
   return (
     <span
       className={className}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,14 +10,15 @@
  *   - `@tempo/ui/theme`       → design tokens as TypeScript constants
  *   - `@tempo/ui/native`      → RN-native primitives
  */
-export * from "./primitives";
+
 export { BrandMark, Wordmark } from "./brand";
+export * from "./primitives";
 export {
+  type TempoColorToken,
   tempoColors,
   tempoColorsDark,
   tempoFonts,
+  tempoMotion,
   tempoRadii,
   tempoSpacing,
-  tempoMotion,
-  type TempoColorToken,
 } from "./theme/tokens";

--- a/packages/ui/src/primitives/Button.tsx
+++ b/packages/ui/src/primitives/Button.tsx
@@ -13,18 +13,11 @@ import type { ButtonHTMLAttributes, ReactNode } from "react";
  *   - inverse  : ink fill, cream text
  *   - destructive : brick fill
  */
-export type ButtonVariant =
-  | "primary"
-  | "soft"
-  | "ghost"
-  | "subtle"
-  | "inverse"
-  | "destructive";
+export type ButtonVariant = "primary" | "soft" | "ghost" | "subtle" | "inverse" | "destructive";
 export type ButtonSize = "sm" | "md" | "lg";
 
 const variantMap: Record<ButtonVariant, string> = {
-  primary:
-    "bg-primary text-primary-foreground hover:brightness-105 active:brightness-95",
+  primary: "bg-primary text-primary-foreground hover:brightness-105 active:brightness-95",
   soft: "bg-card text-foreground border border-border hover:bg-surface-sunken",
   ghost: "bg-transparent text-foreground hover:bg-surface-sunken",
   subtle: "bg-surface-sunken text-muted-foreground hover:text-foreground",

--- a/packages/ui/src/primitives/CoachBubble.tsx
+++ b/packages/ui/src/primitives/CoachBubble.tsx
@@ -20,10 +20,8 @@ export type CoachBubbleProps = {
 
 const roleMap: Record<CoachBubbleRole, string> = {
   coach: "bg-card border-border-soft text-foreground self-start",
-  user:
-    "bg-surface-inverse text-cream border-transparent self-end",
-  system:
-    "bg-surface-sunken text-muted-foreground border-border-soft self-center",
+  user: "bg-surface-inverse text-cream border-transparent self-end",
+  system: "bg-surface-sunken text-muted-foreground border-border-soft self-center",
 };
 
 export function CoachBubble({
@@ -42,12 +40,8 @@ export function CoachBubble({
       ].join(" ")}
     >
       <div className="text-body leading-6">{children}</div>
-      {actions ? (
-        <div className="flex flex-wrap items-center gap-2 pt-1">{actions}</div>
-      ) : null}
-      {timestamp ? (
-        <span className="text-caption font-tabular opacity-60">{timestamp}</span>
-      ) : null}
+      {actions ? <div className="flex flex-wrap items-center gap-2 pt-1">{actions}</div> : null}
+      {timestamp ? <span className="text-caption font-tabular opacity-60">{timestamp}</span> : null}
     </div>
   );
 }

--- a/packages/ui/src/primitives/Field.tsx
+++ b/packages/ui/src/primitives/Field.tsx
@@ -11,21 +11,11 @@ export type FieldProps = InputHTMLAttributes<HTMLInputElement> & {
   trailing?: ReactNode;
 };
 
-export function Field({
-  label,
-  helper,
-  error,
-  trailing,
-  id,
-  className = "",
-  ...rest
-}: FieldProps) {
+export function Field({ label, helper, error, trailing, id, className = "", ...rest }: FieldProps) {
   const fieldId = id ?? rest.name;
   return (
     <label className="flex w-full flex-col gap-1.5" htmlFor={fieldId}>
-      {label ? (
-        <span className="font-eyebrow text-muted-foreground">{label}</span>
-      ) : null}
+      {label ? <span className="font-eyebrow text-muted-foreground">{label}</span> : null}
       <span
         className={[
           "flex items-center gap-2 rounded-lg border border-border bg-card px-3 h-10",
@@ -46,9 +36,7 @@ export function Field({
       {helper && !error ? (
         <span className="text-caption text-muted-foreground">{helper}</span>
       ) : null}
-      {error ? (
-        <span className="text-caption text-destructive">{error}</span>
-      ) : null}
+      {error ? <span className="text-caption text-destructive">{error}</span> : null}
     </label>
   );
 }

--- a/packages/ui/src/primitives/HabitRing.tsx
+++ b/packages/ui/src/primitives/HabitRing.tsx
@@ -12,12 +12,7 @@ type Props = {
   size?: number;
 };
 
-export function HabitRing({
-  completed,
-  total = 7,
-  label,
-  size = 44,
-}: Props) {
+export function HabitRing({ completed, total = 7, label, size = 44 }: Props) {
   return (
     <div className="flex flex-col items-center gap-1">
       <Ring size={size} value={completed} max={total}>
@@ -26,9 +21,7 @@ export function HabitRing({
           <span className="text-muted-foreground">/{total}</span>
         </span>
       </Ring>
-      {label ? (
-        <span className="text-caption text-muted-foreground">{label}</span>
-      ) : null}
+      {label ? <span className="text-caption text-muted-foreground">{label}</span> : null}
     </div>
   );
 }

--- a/packages/ui/src/primitives/Pill.tsx
+++ b/packages/ui/src/primitives/Pill.tsx
@@ -12,27 +12,15 @@ export type PillProps = HTMLAttributes<HTMLSpanElement> & {
 };
 
 const toneMap: Record<PillTone, string> = {
-  neutral:
-    "bg-surface-sunken text-muted-foreground",
-  moss:
-    "bg-[color:var(--color-moss)]/10 text-[color:var(--color-moss)]",
-  brick:
-    "bg-[color:var(--color-brick)]/10 text-[color:var(--color-brick)]",
-  amber:
-    "bg-[color:var(--color-amber)]/14 text-[color:var(--color-amber)]",
-  slate:
-    "bg-[color:var(--color-slate-blue)]/12 text-[color:var(--color-slate-blue)]",
-  orange:
-    "bg-[color:var(--color-tempo-orange)]/12 text-[color:var(--color-tempo-orange)]",
+  neutral: "bg-surface-sunken text-muted-foreground",
+  moss: "bg-[color:var(--color-moss)]/10 text-[color:var(--color-moss)]",
+  brick: "bg-[color:var(--color-brick)]/10 text-[color:var(--color-brick)]",
+  amber: "bg-[color:var(--color-amber)]/14 text-[color:var(--color-amber)]",
+  slate: "bg-[color:var(--color-slate-blue)]/12 text-[color:var(--color-slate-blue)]",
+  orange: "bg-[color:var(--color-tempo-orange)]/12 text-[color:var(--color-tempo-orange)]",
 };
 
-export function Pill({
-  tone = "neutral",
-  leading,
-  className = "",
-  children,
-  ...rest
-}: PillProps) {
+export function Pill({ tone = "neutral", leading, className = "", children, ...rest }: PillProps) {
   return (
     <span
       className={[

--- a/packages/ui/src/primitives/Ring.tsx
+++ b/packages/ui/src/primitives/Ring.tsx
@@ -49,7 +49,14 @@ export function Ring({
         aria-valuemax={max}
       >
         <title>{`${value} of ${max}`}</title>
-        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke={trackColor} strokeWidth={stroke} />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke={trackColor}
+          strokeWidth={stroke}
+        />
         <circle
           cx={size / 2}
           cy={size / 2}

--- a/packages/ui/src/primitives/SoftCard.tsx
+++ b/packages/ui/src/primitives/SoftCard.tsx
@@ -31,12 +31,7 @@ export function SoftCard({
   className = "",
   ...rest
 }: SoftCardProps) {
-  const classes = [
-    "rounded-xl border shadow-whisper",
-    toneMap[tone],
-    padMap[padding],
-    className,
-  ]
+  const classes = ["rounded-xl border shadow-whisper", toneMap[tone], padMap[padding], className]
     .filter(Boolean)
     .join(" ");
   return <Tag className={classes} {...rest} />;

--- a/packages/ui/src/primitives/TaskRow.tsx
+++ b/packages/ui/src/primitives/TaskRow.tsx
@@ -74,9 +74,7 @@ export function TaskRow({
         >
           {title}
         </span>
-        {meta ? (
-          <span className="text-caption text-muted-foreground">{meta}</span>
-        ) : null}
+        {meta ? <span className="text-caption text-muted-foreground">{meta}</span> : null}
       </button>
 
       {trailing}

--- a/packages/ui/src/primitives/index.ts
+++ b/packages/ui/src/primitives/index.ts
@@ -1,8 +1,8 @@
-export { SoftCard, type SoftCardProps } from "./SoftCard";
-export { Button, type ButtonProps, type ButtonVariant, type ButtonSize } from "./Button";
+export { Button, type ButtonProps, type ButtonSize, type ButtonVariant } from "./Button";
+export { CoachBubble, type CoachBubbleProps, type CoachBubbleRole } from "./CoachBubble";
 export { Field, type FieldProps } from "./Field";
+export { HabitRing } from "./HabitRing";
 export { Pill, type PillProps, type PillTone } from "./Pill";
 export { Ring } from "./Ring";
+export { SoftCard, type SoftCardProps } from "./SoftCard";
 export { TaskRow, type TaskRowProps } from "./TaskRow";
-export { HabitRing } from "./HabitRing";
-export { CoachBubble, type CoachBubbleProps, type CoachBubbleRole } from "./CoachBubble";

--- a/packages/utils/biome.json
+++ b/packages/utils/biome.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "extends": ["../config/biome.json"],
+  "vcs": {
+    "useIgnoreFile": false
+  },
+  "files": {
+    "includes": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.json", "!**/node_modules"]
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -25,7 +25,9 @@ export function clamp(value: number, min: number, max: number): number {
  * Generate a random string ID (not cryptographically secure — use Convex IDs for DB)
  */
 export function randomId(length = 8): string {
-  return Math.random().toString(36).substring(2, 2 + length);
+  return Math.random()
+    .toString(36)
+    .substring(2, 2 + length);
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardening pass on the `/today` brain-dump-to-plan flow that landed in #21 (already merged into `master`). Fixes three real defects discovered while auditing the merged code, fills the test gap for the new surface, gives shared workspaces a Biome config so `bun run check` stops failing on them, and wires up `bun run test` so the existing CI `Test` job stops no-opping. No user-visible UI surface change.

## Linked task(s)

Task: PR-21 follow-up (no dedicated `T-XXXX` row — this is a post-merge hardening pass on the merged PR #21 surface).

## Screenshots / screen recording

N/A — no user-visible surface change.

- The control-character strip and the 280-char title cap are silent guards on inputs that the UI already restricts.
- The reactive day-bounds hook only matters for users who keep `/today` open across local midnight or come back to a backgrounded tab the next morning, in which case quick-add and brain-dump-to-Today now use the correct day's `dueAt` automatically instead of yesterday's.

## Test plan

- [x] Local `bun run typecheck` passes (`>>> FULL TURBO`)
- [x] Local `bun run lint` passes (`>>> FULL TURBO`)
- [x] Local `bun run test` passes — **36 pass, 0 fail, 92 `expect()` calls** across 3 files
- [x] Convex `tsc --noEmit` clean against `convex/tsconfig.json`
- [x] `bun run check` passes for `packages/types`, `packages/ui`, `packages/utils` (the new biome configs land them in scope of the shared formatter; `apps/web` and `apps/mobile` still carry pre-existing format drift unrelated to this branch)
- [x] Relevant unit tests added (see below)
- [ ] Manual QA: not run; the changes are pure-logic + reactive-hook hardening with no UI surface change. The originating PR #21 already has manual QA evidence in `docs/phase4-brain-dump-validation.md`. The cross-midnight fix specifically requires waiting through local midnight in a real browser session — outside the autonomous-agent envelope; the new `nextLocalDayRolloverDelayMs` unit tests pin the timer math instead.

## Acceptance criteria

User-stated audit goals:

1. ✅ Verify branch / commit / PR #21 state and changed files — done; PR #21 is **MERGED** at `2026-04-25T14:48:59Z`, head `880137eb…`, merge commit `b71ce705…`.
2. ✅ Audit the `/today` flow.
3. ✅ Add focused tests where useful — 36 new tests across prioritizer, parser, day bounds, rollover-delay helper.
4. ✅ Check edge cases: empty / whitespace / very long / partial Add-to-Today failure / auth missing-or-expired / midnight `dueAt` boundary.
5. ✅ Run typecheck, lint, and tests — all green.
6. ✅ Use a separate branch (`cursor/pr21-hardening-pass-6b93`) and report exact files changed.

## What changed

**Code fixes:**

- `41ba6e3 fix(today): strip control chars and bound quick-add title length`
  - `apps/web/lib/brainDumpPrioritizer.ts` — `normalizeWhitespace` now strips C0/C1 control characters (`\u0000-\u0008`, `\u000B-\u001F`, `\u007F-\u009F`).
  - `convex/brain_dump.ts` — `parsePlanFromModelContent` is now exported and runs the same control-char + trim sanitization on `summary`, `title`, and `reason` from the model response.
  - `convex/tasks.ts` — `createQuick` now rejects empty titles after trim and bounds title length at 280 chars (with ellipsis); UI flows are unaffected because `TodayQuickAdd` validates non-empty before sending and the brain-dump UI already caps to ~78 chars.

- `dc08ab3 fix(today): refresh local-day bounds across midnight, focus, visibility`
  - `apps/web/lib/useLocalDayBounds.ts` *(new)* — client-only hook that returns the current local-day bounds and refreshes them on three triggers: timer set for `endMs - now + 50ms`, `document.visibilitychange → visible`, and `window` `focus`. Uses a single `setTimeout`, never polling.
  - `apps/web/lib/todayBounds.ts` — extracts pure helper `nextLocalDayRolloverDelayMs(now)` for unit testing; floors at 50ms so a stale timer can never fire-immediately-loop.
  - `apps/web/components/today/TodayScreen.tsx` — switches from `useMemo(getLocalDayBoundsMs(), [])` to `useLocalDayBounds()`. This closes the cross-midnight `dueAt` staleness called out in `docs/QA/phase3-audit-2026-04-24.md`.

**Tests:**

- `6a56637 test(today): add unit tests for brain-dump prioritizer and parser`
  - `apps/web/lib/brainDumpPrioritizer.test.ts` — 15 tests: empty / whitespace input, bullet & semicolon splitting, 6-priority cap, urgency classification (`now`/`soon`/`later`), dedupe, control-char strip, filler-prefix trim, long-line shorten, large-input safety, summary consistency.
  - `convex/brain_dump.test.ts` — 11 tests: clean JSON, fenced ```` ```json ```` fallback, friendly error on non-JSON, empty-summary rejection, missing-priorities rejection, invalid-urgency filtering, 6-priority cap, control-char strip, length truncation, non-object root JSON rejection.
  - `apps/web/lib/todayBounds.test.ts` — 10 tests: 24h half-open window, midnight alignment, `dueAt = endMs - 1` is inside, `dueAt = endMs` is outside, consecutive-day windows do not overlap, plus 5 tests for `nextLocalDayRolloverDelayMs` covering noon, ~midnight, exact midnight, always-positive invariant, and alignment with `endMs`.

**Test wiring (in `6a56637`):**

- `package.json` — added `"test": "bun test"` at the workspace root so the existing CI `Test` job stops logging `::notice::root 'test' script not yet implemented` and starts running.
- `bun.lock` — adds `@types/bun@1.3.13` so `bun:test` resolves under the web `tsconfig.json`.
- `convex/tsconfig.json` — adds `"bun"` to `types` so the convex test typechecks under the convex tsconfig.

**Workspace tooling fix:**

- `8489ba0 chore(packages): give shared workspaces a biome.json + format`
  - `packages/types/biome.json`, `packages/ui/biome.json`, `packages/utils/biome.json` *(new)* — each extends `../config/biome.json`, disables `vcs.useIgnoreFile` (Biome looks for `.gitignore` in the cwd, which the package directories do not have), and scopes `files.includes`. Without these, `bun run check` was failing on master because Biome was applying its built-in defaults (tabs, line-width 80) while the rest of the monorepo uses spaces / 100.
  - `packages/{types,utils,ui}/src/**` — re-formatted to the shared style with `biome check --write .`. Pure formatting (line-wrap and method-chain breaks); no logic changes. 14 files touched. `apps/web` and `apps/mobile` carry their own pre-existing format drift that is unrelated to PR #21 and was deliberately left out of scope here.

## Audit findings (no action needed in this PR)

- **PR #21 has already merged.** Pre-merge CI was green and the in-tree audit at the head commit was thorough.
- **Add-to-Today partial-failure path** is already handled correctly in `TodayBrainDumpPanel.tsx` (counts `added`/`failed` independently, removes only successfully-added indices, surfaces a non-shaming hint).
- **Duplicate-prevention** for Add-to-Today is already in place at the head commit `880137eb`.
- **`apps/web` / `apps/mobile` Biome formatter drift** is pre-existing and broad (60+ files); reformatting it here would balloon this hardening PR. Out of scope.
- **Real Mistral-call smoke** still unverified — needs `MISTRAL_API_KEY` in the dev Convex deployment, which is outside the autonomous-agent envelope per the user's no-secrets rule.
- **`docs/brain` submodule pointer drift** in this workspace is pre-existing (the submodule is checked out on `cursor/t-0023-…`); deliberately not bumped.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2). Pure-TS edits + bun test + Biome config.
- [x] AI-originated state changes still surface an accept/reject card (§1, §6) — unchanged.
- [x] No schema changes (§5).
- [x] No styling changes (§7).
- [x] No accessibility regressions (§8) — no UI surface changes.
- [x] No secrets committed; no new env vars (§13).
- [x] Voice rules honored (§1, §9) — error copy unchanged and remains anti-shame.

## Owner tag (§14)

- [x] `cursor-cloud-1` — PR #21 sits in the Core Features cluster (Today / Tasks).

## Reviewer

`human-amit`. This is a code-agent PR; cloud agent will not merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-741b1ebb-266c-4585-9c6a-8ca26e8e6b93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-741b1ebb-266c-4585-9c6a-8ca26e8e6b93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

