### PR TITLE
docs(workflows): next-week agentic workflow plan (week of 2026-04-27)

### DIFF
--- a/.claude/workflows/next-week-2026-04-27.md
+++ b/.claude/workflows/next-week-2026-04-27.md
@@ -1,0 +1,180 @@
+# Tempo — Next-Week Agentic Workflow Plan (week of 2026-04-27)
+
+## Context
+
+Drafted Sat 2026-04-25. PR #21 (the `/today` brain-dump-to-plan loop) is the gate. Locally validated 2026-04-24/25; preview auth + real Mistral path remain unproven. Production Convex isn't linked (T-0008), Resend isn't wired into the linked Convex, Mistral key not set in dashboard, GetTerms / RevenueCat / custom domain all `planned`.
+
+The risk next week is not capability — it is **Amit burning out doing dashboard clicks while three agents idle waiting**. This plan separates work into lanes that run while Amit sleeps, lanes that run when he's at the keyboard for two hours, and lanes that strictly need his hands on a browser. Blocker-first, owner-tag honest.
+
+Week shape: Mon 04-27 → Sun 05-03. Two daytime 2-hour windows per weekday assumed. One nightly cloud run per weekday. Weekend = recover or one optional half-day.
+
+Companion docs: [`executor-advisor.md`](./executor-advisor.md), [`nightly-run-intake.md`](./nightly-run-intake.md), [`cross-surface-guide.md`](./cross-surface-guide.md).
+
+---
+
+## 1. Nightly cloud-agent lanes (unattended, ~6–8h)
+
+Each night, **one bounded slice per cloud agent**. Never "run overnight, see what happens" (per `executor-advisor.md` §6).
+
+| Night | Lane | Slice | Acceptance |
+|---|---|---|---|
+| Sun→Mon | Cursor Cloud `cursor-cloud-1` | Re-enable biome `useBlockStatements` + `noImplicitBoolean` (Linux only — Windows blocker, see TASKS.md Next #2). Auto-fix + open PR. | CI green, PR open, draft. |
+| Mon→Tue | Codex Cloud | Phase 4.5a: brain-dump persistence + reopen/search (per `phase3-audit-2026-04-24.md` recommendation). One ticket. | Draft PR, schema-checker pass. |
+| Tue→Wed | Cursor Cloud `cursor-cloud-2` | Cross-midnight `dueAt` recompute fix on `TodayScreen.tsx` (known issue from audit). | Draft PR, smoke clip in PR body. |
+| Wed→Thu | Cursor Cloud `cursor-cloud-3` | T-0020: implement `pnpm scan:forbidden-tech` + `pnpm scan:secrets` so they stop being `planned`. | Scans run in CI on this PR. |
+| Thu→Fri | Codex Cloud | Convex schema migration prep for `userId: v.optional(v.string())` (per HARD_RULES §5 "current repository" caveat). Plan-only artifact, no schema write. | Migration plan doc + widen-step PR draft. |
+| Fri→Sat | Claude Code web | `/ultrareview` of the merged-this-week stack. | Review report posted to each PR. |
+
+Rules per night: bounded ticket, draft PR only, stop on first §3 escalation trigger, write reason into PR body.
+
+---
+
+## 2. Local two-hour device-agent lanes (Amit at keyboard)
+
+Two windows per weekday. Each window = **one Sonnet executor + Opus advisor** in Cursor (per `executor-advisor.md`). Amit reviews diffs as they land — no unattended local runs.
+
+- **AM window (review + dashboard)**: read last night's PR, decide merge/iterate, then do *one* dashboard action that unblocks the next nightly run.
+- **PM window (build)**: pick one ticket from `_INDEX.md` matching 2-hour budget; Sonnet executes; Opus only on §3 triggers.
+
+If the AM window finds last night's PR is already mergeable: skip straight to the PM ticket. If both windows would land on the same module, serialize.
+
+Hard rule: **no merging a PR Amit hasn't read line-by-line.** Cloud summary ≠ truth (per `nightly-run-intake.md`).
+
+---
+
+## 3. What Cursor Cloud should own
+
+- Repo-aware bounded tickets with files_touched declared.
+- Style/lint sweeps, refactors, scaffolds, schema-adjacent codegen.
+- Anything the verification sub-agents (`tempo-schema-checker`, `tempo-design-token-validator`, `tempo-accept-reject-checker`) can audit on a draft PR.
+- Convex codegen + smoke when the slice is one Convex module.
+
+Do not own: dashboard actions, secret rotation, anything needing a logged-in browser.
+
+## 4. What Codex Cloud should own
+
+- Slices Cursor Cloud has been touching all week (avoid context-collision with itself).
+- Schema migration **planning** (widen-migrate-narrow doc), since it currently produced PR #21 cleanly and is good at long-context spec work.
+- Cross-cutting refactors that touch >3 modules (per §3 escalation trigger, these need an advisor pass anyway).
+- `convex/lib/ai_router.ts` work and AI-router golden-fixture tests.
+
+Do not own: anything where Cursor Cloud is mid-flight on the same files.
+
+## 5. What Claude Code should own
+
+- **Cursor desktop session**: orchestration + executor/advisor for the live 2-hour windows. Opus plans, Sonnet executes (per CLAUDE.md).
+- **Claude Code web**: weekly `/ultrareview` of the merged stack, and any ticket > 45 min that should outlive the laptop being closed.
+- **Mobile**: triage PR status, kick off cloud runs, advisor-style "should I merge?" calls. Never approve merges from mobile.
+- Reconciling cloud summaries against local checkout (per `nightly-run-intake.md`).
+
+Do not own: writing code on mobile, dashboard clicks, autonomous merges.
+
+## 6. What Manus / Bud / Twin / Atlas GUI should own
+
+GUI agents = browser-clicking lanes for things code agents are explicitly forbidden from doing (HARD_RULES §14).
+
+- **Twin** (primary dashboard agent): Convex dashboard env-var sets, Vercel env-var sets, Vercel preview re-enable toggle, Resend domain DNS verification clicks, GetTerms ID retrieval, Mistral console key issuance, RevenueCat project bootstrap.
+- **Manus / Atlas / Bud** (long-form browser flows): sign-up flows for new SaaS (Resend, GetTerms, RevenueCat) where the page has multi-step forms, email verification, OTP. End each run by pasting credentials/IDs into a Twin handoff for env-var entry.
+- All GUI agents stop at "ready to paste" — they never type a secret into a place that persists outside the dashboard. Amit confirms each handoff.
+
+Do not own: writing code, opening PRs, merging anything.
+
+## 7. What must wait for Amit's computer
+
+- Final merge clicks on PRs (HARD_RULES §12 — no agent self-merges).
+- `bun x convex dev` first-run interactive login on any new machine.
+- `bun x eas login` (mobile builds).
+- Reading the diff before merge (mobile is not enough).
+- Resolving merge conflicts when two cloud lanes collide.
+- Promoting `coded` → `locally-tested` in `SHIP_STATE.md`.
+
+Buffer: assume ~15 min/day of merge-review pure time. If the queue exceeds that, the bottleneck is Amit, not the agents — drop a nightly lane rather than push.
+
+## 8. What must wait for payment / manual approval
+
+- **Mistral**: paid API key issuance (free tier insufficient for `mistral-large`). Amit clicks pay.
+- **Resend**: free tier OK for dev volume; domain verification is DNS, not pay.
+- **RevenueCat**: free up to threshold, but Stripe + App Store + Play Store linkage is human-only. Defer to week 2 unless a billing demo blocks user testing.
+- **GetTerms**: paid plan for the three policy pages. Amit clicks pay; Twin retrieves IDs.
+- **Domain**: registrar payment + DNS host selection. Amit clicks pay.
+- **Convex production scale**: free tier carries; only escalate after preview traffic shows real usage.
+- **Vercel**: existing plan covers prod. No action.
+
+Hard rule: **no agent enters a credit card.** Ever.
+
+---
+
+## 9. Service setup order (recommended sequence — blocker-first, not the listed order)
+
+Dependency-driven order. Each step lists blocker, owner, and what it unblocks.
+
+### Step 1 — Mistral key into Convex dashboard `[twin]`
+- **Why first**: PR #21's AI path is dead until this lands. Code is shipped; config is missing.
+- **Owner**: Twin (dashboard click). Amit pays.
+- **Action**: Mistral console → create paid key → Convex dashboard `dev:ceaseless-dog-617` → env vars → `MISTRAL_API_KEY`.
+- **Unblocks**: real Mistral smoke on local + preview Today loop.
+- **Verify**: Amit, AM window: paste a brain dump on `/today`, see "Source: server planner" not "local sort".
+
+### Step 2 — Resend setup + Convex dashboard env `[manus → twin]`
+- **Why second**: Magic-link auth fails in preview without it (per `docs/phase4-brain-dump-validation.md` §root-cause-2).
+- **Owner**: Manus signs up + adds sender domain. Twin pastes `RESEND_API_KEY` + `RESEND_FROM_EMAIL` into Convex dashboard. Amit owns DNS records (see Step 3).
+- **Unblocks**: preview-auth re-test, eventual prod auth.
+- **Verify**: Amit, AM window: sign in via magic link on preview URL, lands on `/today`.
+
+### Step 3 — Domain + DNS `[human-amit → twin]`
+- **Why third**: Resend deliverability needs DKIM/SPF on the sender domain. Vercel custom domain needs DNS too. Both share the same DNS panel.
+- **Owner**: Amit picks registrar, pays, hands DNS panel access to Twin. Twin adds Resend DKIM/SPF + Vercel A/CNAME records.
+- **Unblocks**: Resend deliverability, Vercel custom domain, prod auth flow.
+- **Verify**: Resend dashboard shows domain "verified"; `dig` shows Vercel records.
+
+### Step 4 — Convex prod link (T-0008) `[human-amit / twin]`
+- **Why fourth**: Need Mistral + Resend keys ready before pointing prod at them; otherwise prod auth/AI launch broken on day 1.
+- **Owner**: Amit + Twin. Convex dashboard → link prod → set `CONVEX_DEPLOY_KEY` in Vercel prod scope → re-run Steps 1–2 env-var entries against the prod deployment.
+- **Unblocks**: actually shipping (`shipped-and-running` in `docs/SHIP_STATE.md`).
+- **Verify**: `vercel env ls --environment=production` shows the key; Convex dashboard shows prod deployment with both Mistral and Resend env vars.
+
+### Step 5 — Vercel domain bind + previews re-enable `[twin]`
+- **Why fifth**: Once DNS propagates and prod Convex is live, point the custom domain at Vercel and re-enable previews against `preview:*` Convex (or document that previews still run against dev).
+- **Owner**: Twin. Update `docs/ENVIRONMENTS.md` to reflect re-enabled state.
+- **Unblocks**: branded prod URL, automatic preview validation per PR.
+- **Verify**: prod domain serves `/today`; throwaway PR produces a preview URL.
+
+### Step 6 — GetTerms `[manus → twin]`
+- **Why sixth**: Required for public-facing prod (HARD_RULES §10) but does not block code/auth/AI loops.
+- **Owner**: Manus signs up + generates Privacy/Terms/Cookies. Twin pastes IDs into Vercel env (`TEMPO_GETTERMS_PRIVACY_ID`, `TEMPO_GETTERMS_TERMS_ID`, `TEMPO_GETTERMS_COOKIES_ID`).
+- **Unblocks**: legal pages render with real content; safe to invite beta-2.
+- **Verify**: `/(legal)/privacy`, `/terms`, `/cookies` render the embedded content.
+
+### Step 7 — RevenueCat `[manus → human-amit → twin]`
+- **Why last**: No billing UI in scope this week; pre-wiring saves a week-2 day but is not a launch gate.
+- **Owner**: Manus creates RC project. Amit links App Store / Play Store / Stripe (human-only). Twin adds public key to Vercel + secret key to Convex dashboard.
+- **Unblocks**: future paywall ticket; not blocking anything next week.
+- **Verify**: RC dashboard shows project; webhook URL responds 200 from a Convex action stub.
+
+---
+
+## Critical files to reference next week
+
+- `docs/SHIP_STATE.md` — flip rows as steps land. Reality wins.
+- `docs/ENVIRONMENTS.md` — update §"Vercel: production domain only this weekend" when previews re-enable; §"What is NOT decided yet" shrinks as Steps 4–5 land.
+- `docs/HARD_RULES.md` §13 (env vars), §14 (owner-tag), §10 (privacy/GetTerms).
+- `.claude/workflows/nightly-run-intake.md` — every morning's reconcile loop.
+- `.claude/workflows/executor-advisor.md` §3 — the escalation triggers; non-negotiable.
+- `docs/brain/tickets/_INDEX.md` (in submodule) — source of bounded slices for both nightly + 2-hour lanes.
+- `apps/web/components/auth/SignInForm.tsx`, `convex/lib/requireUser.ts`, `convex/lib/ai_router.ts` — recent change surface; treat as fragile until preview-tested.
+- `convex/auth.ts` — Resend env reads happen here; verify keys reach it after Step 2.
+
+---
+
+## Verification (end-of-week gate)
+
+A successful next week ends with all of these green:
+
+1. `/today` brain-dump → server planner → Add-to-Today → tasks visible — works against **prod Convex** in a real browser. Recorded once.
+2. Magic-link sign-in on the **prod domain** delivers to a non-Amit Gmail in <30s.
+3. `SHIP_STATE.md` has at least `/today route` at `preview-tested` (ideally `shipped-and-running`) and `Convex production deployment` at `shipped-and-running`.
+4. CI scans (`forbidden-tech`, `secrets`) move from `planned` to `shipped-and-running`.
+5. Each nightly cloud-run produced exactly one draft PR; Amit merged or rejected each within 24h.
+6. Amit logged ≤ 2h/day at keyboard. If more — the plan failed its goal regardless of what shipped.
+
+If (1)–(4) slip but (5)–(6) hold: the plan still succeeded. Burnout-first.


### PR DESCRIPTION
## Summary

- Adds `.claude/workflows/next-week-2026-04-27.md` — operational, blocker-first plan for the week after PR #21 merges.
- Splits work into **nightly cloud-agent lanes** (one bounded slice each), **two-hour local lanes** (Sonnet executor + Opus advisor in Cursor), and per-surface ownership: Cursor Cloud / Codex Cloud / Claude Code / Manus-Bud-Twin-Atlas GUI.
- Recommends a **dependency-driven service setup order** (Mistral → Resend → DNS → Convex prod → Vercel domain → GetTerms → RevenueCat) rather than the listed order, so each manual step Amit takes unblocks the next nightly run instead of stalling it.
- Goal isn't speed — it's keeping Amit ≤ 2h/day at the keyboard. End-of-week verification gate explicitly prefers "burnout-first" over feature throughput.

No code changes. Pure planning doc, sits alongside the existing `executor-advisor.md`, `nightly-run-intake.md`, `cross-surface-guide.md`.

## Test plan

- [ ] Read the plan top-to-bottom; confirm each lane assignment matches HARD_RULES §14 owner-tag discipline (no code agent doing dashboard work).
- [ ] Confirm Step 1–7 ordering matches your real payment / DNS access constraints.
- [ ] Adjust the night-by-night table in §1 if any of the named tickets (biome re-enable, Phase 4.5a, cross-midnight `dueAt`, T-0020 scans, schema migration prep, ultrareview) shouldn't be next-week scope.
- [ ] Decide whether to merge as-is or convert to a tracking issue first.

Drafted because this is a planning artifact — happy to take edits before merge.

https://claude.ai/code/session_019j6eD9JFfXx9uGUPRgeWKV

---
_Generated by [Claude Code](https://claude.ai/code/session_019j6eD9JFfXx9uGUPRgeWKV)_