### PR TITLE
chore(mobile): point EAS config at accessible Tempo project

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
     "name": "Tempo Rhythm",
-    "slug": "tempo-rhythm",
+    "slug": "tempi",
     "version": "1.0.0",
     "runtimeVersion": {
       "policy": "sdkVersion"
@@ -59,9 +59,9 @@
     "extra": {
       "router": {},
       "eas": {
-        "projectId": "6f4c596f-b3ed-431b-b9d2-70813ac231d2"
+        "projectId": "90dfac90-0baa-461b-946c-351d2306e607"
       }
     },
-    "owner": "tempo-rhythm"
+    "owner": "amitlevin"
   }
 }

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -83,7 +83,7 @@ Negative rule: do not create or read `apps/web/.env` or `apps/mobile/.env`. Use 
 - **Preview Convex provisioned.** The `preview:*` deployment is planned but not provisioned. Do not reference preview Convex URLs in any config.
 - **Vercel preview re-enablement plan.** Previews are disabled this weekend. When re-enabled, this file must be updated with the actual scope of preview secrets and the confirmation step.
 - **Convex local dev attachment.** Choose existing `dev:tremendous-bass-443` vs a new personal `dev:*` deployment before running an interactive `bun x convex dev` configuration.
-- **EAS ownership path.** The workstation is authenticated to EAS as `amitlevin`, but `apps/mobile/app.json` currently points at owner `tempo-rhythm` and project ID `6f4c596f-b3ed-431b-b9d2-70813ac231d2`, which this login cannot read. The verified accessible candidate is `@amitlevin/tempi` with project ID `90dfac90-0baa-461b-946c-351d2306e607`. Either log into the owning Expo account/org for `tempo-rhythm`, or explicitly approve relinking mobile to `@amitlevin/tempi`.
+- **EAS project identity.** Resolved on 2026-06-04: `apps/mobile/app.json` points at the accessible Expo/EAS project `@amitlevin/tempi` with project ID `90dfac90-0baa-461b-946c-351d2306e607`. The `tempi` slug is the existing Tempo Rhythm Expo project name; app display name, bundle identifier, Android package, and URL scheme remain Tempo Rhythm / `com.temporhythm.app` / `tempo-rhythm`.
 
 ---
 

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -57,7 +57,6 @@ _(nothing in flight right now — waiting for tomorrow morning's 45-min + overni
 - **Promote `tempo-web` Vercel env vars into Convex dashboard** so prod and dashboard share one source of truth (currently set via `vercel env` + `.local.vercel.env`).
 
 ### Mobile
-- **Resolve EAS ownership mismatch.** This workstation is logged into EAS as `amitlevin`, but `apps/mobile/app.json` points at owner `tempo-rhythm` and project ID `6f4c596f-b3ed-431b-b9d2-70813ac231d2`, which is not readable by that login. Verified accessible candidate: `@amitlevin/tempi` / `90dfac90-0baa-461b-946c-351d2306e607`. Choose either owner-account login or explicit relink before EAS builds.
 - **Fix `apps/mobile` Biome style rules** (currently muted in `apps/mobile/biome.json`).
 
 ### RAG / brain
@@ -70,6 +69,9 @@ _(nothing in flight right now — waiting for tomorrow morning's 45-min + overni
 ---
 
 ## Done (by date)
+
+### 2026-06-04 — Expo/EAS identity resolved
+- Mobile Expo/EAS project now points at the existing accessible Tempo Rhythm project `@amitlevin/tempi` with project ID `90dfac90-0baa-461b-946c-351d2306e607`. The `tempi` slug is a historical spelling mistake in the Expo project name; the app still presents as Tempo Rhythm and keeps `com.temporhythm.app` plus `tempo-rhythm` URL scheme.
 
 ### 2026-04-18 — "Phase 3 rails" session (evening)
 - **Atomic ticket queue generated:** 59 ticket files across 13 cluster parents covering Phase 0 + M0 + M1 in `docs/brain/tickets/`. Each ticket sized ~30 min, with `product` / `assignee` / `execution` / `cluster` / `parallelizable` / `blocked-by` / `blocks` frontmatter and full acceptance criteria + implementation guidance. See `docs/brain/tickets/_INDEX.md` (by time / parallelizability / dependency / cluster / assignee / fallback log) and `docs/brain/tickets/CLUSTERS.md` (parent → child split rationale).


### PR DESCRIPTION
## Summary

Resolves the Expo/EAS ownership mismatch by pointing the mobile app at the existing accessible Tempo Rhythm EAS project.

## What changed

- Updates pps/mobile/app.json owner to mitlevin.
- Updates Expo slug to 	empi, the existing Expo project slug for Tempo Rhythm.
- Updates EAS project ID to 90dfac90-0baa-461b-946c-351d2306e607.
- Documents that 	empi is the existing Tempo Rhythm Expo project name and that the app name, bundle ID, Android package, and URL scheme remain Tempo Rhythm.

## Verification

- as project:info --non-interactive now resolves @amitlevin/tempi.
- as config --profile development --platform android --non-interactive resolves successfully.
- git diff --check
- un run lint
- un test
- un run typecheck
- un run build

## Notes

No app-store package identity changed: iOS remains com.temporhythm.app, Android remains com.temporhythm.app, and scheme remains 	empo-rhythm.