### PR TITLE
feat(consent): add layered acknowledgment log

### DIFF
--- a/apps/web/components/consent/ConsentAcknowledgment.tsx
+++ b/apps/web/components/consent/ConsentAcknowledgment.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useMutation } from "convex/react";
+import { makeFunctionReference } from "convex/server";
+import { CheckCircle2, Loader2, ShieldCheck } from "lucide-react";
+import { useCallback, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { type ConsentPoint, getConsentCopy } from "./copy";
+
+const acknowledgeConsent = makeFunctionReference<
+  "mutation",
+  { point: ConsentPoint },
+  {
+    consentLogId: string;
+    point: ConsentPoint;
+    version: string;
+    acknowledgedAt: number;
+  }
+>("consent:acknowledge");
+
+type ConsentAcknowledgmentProps = {
+  point: ConsentPoint;
+  className?: string;
+  onAcknowledged?: (result: {
+    point: ConsentPoint;
+    version: string;
+    acknowledgedAt: number;
+  }) => void;
+};
+
+export function ConsentAcknowledgment({
+  point,
+  className,
+  onAcknowledged,
+}: ConsentAcknowledgmentProps) {
+  const acknowledge = useMutation(acknowledgeConsent);
+  const copy = getConsentCopy(point);
+  const [status, setStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [message, setMessage] = useState("");
+
+  const handleAcknowledge = useCallback(async () => {
+    setStatus("saving");
+    setMessage("");
+    try {
+      const result = await acknowledge({ point });
+      setStatus("saved");
+      setMessage("Acknowledged. We saved this consent note to your account.");
+      onAcknowledged?.(result);
+    } catch {
+      setStatus("error");
+      setMessage("Could not save this acknowledgment yet. You can try again when you are ready.");
+    }
+  }, [acknowledge, onAcknowledged, point]);
+
+  const isSaving = status === "saving";
+  const isSaved = status === "saved";
+
+  return (
+    <section
+      className={cn(
+        "rounded-[1.5rem] border border-border bg-card p-5 text-card-foreground shadow-sm",
+        className
+      )}
+      aria-labelledby={`${point}-consent-title`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-1 rounded-full bg-primary/10 p-2 text-primary">
+          <ShieldCheck className="h-5 w-5" aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              {copy.eyebrow}
+            </p>
+            <h2 id={`${point}-consent-title`} className="font-heading text-xl text-foreground">
+              {copy.title}
+            </h2>
+          </div>
+
+          <p className="text-sm leading-6 text-muted-foreground">{copy.body}</p>
+
+          <div className="rounded-[1rem] border border-border bg-muted/35 px-4 py-3">
+            <p className="text-sm font-medium text-foreground">{copy.acknowledgment}</p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              onClick={() => void handleAcknowledge()}
+              disabled={isSaving || isSaved}
+              className="rounded-full"
+            >
+              {isSaving ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                  Saving...
+                </>
+              ) : isSaved ? (
+                <>
+                  <CheckCircle2 className="h-4 w-4" aria-hidden />
+                  Acknowledged
+                </>
+              ) : (
+                copy.buttonLabel
+              )}
+            </Button>
+            <p className="text-sm text-muted-foreground">
+              No blanket consent; this saves this point only.
+            </p>
+          </div>
+
+          {message ? (
+            <p
+              className={cn(
+                "text-sm",
+                status === "error" ? "text-destructive" : "text-muted-foreground"
+              )}
+              role={status === "error" ? "alert" : "status"}
+            >
+              {message}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/consent/copy.ts
+++ b/apps/web/components/consent/copy.ts
@@ -1,0 +1,60 @@
+export const consentPoints = [
+  "connector_scope",
+  "voice_permission",
+  "trial_conversion",
+  "refund_policy",
+] as const;
+
+export type ConsentPoint = (typeof consentPoints)[number];
+
+export type ConsentCopy = {
+  point: ConsentPoint;
+  eyebrow: string;
+  title: string;
+  body: string;
+  acknowledgment: string;
+  buttonLabel: string;
+};
+
+export const consentCopy = {
+  connector_scope: {
+    point: "connector_scope",
+    eyebrow: "Connector scope",
+    title: "Connectors only use the scope you approve",
+    body: "When you connect another tool, Tempo can only use the specific access listed for that connector. You can remove the connection later from Integrations.",
+    acknowledgment: "I understand this connector uses only the scope shown here.",
+    buttonLabel: "Acknowledge connector scope",
+  },
+  voice_permission: {
+    point: "voice_permission",
+    eyebrow: "Voice permission",
+    title: "Voice starts only when you choose it",
+    body: "Tempo asks before using your microphone. Voice input is used to turn what you say into Tempo actions or notes; you can stop or skip voice at any time.",
+    acknowledgment: "I understand when voice input is used and that I can stop it.",
+    buttonLabel: "Acknowledge voice use",
+  },
+  trial_conversion: {
+    point: "trial_conversion",
+    eyebrow: "Trial conversion",
+    title: "Trial billing is only placeholder text right now",
+    body: "This phase does not charge payments. Any trial-conversion copy you see is a stub so we can test the consent moment before real billing is connected.",
+    acknowledgment: "I understand this trial conversion text is a no-charge placeholder.",
+    buttonLabel: "Acknowledge trial note",
+  },
+  refund_policy: {
+    point: "refund_policy",
+    eyebrow: "Refund policy",
+    title: "Refund copy is a placeholder this phase",
+    body: "Refund language is shown as stub text while payments are not active. No payment or refund request is submitted from this consent step.",
+    acknowledgment: "I understand refund text is a placeholder until payments are active.",
+    buttonLabel: "Acknowledge refund note",
+  },
+} satisfies Record<ConsentPoint, ConsentCopy>;
+
+export function getConsentCopy(point: ConsentPoint): ConsentCopy {
+  const copy = consentCopy[point];
+  if (!copy) {
+    throw new Error("Unknown consent point.");
+  }
+  return copy;
+}

--- a/apps/web/components/consent/index.ts
+++ b/apps/web/components/consent/index.ts
@@ -1,0 +1,3 @@
+export { ConsentAcknowledgment } from "./ConsentAcknowledgment";
+export type { ConsentCopy, ConsentPoint } from "./copy";
+export { consentCopy, consentPoints, getConsentCopy } from "./copy";

--- a/convex/consent.test.ts
+++ b/convex/consent.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import type { Id } from "./_generated/dataModel";
+import {
+  buildConsentLogRecord,
+  type ConsentPoint,
+  consentDefinitions,
+  consentPoints,
+  getConsentDefinition,
+} from "./consent";
+
+describe("consent definitions", () => {
+  test("defines separate plain-English copy for every consent point", () => {
+    expect(consentPoints).toEqual([
+      "connector_scope",
+      "voice_permission",
+      "trial_conversion",
+      "refund_policy",
+    ]);
+
+    for (const point of consentPoints) {
+      const definition = getConsentDefinition(point);
+      expect(definition.point).toBe(point);
+      expect(definition.version.length).toBeGreaterThan(0);
+      expect(definition.title).not.toMatch(/blanket/i);
+      expect(definition.body.length).toBeGreaterThan(80);
+      expect(definition.acknowledgment).toMatch(/^I understand/);
+    }
+  });
+
+  test("keeps trial and refund consent as no-payment placeholder copy", () => {
+    expect(consentDefinitions.trial_conversion.body).toMatch(/does not charge payments/i);
+    expect(consentDefinitions.refund_policy.body).toMatch(/payments are not active/i);
+  });
+});
+
+describe("buildConsentLogRecord", () => {
+  test("builds a versioned acknowledgment row for a consent point", () => {
+    const now = 1_783_996_200_000;
+    const userId = "users:demo" as Id<"users">;
+    const record = buildConsentLogRecord({
+      userId,
+      point: "voice_permission",
+      now,
+    });
+
+    expect(record).toMatchObject({
+      userId,
+      point: "voice_permission",
+      version: consentDefinitions.voice_permission.version,
+      acknowledgedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+    expect(record.copyText).toContain(consentDefinitions.voice_permission.title);
+    expect(record.copyText).toContain(consentDefinitions.voice_permission.acknowledgment);
+  });
+
+  test("rejects unknown consent points before a log row is built", () => {
+    expect(() => getConsentDefinition("blanket_consent" as ConsentPoint)).toThrow();
+  });
+});

--- a/convex/consent.ts
+++ b/convex/consent.ts
@@ -1,0 +1,148 @@
+import { v } from "convex/values";
+import type { Id } from "./_generated/dataModel";
+import { mutation, query } from "./_generated/server";
+import { requireUser } from "./lib/requireUser";
+
+export const consentPoints = [
+  "connector_scope",
+  "voice_permission",
+  "trial_conversion",
+  "refund_policy",
+] as const;
+
+export type ConsentPoint = (typeof consentPoints)[number];
+
+type ConsentDefinition = {
+  point: ConsentPoint;
+  version: string;
+  title: string;
+  body: string;
+  acknowledgment: string;
+};
+
+export type ConsentLogRecord = {
+  userId: Id<"users">;
+  point: ConsentPoint;
+  version: string;
+  copyText: string;
+  acknowledgedAt: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export const consentPointValidator = v.union(
+  v.literal("connector_scope"),
+  v.literal("voice_permission"),
+  v.literal("trial_conversion"),
+  v.literal("refund_policy")
+);
+
+export const consentDefinitions = {
+  connector_scope: {
+    point: "connector_scope",
+    version: "2026-07-14.connector-scope.v1",
+    title: "Connectors only use the scope you approve",
+    body: "When you connect another tool, Tempo can only use the specific access listed for that connector. You can remove the connection later from Integrations.",
+    acknowledgment: "I understand this connector uses only the scope shown here.",
+  },
+  voice_permission: {
+    point: "voice_permission",
+    version: "2026-07-14.voice-permission.v1",
+    title: "Voice starts only when you choose it",
+    body: "Tempo asks before using your microphone. Voice input is used to turn what you say into Tempo actions or notes; you can stop or skip voice at any time.",
+    acknowledgment: "I understand when voice input is used and that I can stop it.",
+  },
+  trial_conversion: {
+    point: "trial_conversion",
+    version: "2026-07-14.trial-conversion.v1",
+    title: "Trial billing is only placeholder text right now",
+    body: "This phase does not charge payments. Any trial-conversion copy you see is a stub so we can test the consent moment before real billing is connected.",
+    acknowledgment: "I understand this trial conversion text is a no-charge placeholder.",
+  },
+  refund_policy: {
+    point: "refund_policy",
+    version: "2026-07-14.refund-policy.v1",
+    title: "Refund copy is a placeholder this phase",
+    body: "Refund language is shown as stub text while payments are not active. No payment or refund request is submitted from this consent step.",
+    acknowledgment: "I understand refund text is a placeholder until payments are active.",
+  },
+} satisfies Record<ConsentPoint, ConsentDefinition>;
+
+export function getConsentDefinition(point: ConsentPoint): ConsentDefinition {
+  const definition = consentDefinitions[point];
+  if (!definition) {
+    throw new Error("Unknown consent point.");
+  }
+  return definition;
+}
+
+export function buildConsentLogRecord({
+  userId,
+  point,
+  now,
+}: {
+  userId: Id<"users">;
+  point: ConsentPoint;
+  now: number;
+}): ConsentLogRecord {
+  const definition = getConsentDefinition(point);
+
+  return {
+    userId,
+    point,
+    version: definition.version,
+    copyText: `${definition.title}\n\n${definition.body}\n\n${definition.acknowledgment}`,
+    acknowledgedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export const acknowledge = mutation({
+  args: {
+    point: consentPointValidator,
+  },
+  handler: async (ctx, { point }) => {
+    const user = await requireUser(ctx);
+    const now = Date.now();
+    const record = buildConsentLogRecord({ userId: user._id, point, now });
+    const consentLogId = await ctx.db.insert("consentLogs", record);
+
+    return {
+      consentLogId,
+      point: record.point,
+      version: record.version,
+      acknowledgedAt: record.acknowledgedAt,
+    };
+  },
+});
+
+export const listMine = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await requireUser(ctx);
+    const rows = await ctx.db
+      .query("consentLogs")
+      .withIndex("by_userId_deletedAt", (q) => q.eq("userId", user._id).eq("deletedAt", undefined))
+      .collect();
+
+    return [...rows].sort((a, b) => b.acknowledgedAt - a.acknowledgedAt);
+  },
+});
+
+export const latestByPoint = query({
+  args: {
+    point: consentPointValidator,
+  },
+  handler: async (ctx, { point }) => {
+    const user = await requireUser(ctx);
+    const rows = await ctx.db
+      .query("consentLogs")
+      .withIndex("by_userId_point", (q) => q.eq("userId", user._id).eq("point", point))
+      .collect();
+    const activeRows = rows.filter((row) => row.deletedAt === undefined);
+    activeRows.sort((a, b) => b.acknowledgedAt - a.acknowledgedAt);
+
+    return activeRows[0] ?? null;
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -74,6 +74,25 @@ export default defineSchema({
     updatedAt: v.number(),
   }).index("by_userId", ["userId"]),
 
+  consentLogs: defineTable({
+    userId: v.id("users"),
+    point: v.union(
+      v.literal("connector_scope"),
+      v.literal("voice_permission"),
+      v.literal("trial_conversion"),
+      v.literal("refund_policy"),
+    ),
+    version: v.string(),
+    copyText: v.string(),
+    acknowledgedAt: v.number(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    deletedAt: v.optional(v.number()),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_userId_point", ["userId", "point"])
+    .index("by_userId_deletedAt", ["userId", "deletedAt"]),
+
   conversations: defineTable({
     userId: v.id("users"),
     title: v.string(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the layered consent foundation needed by connector and voice flows so each sensitive moment can be acknowledged separately and persisted server-side. The server owns consent point versions and stores the exact copy snapshot with every acknowledgment, avoiding a single blanket checkbox.

## Linked task(s)

Task: TEMPO-104

## Screenshots / screen recording

N/A — this adds a reusable consent component and Convex API surface, but it is not mounted on a user-visible route in this PR.

## Test plan

- [x] Local `bun run typecheck` passes
- [x] Local `bun run lint` passes (existing `@tempo/ui/src/icons/index.tsx` warning is replayed; command exits 0)
- [x] Relevant unit / integration tests added or updated (`convex/consent.test.ts`)
- [x] Manual QA steps performed: N/A, no mounted route for the new reusable component
- [x] Reproduces the acceptance criteria below
- [x] `bun run test` passes
- [x] Standalone Convex TS check passes for `convex/consent.ts`, `convex/consent.test.ts`, `convex/schema.ts`
- [x] Changed-file forbidden-tech search returned no matches

Convex CLI notes:
- `bunx convex codegen` and `CONVEX_DEPLOYMENT=dev:tremendous-bass-443 bunx convex dev --once --typecheck=enable` are blocked in this environment by missing Convex access token / non-interactive login.

## Acceptance criteria

- each consent point logs an acknowledgment row
- plain-English copy
- not a single blanket checkbox
- log persists server-side

## HARD_RULES compliance checklist

Read @docs/HARD_RULES.md before ticking. Unchecked boxes must have a note.

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). N/A — no AI-originated state mutation in this change.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5).
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7).
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8).
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13). N/A — no env vars added.
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9).

## Owner tag (§14)

- [ ] `cursor-ide`
- [ ] `cursor-cloud-1`
- [ ] `cursor-cloud-2`
- [x] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

## Reviewer

Amit (`human-amit`) by default.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TEMPO-104](https://linear.app/amit-levin/issue/TEMPO-104/i2-layered-consent-acknowledgment-log)

<div><a href="https://cursor.com/agents/bc-37db3043-e9e0-42df-add4-0af9e6ac7ae6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37db3043-e9e0-42df-add4-0af9e6ac7ae6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

