### PR TITLE
fix(web): use supported scaffold tones

### DIFF
--- a/apps/web/components/tempo/ScaffoldScreen.tsx
+++ b/apps/web/components/tempo/ScaffoldScreen.tsx
@@ -25,7 +25,7 @@ const routeStateCards = [
   },
   {
     label: "Error state",
-    tone: "danger" as const,
+    tone: "inverse" as const,
     body: "We could not load this screen from production services. Retry is safe; no billing or legal actions are submitted from this preview.",
   },
 ];
@@ -36,7 +36,7 @@ export function ScaffoldScreen({ title, category, source, summary }: Props) {
       <header className="flex flex-col gap-4">
         <div className="flex flex-wrap items-center gap-3">
           <Pill tone="orange">{category}</Pill>
-          <Pill tone="blue">Beta preview</Pill>
+          <Pill tone="slate">Beta preview</Pill>
           <span className="text-caption font-tabular text-muted-foreground">
             Reference: {source}
           </span>


### PR DESCRIPTION
## Summary
- replace unsupported ScaffoldScreen UI tones with existing `@tempo/ui` primitive tones
- unblock the current root typecheck failure without changing behavior

## Verification
- `bun run lint` passes (existing `@tempo/ui` unused suppression warning remains)
- `bun run typecheck` passes

## Notes
- Draft PR only; no merge/deploy performed.