### PR TITLE
test(e2e): add scripted GUI flow harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ dist/
 build/
 out/
 .tmp/
+playwright-report/
+test-results/
 
 # Expo
 .expo/

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
+        "@playwright/test": "^1.61.1",
         "@types/bun": "^1.3.13",
         "@types/node": "^20.19.0",
         "turbo": "^2.3.3",
@@ -573,6 +574,8 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
+
     "@polar-sh/adapter-utils": ["@polar-sh/adapter-utils@0.4.4", "", { "dependencies": { "@polar-sh/sdk": "^0.46.0" } }, "sha512-0fvscT82EMoo+otgnw7YsbzxmatxTpc457DytZY9Lr+6B9XNBI/wP7THK0nV3Qdaipd66Pp9hyZI9Dzusj1KzQ=="],
 
     "@polar-sh/nextjs": ["@polar-sh/nextjs@0.9.4", "", { "dependencies": { "@polar-sh/adapter-utils": "0.4.4", "@polar-sh/sdk": "^0.46.0" }, "peerDependencies": { "next": "^15.0.0 || ^16.0.0" } }, "sha512-CN6qjaVXVR5OojcpjtlXF7FcVnCEXAKB4vyOECP3n3YjD7DdJ4/PPtKvc2/TVXC9bM8m6pcUOI7Y9f7K5T0jNA=="],
@@ -1099,7 +1102,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1420,6 +1423,10 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
@@ -1893,6 +1900,8 @@
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -1930,6 +1939,8 @@
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "lint": "turbo run lint",
     "check": "turbo run check",
     "test": "bun test",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "clean": "turbo run clean && rm -rf node_modules",
     "convex:dev": "bun x convex dev",
     "convex:deploy": "bun x convex deploy",
@@ -27,6 +29,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
+    "@playwright/test": "^1.61.1",
     "@types/bun": "^1.3.13",
     "@types/node": "^20.19.0",
     "turbo": "^2.3.3"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env.PLAYWRIGHT_PORT ?? 3107);
+const host = "127.0.0.1";
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://${host}:${port}`;
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  testMatch: "**/*.e2e.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [["list"], ["github"], ["html", { open: "never" }]]
+    : [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command: `cd apps/web && bun x next dev --turbopack --hostname ${host} --port ${port}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NEXT_PUBLIC_CONVEX_URL:
+        process.env.NEXT_PUBLIC_CONVEX_URL ?? "https://example.convex.cloud",
+      NEXT_TELEMETRY_DISABLED: "1",
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/tests/e2e/flow-contracts.e2e.ts
+++ b/tests/e2e/flow-contracts.e2e.ts
@@ -1,0 +1,44 @@
+import { test } from "@playwright/test";
+
+const pendingFlowContracts = [
+  {
+    title: "signed-in user can create a task and mark it complete",
+    reason:
+      "Needs a deterministic Convex Auth test identity or browser-level Convex mocks before this can run headless.",
+  },
+  {
+    title: "onboarding moves from welcome to first plan",
+    reason:
+      "The onboarding route is currently a protected scaffold shell; add step controls before enabling this GUI flow.",
+  },
+  {
+    title: "panic flow proposes one small task",
+    reason:
+      "No dedicated panic-mode GUI seam exists yet. Enable once the mocked one-small-task proposal card is routable.",
+  },
+  {
+    title: "calendar connection completes with mocked provider callback",
+    reason:
+      "Calendar and integrations routes are scaffold shells. Enable after mock OAuth callback handling exists in the UI.",
+  },
+  {
+    title: "push-to-talk turn renders mocked STT and TTS output",
+    reason:
+      "Voice/PTT UI is not routable yet. Enable once mocked microphone, STT, and TTS adapters are injectable.",
+  },
+  {
+    title: "capture webhook renders a candidate task",
+    reason:
+      "No test webhook capture surface exists yet. Enable when a mocked capture route or inbox card is available.",
+  },
+] as const;
+
+test.describe("TEMPO-108 scripted GUI flow contracts", () => {
+  for (const flow of pendingFlowContracts) {
+    test(flow.title, async ({ page }, testInfo) => {
+      testInfo.annotations.push({ type: "fixme", description: flow.reason });
+      test.fixme(true, flow.reason);
+      void page;
+    });
+  }
+});

--- a/tests/e2e/navigation.e2e.ts
+++ b/tests/e2e/navigation.e2e.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("public navigation and auth gates", () => {
+  test("clicking the landing sign-in link lands on the sign-in form", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("link", { name: "Sign in" }).click();
+
+    await expect(page).toHaveURL(/\/sign-in$/);
+    await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Password" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
+  });
+
+  test("clicking the app preview preserves the Today destination through sign-in", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await page.getByRole("link", { name: "Preview the app" }).click();
+
+    await expect(page).toHaveURL(/\/sign-in\?next=%2Ftoday$/);
+    await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+  });
+
+  test("guarded onboarding preserves its destination through sign-in", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("link", { name: "Start your $1 walk" }).click();
+
+    await expect(page).toHaveURL(/\/sign-in\?next=%2Fonboarding$/);
+    await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+  });
+
+  test("guarded calendar route redirects with an exact next path", async ({ page }) => {
+    await page.goto("/calendar");
+
+    await expect(page).toHaveURL(/\/sign-in\?next=%2Fcalendar$/);
+    await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the first Playwright GUI correctness layer for TEMPO-108 so route-level behavior is asserted headlessly instead of checked by visual impression. The runnable tests cover public sign-in navigation plus guarded route redirects, while the remaining Linear-requested flows are registered as explicit skipped contracts until their mocked auth/backend/UI seams exist.

## Linked task(s)

Task: TEMPO-108

## Screenshots / screen recording

N/A — test harness only, no user-visible UI change.

## Test plan

- [x] Local `bun run typecheck` passes
- [x] Local `bun run lint` passes (exits 0; existing `@tempo/ui` unused suppression warning remains)
- [x] Relevant unit / integration tests added or updated
- [x] Manual QA steps performed: `bun run test:e2e` starts the Next web app headlessly and verifies route behavior
- [x] Reproduces the acceptance criteria below where current GUI seams exist
- [x] Local `bun test` passes: 36 pass, 0 fail
- [x] Local `bun run test:e2e` passes: 4 passed, 6 skipped annotated flow contracts
- [ ] `bun run check` is not clean due pre-existing formatting drift in web/mobile files outside this PR scope; not committed

## Acceptance criteria

core flows green in CI headless; failures annotate the PR.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). N/A — no AI mutation changes.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). N/A — no schema changes.
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7). N/A — no UI styling changes.
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8). N/A — test harness only.
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13). N/A — no new persisted env vars.
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9).

## Owner tag (§14)

- [ ] `cursor-ide`
- [ ] `cursor-cloud-1`
- [ ] `cursor-cloud-2`
- [x] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

## Reviewer

Amit (`human-amit`) by default.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TEMPO-108](https://linear.app/amit-levin/issue/TEMPO-108/q2-scripted-gui-flows-playwright)

<div><a href="https://cursor.com/agents/bc-9bee40cc-d151-48d0-9975-f21168c80687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9bee40cc-d151-48d0-9975-f21168c80687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

