### PR TITLE
chore: add Cyrus worktree setup script

### DIFF
--- a/cyrus-setup.sh
+++ b/cyrus-setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Tempo Cyrus setup starting"
+echo "Issue: ${LINEAR_ISSUE_IDENTIFIER:-unknown}"
+
+export CI=1
+export NEXT_TELEMETRY_DISABLED=1
+export TURBO_TELEMETRY_DISABLED=1
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "Bun is not installed; installing Bun 1.3.9 with npm"
+  npm install --global bun@1.3.9
+fi
+
+echo "Node: $(node --version 2>/dev/null || echo missing)"
+echo "npm: $(npm --version 2>/dev/null || echo missing)"
+echo "bun: $(bun --version 2>/dev/null || echo missing)"
+
+bun install --frozen-lockfile
+
+echo "Tempo Cyrus setup complete"

--- a/cyrus-setup.sh
+++ b/cyrus-setup.sh
@@ -9,8 +9,18 @@ export NEXT_TELEMETRY_DISABLED=1
 export TURBO_TELEMETRY_DISABLED=1
 
 if ! command -v bun >/dev/null 2>&1; then
-  echo "Bun is not installed; installing Bun 1.3.9 with npm"
-  npm install --global bun@1.3.9
+  if command -v npm >/dev/null 2>&1; then
+    echo "Bun is not installed; installing Bun 1.3.9 with npm"
+    npm install --global bun@1.3.9 || {
+      echo "npm install failed. Trying official Bun installer..."
+      curl -fsSL https://bun.sh/install | BUN_VERSION=1.3.9 bash
+      export PATH="$HOME/.bun/bin:$PATH"
+    }
+  else
+    echo "Bun and npm are both missing. Installing Bun 1.3.9 via official script..."
+    curl -fsSL https://bun.sh/install | BUN_VERSION=1.3.9 bash
+    export PATH="$HOME/.bun/bin:$PATH"
+  fi
 fi
 
 echo "Node: $(node --version 2>/dev/null || echo missing)"

--- a/docs/AGENT_AUTOMATION_RUNBOOK.md
+++ b/docs/AGENT_AUTOMATION_RUNBOOK.md
@@ -42,6 +42,21 @@ Do not use `bun run check` as a verification-only command until the repo fixes
 that script. On 2026-06-02 it was observed to run `biome check --write` in the
 mobile package and to fail on pre-existing web formatter diagnostics.
 
+## Cyrus worktree setup
+
+The repository root includes `cyrus-setup.sh` for Cyrus-created worktrees.
+Cyrus runs this script after creating an isolated worktree for a Linear issue.
+
+The script is intentionally small:
+
+- disables common telemetry in CI-style agent runs;
+- installs Bun `1.3.9` only when Bun is missing from the runner;
+- runs `bun install --frozen-lockfile`;
+- avoids secrets, dashboard writes, deploys, and long build steps.
+
+Do not add API keys or production environment variables to this script. Those
+belong in the owning dashboard or secret manager.
+
 ## Worktree pattern
 
 Use one worktree per independent task:


### PR DESCRIPTION
## Summary

Adds the root `cyrus-setup.sh` script that Cyrus officially supports for preparing each issue worktree. The script keeps setup non-secret and fast: disable CI-style telemetry, ensure Bun exists when missing, and run `bun install --frozen-lockfile`.

## Why

Cyrus cloud package installation could not be completed reliably through the current in-app browser package-search textbox, but Cyrus docs support repository setup scripts as the worktree bootstrap path. This gives Cyrus-created worktrees a predictable dependency install step without dashboard secrets or deploy actions.

## Safety

- No API keys or environment variables added.
- No deploys, dashboard writes, or production changes.
- No long build step inside the setup script.
- Script is executable and non-interactive.

## Checks

- [x] `./cyrus-setup.sh` smoke test with fake issue context
- [x] `bash -n cyrus-setup.sh`
- [x] `git diff --cached --check`
- [x] `bun install --frozen-lockfile`
- [x] `bun run lint`
- [x] `bun test`
- [x] `bun run typecheck`
- [x] `bun run build`