### PR TITLE
chore: add GitHub automation readiness

### DIFF
--- a/.cursor/commands/automation-outline.md
+++ b/.cursor/commands/automation-outline.md
@@ -1,0 +1,52 @@
+# /automation-outline — recurring agent outline
+
+Use this when the user asks to configure or review background automations before
+turning them loose.
+
+## 1. Pick the automation
+
+Choose exactly one lane:
+
+- `bug-scan`
+- `test-coverage`
+- `docs-generation`
+- `pr-readiness`
+- `merge-steward`
+
+## 2. Stay read-only first
+
+Start with the matching prompt in `docs/CURSOR_PROMPTS.md` §13.
+
+For the first pass:
+
+- Read the relevant docs and changed files.
+- Run only read-only checks.
+- Return a short outline of proposed changes.
+- Wait for explicit approval before editing files.
+
+## 3. Execution rules after approval
+
+- Use one branch and one worktree per task.
+- Keep the diff narrow.
+- Run `/run-qa` before opening or updating a PR.
+- Do not merge your own PR.
+- Do not deploy.
+- Do not write secrets.
+
+## 4. Report format
+
+```
+Automation outline — <lane>
+
+Scope:
+- <files / route / package>
+
+Findings:
+- <high-signal finding>
+
+Proposed action:
+- <smallest useful next step>
+
+Blocked by:
+- <human decision or none>
+```

--- a/.cursor/commands/automation-outline.md
+++ b/.cursor/commands/automation-outline.md
@@ -7,11 +7,11 @@ turning them loose.
 
 Choose exactly one lane:
 
-- `bug-scan`
-- `test-coverage`
-- `docs-generation`
-- `pr-readiness`
-- `merge-steward`
+- `bug-scan` — use `docs/CURSOR_PROMPTS.md` §13.8.
+- `test-coverage` — use `docs/CURSOR_PROMPTS.md` §13.9.
+- `docs-generation` — use `docs/CURSOR_PROMPTS.md` §13.10.
+- `pr-readiness` — use `docs/CURSOR_PROMPTS.md` §13.11.
+- `merge-steward` — use `docs/CURSOR_PROMPTS.md` §13.12.
 
 ## 2. Stay read-only first
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Asia/Jerusalem
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - automation
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:30"
+      timezone: Asia/Jerusalem
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - automation
+    groups:
+      tempo-workspace:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /apps/web
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: Asia/Jerusalem
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - automation
+    groups:
+      web-app:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /apps/mobile
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:30"
+      timezone: Asia/Jerusalem
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - automation
+    groups:
+      mobile-app:
+        patterns:
+          - "*"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,36 @@
+name: Security
+
+on:
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secret-scan:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: TruffleHog
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --only-verified

--- a/apps/web/components/tempo/ScaffoldScreen.tsx
+++ b/apps/web/components/tempo/ScaffoldScreen.tsx
@@ -25,7 +25,7 @@ const routeStateCards = [
   },
   {
     label: "Error state",
-    tone: "danger" as const,
+    tone: "inverse" as const,
     body: "We could not load this screen from production services. Retry is safe; no billing or legal actions are submitted from this preview.",
   },
 ];
