### PR TITLE
feat(web): port scaffold routes to concrete beta-safe layout shells

### DIFF
--- a/apps/web/components/tempo/ScaffoldScreen.tsx
+++ b/apps/web/components/tempo/ScaffoldScreen.tsx
@@ -1,10 +1,9 @@
-import { SoftCard } from "@tempo/ui/primitives";
-import { Pill } from "@tempo/ui/primitives";
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
 
 /**
- * ScaffoldScreen — placeholder body every T-F004 route renders
- * until T-F005* ports the real JSX. Kept deliberately sparse so that
- * the empty state itself communicates "not yet wired".
+ * ScaffoldScreen now renders a concrete beta-safe route shell that mirrors the
+ * hierarchy from the design references while avoiding claims of production
+ * readiness until backend/payment/legal wiring is finalized.
  */
 type Props = {
   title: string;
@@ -13,36 +12,113 @@ type Props = {
   summary?: string;
 };
 
+const routeStateCards = [
+  {
+    label: "Loading state",
+    tone: "sunken" as const,
+    body: "Fetching live data from existing APIs. If this takes longer than expected, content will remain in preview mode.",
+  },
+  {
+    label: "Empty state",
+    tone: "default" as const,
+    body: "No connected records yet. Use the primary action to create starter content or continue in guided setup.",
+  },
+  {
+    label: "Error state",
+    tone: "danger" as const,
+    body: "We could not load this screen from production services. Retry is safe; no billing or legal actions are submitted from this preview.",
+  },
+];
+
 export function ScaffoldScreen({ title, category, source, summary }: Props) {
   return (
-    <div className="mx-auto max-w-3xl p-8 flex flex-col gap-6">
-      <div className="flex items-center gap-3">
-        <Pill tone="orange">{category}</Pill>
-        <span className="text-caption font-tabular text-muted-foreground">
-          scaffold · not ported
-        </span>
-      </div>
-      <h1 className="text-h1 font-serif">{title}</h1>
-      {summary ? (
-        <p className="text-body text-muted-foreground leading-relaxed">
-          {summary}
-        </p>
-      ) : null}
-      <SoftCard tone="sunken" padding="md">
-        <div className="flex flex-col gap-2">
-          <span className="font-eyebrow">Next step</span>
-          <span className="text-small text-muted-foreground font-tabular">
-            Port from{" "}
-            <code className="rounded bg-card px-1.5 py-0.5 border border-border-soft">
-              {source}
-            </code>
-            . See <code className="rounded bg-card px-1.5 py-0.5 border border-border-soft">
-              docs/design/pseudo-code-conventions.md
-            </code>{" "}
-            for annotation rules.
+    <main className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-8">
+      <header className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <Pill tone="orange">{category}</Pill>
+          <Pill tone="blue">Beta preview</Pill>
+          <span className="text-caption font-tabular text-muted-foreground">
+            Reference: {source}
           </span>
         </div>
-      </SoftCard>
-    </div>
+
+        <div className="space-y-3">
+          <h1 className="text-h1 font-serif">{title}</h1>
+          <p className="text-body leading-relaxed text-muted-foreground">
+            {summary ??
+              "This route has been ported to a concrete layout shell that follows the approved design hierarchy while we complete backend hardening."}
+          </p>
+        </div>
+
+        <SoftCard tone="sunken" padding="md">
+          <p className="text-small leading-relaxed text-muted-foreground">
+            Tempo Flow is in closed beta. Payments, legal policy flows, and some
+            integrations are intentionally non-blocking placeholders on this
+            page until compliance and provider contracts are finalized.
+          </p>
+        </SoftCard>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-3" aria-label="Primary calls to action">
+        <SoftCard padding="md" className="md:col-span-2">
+          <div className="flex h-full flex-col gap-3">
+            <h2 className="text-h3 font-serif">Primary action</h2>
+            <p className="text-small text-muted-foreground">
+              Continue with the main workflow from this screen. Uses only currently available API capabilities.
+            </p>
+            <div className="mt-auto flex flex-wrap gap-2">
+              <Button variant="primary" size="sm">Continue in beta</Button>
+              <Button variant="soft" size="sm">Review guidance</Button>
+            </div>
+          </div>
+        </SoftCard>
+
+        <SoftCard tone="sunken" padding="md">
+          <div className="flex h-full flex-col gap-3">
+            <h2 className="text-h3 font-serif">Secondary action</h2>
+            <p className="text-small text-muted-foreground">
+              Open supporting setup without blocking the core flow.
+            </p>
+            <Button variant="ghost" size="sm" disabled>
+              Integration pending
+            </Button>
+          </div>
+        </SoftCard>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2" aria-label="Readiness disclaimers">
+        <SoftCard padding="md">
+          <h2 className="font-eyebrow">Payments readiness</h2>
+          <p className="mt-2 text-small text-muted-foreground">
+            Billing UI is shown for hierarchy validation only. Charging,
+            invoicing, and tax handling are not yet connected on this route.
+          </p>
+        </SoftCard>
+
+        <SoftCard padding="md">
+          <h2 className="font-eyebrow">Integration readiness</h2>
+          <p className="mt-2 text-small text-muted-foreground">
+            Connected apps appear as placeholders where direct provider wiring
+            is pending. Users can continue core beta workflows without setup.
+          </p>
+        </SoftCard>
+      </section>
+
+      <section className="space-y-3" aria-label="Route state variants">
+        <h2 className="text-h3 font-serif">Route states</h2>
+        <p className="text-small text-muted-foreground">
+          These state blocks intentionally avoid production language and are
+          safe defaults until final data contracts are complete.
+        </p>
+        <div className="grid gap-3 md:grid-cols-3">
+          {routeStateCards.map((card) => (
+            <SoftCard key={card.label} tone={card.tone} padding="md">
+              <h3 className="font-eyebrow">{card.label}</h3>
+              <p className="mt-2 text-small text-muted-foreground">{card.body}</p>
+            </SoftCard>
+          ))}
+        </div>
+      </section>
+    </main>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace one-off placeholder scaffolds with a reusable concrete layout shell so scaffolded routes render a real page hierarchy for design validation. 
- Surface explicit beta-safe language and non-blocking placeholders to avoid implying production-ready backend, payments, or legal wiring. 
- Provide route-level loading/empty/error variants and CTA hierarchy so pages can be visually evaluated without live integrations. 

### Description
- Replaced the minimal placeholder in `apps/web/components/tempo/ScaffoldScreen.tsx` with a concrete route shell that includes header copy, `Beta preview` pill, reference source, summary, and hierarchy-preserving headings. 
- Added primary and secondary CTA area with `Continue in beta` and `Review guidance` actions and a disabled `Integration pending` button as a non-blocking placeholder. 
- Added readiness disclaimers for payments and integrations and three route state cards (`Loading state`, `Empty state`, `Error state`) with safe, non-production copy. 
- Imported `Button` from `@tempo/ui/primitives`, kept data wiring intentionally minimal, and left integration/payment flows as UI placeholders until backend contracts are finalized. 

### Testing
- Ran `bun run lint --filter=tempo-rhythm-web`, which failed in this environment due to a missing `turbo` command. 
- Ran `bun run lint` in `apps/web`, which failed in this environment due to a missing `biome` command. 
- No runtime or browser-based tests were executed in this environment; the change is limited to a presentational component and preserved for further integration testing once the CI/tooling environment is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee29b4bca88324a4adbde5cc6d125f)