@@ -36,7 +36,7 @@ export function ScaffoldScreen({ title, category, source, summary }: Props) {
       <header className="flex flex-col gap-4">
         <div className="flex flex-wrap items-center gap-3">
           <Pill tone="orange">{category}</Pill>
-          <Pill tone="blue">Beta preview</Pill>
+          <Pill tone="slate">Beta preview</Pill>
           <span className="text-caption font-tabular text-muted-foreground">
             Reference: {source}
           </span>

--- a/docs/AGENT_AUTOMATION_RUNBOOK.md
+++ b/docs/AGENT_AUTOMATION_RUNBOOK.md
@@ -55,6 +55,14 @@ Recommended lanes:
 - `pr-readiness` — verify the branch and PR body before human review.
 - `merge-steward` — recommend merge order, never self-merge.
 
+Prepared local worktrees on this Windows machine:
+
+- `C:\Users\User\.cyrus\worktrees\tempo-bug-scan` on `codex/bug-scan`
+- `C:\Users\User\.cyrus\worktrees\tempo-test-coverage` on `codex/test-coverage`
+- `C:\Users\User\.cyrus\worktrees\tempo-docs-generation` on `codex/docs-generation`
+- `C:\Users\User\.cyrus\worktrees\tempo-pr-readiness` on `codex/pr-readiness`
+- `C:\Users\User\.cyrus\worktrees\tempo-merge-steward` on `codex/merge-steward`
+
 ## Cursor automation outlines
 
 Use `/automation-outline` in Cursor, or paste one of the §13 prompts from

--- a/docs/AGENT_AUTOMATION_RUNBOOK.md
+++ b/docs/AGENT_AUTOMATION_RUNBOOK.md
@@ -13,6 +13,10 @@ accepted.
 Do not merge either PR automatically. A human should review PR #31 first, then
 close PR #32 after #31 lands.
 
+Current always-on runtime blocker: Cyrus cloud switch support ticket `CYHOST-1030`.
+Until that is resolved, keep agent work local or cloud-IDE based and avoid
+pretending a 24-hour Cyrus runtime is available.
+
 ## Before starting a long agent run
 
 1. Confirm the runtime switch or agent host is online.

--- a/docs/AGENT_AUTOMATION_RUNBOOK.md
+++ b/docs/AGENT_AUTOMATION_RUNBOOK.md
@@ -1,0 +1,86 @@
+# Agent Automation Runbook
+
+This is the clean handoff for "full steam ahead" agent work once the always-on
+runtime is healthy again.
+
+## Current decision
+
+PR #31 is the preferred path. It includes the current `master` typecheck/build
+fix from PR #32 and adds automation readiness. PR #32 is still useful as the
+minimal baseline fix, but it should be treated as superseded if PR #31 is
+accepted.
+
+Do not merge either PR automatically. A human should review PR #31 first, then
+close PR #32 after #31 lands.
+
+## Before starting a long agent run
+
+1. Confirm the runtime switch or agent host is online.
+2. Confirm GitHub auth works with `gh auth status`.
+3. Confirm the repo branch is clean with `git status --short`.
+4. Confirm the correct base branch is `master`.
+5. Confirm no dashboard-only action is being hidden inside a code task.
+6. Run the batch checks:
+
+```powershell
+bun install --frozen-lockfile
+bun run lint
+bun test
+bun run typecheck
+bun run build
+```
+
+Do not use `bun run check` as a verification-only command until the repo fixes
+that script. On 2026-06-02 it was observed to run `biome check --write` in the
+mobile package and to fail on pre-existing web formatter diagnostics.
+
+## Worktree pattern
+
+Use one worktree per independent task:
+
+```powershell
+git fetch origin
+git worktree add ..\tempo-wt\<ticket-or-lane> -b codex/<ticket-or-lane> origin/master
+```
+
+Recommended lanes:
+
+- `bug-scan` — read-only first, then one small fix branch if approved.
+- `test-coverage` — add focused regression tests for changed code only.
+- `docs-generation` — update the nearest existing developer doc.
+- `pr-readiness` — verify the branch and PR body before human review.
+- `merge-steward` — recommend merge order, never self-merge.
+
+## Cursor automation outlines
+
+Use `/automation-outline` in Cursor, or paste one of the §13 prompts from
+`docs/CURSOR_PROMPTS.md`:
+
+- Bug scan: §13.8
+- Test coverage gap finder: §13.9
+- Docs generation: §13.10
+- PR readiness check: §13.11
+- Merge-agent checklist: §13.12
+
+## Stop conditions
+
+Stop and ask Amit when:
+
+- A task requires a secret, token, payment, or OAuth approval.
+- A task requires changing production dashboard settings.
+- The agent cannot prove whether it is touching dev, preview, or production.
+- The branch needs a merge, deploy, or force-push.
+- Batch checks fail for a reason unrelated to the current task.
+
+## End-of-run report
+
+End every long run with:
+
+```text
+Closed PRs ready for review:
+Started but not closed:
+Blocked:
+Checks run:
+Human decisions needed:
+Recommended next move:
+```

--- a/docs/CURSOR_PROMPTS.md
+++ b/docs/CURSOR_PROMPTS.md
@@ -344,6 +344,9 @@ Report baseline numbers and post-fix numbers in the PR description.
 
 Short, recurring prompts for the Cursor Background Agent (or GitHub Actions equivalents).
 
+Use these prompts as outlines first. If the agent proposes code changes, require the
+normal session preamble, a scoped file list, and the full QA gate before opening a PR.
+
 ### 13.1 Forbidden tech scanner
 
 ```
@@ -413,6 +416,108 @@ Every voice session start must:
 - The ai_usage rate limiter reads the user's tier daily cap and blocks further live-voice calls when exceeded.
 
 If any of these are missing, block merge.
+```
+
+### 13.8 Bug scan
+
+```
+Run a read-only bug scan against the current branch.
+
+Scope:
+- Recent diffs on this branch.
+- Code paths touched by the diff.
+- Nearby tests, route handlers, Convex functions, and shared UI primitives.
+
+Method:
+1. Read docs/HARD_RULES.md and docs/CURSOR_RULES.md.
+2. Run `bun install --frozen-lockfile`.
+3. Run `bun run lint`, `bun test`, `bun run typecheck`, and `bun run build`.
+4. Inspect failures and warnings. Separate current-branch regressions from known baseline issues.
+5. For each likely bug, report file path, risk, reproduction path, and smallest safe fix.
+
+Do not modify files. Do not open a PR. End with PASS / FAIL / INSUFFICIENT EVIDENCE.
+```
+
+### 13.9 Test coverage gap finder
+
+```
+Find high-value missing tests for the current branch.
+
+Scope:
+- Files changed on this branch.
+- Public exports and user-visible flows touched by those files.
+- Convex queries, mutations, and actions touched by those files.
+
+Method:
+1. Read the changed files and existing tests first.
+2. List uncovered happy paths, edge cases, and regression cases.
+3. Rank gaps by user risk and implementation effort.
+4. If asked to implement, add only the top 1-3 tests and run the smallest relevant suite plus root `bun test`.
+
+Do not add a new test framework. Do not widen the task into product work.
+```
+
+### 13.10 Docs generation
+
+```
+Generate or update developer documentation for the current branch.
+
+Inputs:
+- The branch diff.
+- docs/HARD_RULES.md.
+- docs/ENVIRONMENTS.md.
+- docs/LOCAL_DEV_WINDOWS.md when local setup is affected.
+
+Rules:
+1. Prefer updating the nearest existing doc over creating a new top-level doc.
+2. Document commands, expected outputs, and human decision points.
+3. Do not include secrets, private tokens, or raw user content.
+4. Do not mark a feature shipped unless docs/SHIP_STATE.md proves it is shipped-and-running.
+
+End with the exact files changed and the verification commands run.
+```
+
+### 13.11 PR readiness check
+
+```
+Check whether this branch is ready for human review.
+
+Required checks:
+- `git status --short` is clean after the final commit.
+- `bun install --frozen-lockfile` passes.
+- `bun run lint` passes or only has documented pre-existing warnings.
+- `bun test` passes.
+- `bun run typecheck` passes.
+- `bun run build` passes.
+- PR body maps changes to acceptance criteria and names any known gaps.
+
+Review:
+- Confirm the branch does not deploy, merge, rotate secrets, or change production dashboards.
+- Confirm any dashboard-only action is documented as a human step.
+- Confirm no unrelated files were changed.
+
+End with READY / NOT READY and the blocking reason.
+```
+
+### 13.12 Merge-agent checklist
+
+```
+Act as the merge steward for one finished branch.
+
+Inputs:
+- PR number.
+- Base branch.
+- Latest CI/check results.
+- Any related superseded PRs.
+
+Checklist:
+1. Confirm the intended PR is the one to merge.
+2. Confirm any superseded PR is documented, not silently ignored.
+3. Confirm required reviews and branch rules are satisfied.
+4. Confirm the final diff has no dashboard actions, secrets, or deploys.
+5. Confirm the post-merge plan: close superseded PRs, update TASKS.md, and rerun smoke checks on master.
+
+Never self-merge. Return the merge recommendation and the exact human action needed.
 ```
 
 ---

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -83,7 +83,7 @@ Negative rule: do not create or read `apps/web/.env` or `apps/mobile/.env`. Use 
 - **Preview Convex provisioned.** The `preview:*` deployment is planned but not provisioned. Do not reference preview Convex URLs in any config.
 - **Vercel preview re-enablement plan.** Previews are disabled this weekend. When re-enabled, this file must be updated with the actual scope of preview secrets and the confirmation step.
 - **Convex local dev attachment.** Choose existing `dev:tremendous-bass-443` vs a new personal `dev:*` deployment before running an interactive `bun x convex dev` configuration.
-- **EAS ownership path.** The workstation is authenticated to EAS, but `apps/mobile/app.json` currently points at owner `tempo-rhythm` and project ID `6f4c596f-b3ed-431b-b9d2-70813ac231d2`. If the authenticated account cannot read that project, either log into the owning Expo account/org or explicitly relink the app to a project owned by the current account.
+- **EAS ownership path.** The workstation is authenticated to EAS as `amitlevin`, but `apps/mobile/app.json` currently points at owner `tempo-rhythm` and project ID `6f4c596f-b3ed-431b-b9d2-70813ac231d2`, which this login cannot read. The verified accessible candidate is `@amitlevin/tempi` with project ID `90dfac90-0baa-461b-946c-351d2306e607`. Either log into the owning Expo account/org for `tempo-rhythm`, or explicitly approve relinking mobile to `@amitlevin/tempi`.
 
 ---
 

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -23,13 +23,14 @@ This document defines the four-mode environment model for Tempo Flow. Every agen
 - **`prod`** — current production deployment: `prod:precious-wildcat-890` (`https://precious-wildcat-890.eu-west-1.convex.cloud`).
 
 Rule: no agent provisions Convex deployments without an explicit human choice of
-team/project. Agents may inspect an existing deployment with an explicit
-`--deployment` flag, but must not create, relink, or promote deployments silently.
+team/project. Agents may inspect an existing deployment with an explicit deployment
+name on a CLI version that supports it, but must not create, relink, or promote
+deployments silently.
 
 Known local CLI state on 2026-06-02:
 
-- `bunx convex function-spec --deployment precious-wildcat-890` can inspect the production deployment.
-- A root `bunx convex function-spec` fails until `CONVEX_DEPLOYMENT` is set or `bun x convex dev` configures a local dev deployment.
+- The repo-pinned Convex CLI is `1.32.0`; `bunx convex function-spec` fails until `CONVEX_DEPLOYMENT` is set or `bun x convex dev` configures a local dev deployment.
+- `npx convex@1.39.1 function-spec --deployment-name=precious-wildcat-890` can inspect the production deployment without writing repo config.
 - Before configuring local dev, choose whether this machine should attach to the existing `dev:tremendous-bass-443` project or create a fresh personal `dev:*` deployment.
 
 ---

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -11,17 +11,26 @@ This document defines the four-mode environment model for Tempo Flow. Every agen
 | **Dev** | Coding, immediate local testing | `dev:<your-slug>` (auto via `bun x convex dev`) | N/A (`next dev` locally) | `.env.local` (git-ignored) | May break at any time. Not a QA surface. |
 | **Test** | Prove behavior | Dev deployment | Local `next build` + CI | `.env.local` + CI env | CI green + local smoke pass. Not a shareable URL. |
 | **Preview** | Branch / PR validation | `preview:<slug>` (target state — not yet provisioned) | Preview URL from PR (**disabled this weekend**) | Vercel env table (preview scope) | Agents MUST NOT treat preview as shipped. |
-| **Deployment** | Promoted stable surface | `prod:<slug>` (not yet linked — T-0008) | Production domain | Vercel env table (production scope) + Convex dashboard env | Only code that passed preview + explicit human promote. |
+| **Deployment** | Promoted stable surface | `prod:<slug>` | Production domain | Vercel env table (production scope) + Convex dashboard env | Only code that passed preview + explicit human promote. |
 
 ---
 
-## Convex: three deployments (target model)
+## Convex: deployments
 
-- **`dev`** — `dev:ceaseless-dog-617` already exists and is the only deployment this weekend that can be edited safely. Every local machine gets its own `dev:*` slug via `bun x convex dev`.
+- **`dev`** — current registry candidate: `dev:tremendous-bass-443` (`https://tremendous-bass-443.convex.cloud`). Every local machine can also get its own `dev:*` slug via `bun x convex dev`.
 - **`preview`** — [placeholder — not yet provisioned]. Documented here as the target model. Provisioning is a `human-amit` / `twin` action: Convex dashboard → Project Settings → Deployments → Add preview deployment. Until then, PRs run against the author's `dev` deployment.
-- **`prod`** — [placeholder — not yet linked (T-0008)]. Until T-0008 is done, `CONVEX_DEPLOY_KEY` stays empty in `.env.example` and any `convex deploy` call fails loudly and intentionally.
+- **`staging`** — current registry candidate: `staging:ceaseless-dog-617` (`https://ceaseless-dog-617.convex.cloud`).
+- **`prod`** — current production deployment: `prod:precious-wildcat-890` (`https://precious-wildcat-890.eu-west-1.convex.cloud`).
 
-Rule: no agent provisions Convex deployments. That is a dashboard action, owner `human-amit` or `twin`.
+Rule: no agent provisions Convex deployments without an explicit human choice of
+team/project. Agents may inspect an existing deployment with an explicit
+`--deployment` flag, but must not create, relink, or promote deployments silently.
+
+Known local CLI state on 2026-06-02:
+
+- `bunx convex function-spec --deployment precious-wildcat-890` can inspect the production deployment.
+- A root `bunx convex function-spec` fails until `CONVEX_DEPLOYMENT` is set or `bun x convex dev` configures a local dev deployment.
+- Before configuring local dev, choose whether this machine should attach to the existing `dev:tremendous-bass-443` project or create a fresh personal `dev:*` deployment.
 
 ---
 
@@ -70,9 +79,10 @@ Negative rule: do not create or read `apps/web/.env` or `apps/mobile/.env`. Use 
 
 ## What is NOT decided yet
 
-- **Production Convex linked (T-0008).** The `prod:*` deployment does not exist. `CONVEX_DEPLOY_KEY` is empty. No agent should treat the production row as real until T-0008 is marked done.
 - **Preview Convex provisioned.** The `preview:*` deployment is planned but not provisioned. Do not reference preview Convex URLs in any config.
 - **Vercel preview re-enablement plan.** Previews are disabled this weekend. When re-enabled, this file must be updated with the actual scope of preview secrets and the confirmation step.
+- **Convex local dev attachment.** Choose existing `dev:tremendous-bass-443` vs a new personal `dev:*` deployment before running an interactive `bun x convex dev` configuration.
+- **EAS ownership path.** The workstation is authenticated to EAS, but `apps/mobile/app.json` currently points at owner `tempo-rhythm` and project ID `6f4c596f-b3ed-431b-b9d2-70813ac231d2`. If the authenticated account cannot read that project, either log into the owning Expo account/org or explicitly relink the app to a project owned by the current account.
 
 ---
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -57,7 +57,7 @@ _(nothing in flight right now — waiting for tomorrow morning's 45-min + overni
 - **Promote `tempo-web` Vercel env vars into Convex dashboard** so prod and dashboard share one source of truth (currently set via `vercel env` + `.local.vercel.env`).
 
 ### Mobile
-- **Resolve EAS ownership mismatch.** This workstation is logged into EAS, but `apps/mobile/app.json` points at owner `tempo-rhythm` and project ID `6f4c596f-b3ed-431b-b9d2-70813ac231d2`. Choose either owner-account login or explicit relink to the current account before EAS builds.
+- **Resolve EAS ownership mismatch.** This workstation is logged into EAS as `amitlevin`, but `apps/mobile/app.json` points at owner `tempo-rhythm` and project ID `6f4c596f-b3ed-431b-b9d2-70813ac231d2`, which is not readable by that login. Verified accessible candidate: `@amitlevin/tempi` / `90dfac90-0baa-461b-946c-351d2306e607`. Choose either owner-account login or explicit relink before EAS builds.
 - **Fix `apps/mobile` Biome style rules** (currently muted in `apps/mobile/biome.json`).
 
 ### RAG / brain

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -47,6 +47,9 @@ _(nothing in flight right now — waiting for tomorrow morning's 45-min + overni
 ## Backlog (unordered, groomed as capacity allows)
 
 ### Platform / infra
+- **Merge PR #31 or PR #32 to unblock `master` checks.** Prefer PR #31 because it includes the `ScaffoldScreen` typecheck/build fix from PR #32 plus GitHub automation readiness. If PR #31 lands, close PR #32 as superseded.
+- **Resolve always-on runtime support ticket.** Cloud runtime switch is blocked outside the repo; keep coding automation work moving locally and retry the switch after support repairs the GitHub App authentication step.
+- **Choose Convex local dev attachment.** Decide whether this workstation should attach to existing `dev:tremendous-bass-443` or create a fresh personal `dev:*` deployment before running interactive `bun x convex dev`.
 - **Backfill + tighten `users` schema.** Today (`convex/schema.ts`) the `role`, `isActive`, `createdAt`, `updatedAt` fields on `users` are `v.optional(...)` so prod could accept pre-existing test users (`beta2@tempo.app`, `beta3@tempo.app`). Backfill those rows, then make the fields required again. Also decide the final shape of `name` vs `fullName` (currently both exist).
 - **Delete or migrate `tempo-marketing` Vercel project.** Unlinked from GitHub (PR #10 session, 2026-04-18) so it stops failing every PR. Still exists as an empty project pointing at a nonexistent `artifacts/tempo-marketing` root dir — either wire it to a real marketing site or delete the project via Vercel dashboard.
 - **Remove orphaned `C:/Projects/tempo-worktrees`** directory on this Windows box (leftover from earlier worktree experiments; Windows long-path issues make it annoying to delete).
@@ -54,7 +57,7 @@ _(nothing in flight right now — waiting for tomorrow morning's 45-min + overni
 - **Promote `tempo-web` Vercel env vars into Convex dashboard** so prod and dashboard share one source of truth (currently set via `vercel env` + `.local.vercel.env`).
 
 ### Mobile
-- **Run `bun x eas login`** on this workstation so EAS builds work without interactive auth.
+- **Resolve EAS ownership mismatch.** This workstation is logged into EAS, but `apps/mobile/app.json` points at owner `tempo-rhythm` and project ID `6f4c596f-b3ed-431b-b9d2-70813ac231d2`. Choose either owner-account login or explicit relink to the current account before EAS builds.
 - **Fix `apps/mobile` Biome style rules** (currently muted in `apps/mobile/biome.json`).
 
 ### RAG / brain


### PR DESCRIPTION
## Summary
Adds GitHub automation readiness for Tempo without deploying or changing runtime behavior.

## Decision: PR #31 vs #32
- Prefer this PR (#31). It includes the same `ScaffoldScreen` typecheck/build fix as PR #32 plus automation readiness docs/config.
- PR #32 remains the minimal fallback if Amit wants only the current `master` build fix.
- If #31 lands, close #32 as superseded.

## What is included
- Dependabot config for GitHub Actions, root workspace dependencies, web app dependencies, and mobile app dependencies.
- Security workflow for pull requests and manual runs using Gitleaks and TruffleHog verified-secret scanning.
- Cursor automation outlines for bug scan, test coverage, docs generation, PR readiness, and merge stewardship.
- `/automation-outline` Cursor command for read-only-first automation setup.
- Clean post-Cyrus agent runbook for long runs once the always-on runtime works.
- Environment docs updated for current Convex deployment evidence and the EAS ownership decision path.
- TASKS.md backlog updated with the remaining platform/configuration decisions.

## Verification
- `bun install --frozen-lockfile` passes.
- `bun run lint` passes with the existing `@tempo/ui/src/icons/index.tsx:480` unused suppression warning.
- `bun test` passes: 36 tests.
- `bun run typecheck` passes.
- `bun run build` passes.
- `git diff --check` passes.

## Known caveat
- `bun run check` is not safe as a read-only verification command right now: mobile runs `biome check --write`, and web has pre-existing formatter diagnostics. This is documented in `docs/AGENT_AUTOMATION_RUNBOOK.md`.

## Remaining gate
Amit should review before merge. This PR is draft by design; no merge or deploy performed.