### PR TITLE
feat(routines): bundle habits and tasks

### DIFF
--- a/apps/web/app/(tempo)/routines/[id]/page.tsx
+++ b/apps/web/app/(tempo)/routines/[id]/page.tsx
@@ -1,30 +1,8 @@
-/**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
- * @screen: routine-detail
- * @category: Library
- * @source: docs/design/claude-export/design-system/screens-3.jsx
- * @summary: Guided run of a routine.
- * @queries: routines.get
- * @mutations: routines.logRun
- * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
- */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { RoutineDetailClient } from "@/components/routines/RoutineDetailClient";
 
 type Params = { id: string };
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<Params>;
-}) {
+export default async function Page({ params }: { params: Promise<Params> }) {
   const { id } = await params;
-  return (
-    <ScaffoldScreen
-      title="Routine guided"
-      category="Library"
-      source="screens-3.jsx"
-      summary={`Guided run of a routine. (id: ${id})`}
-    />
-  );
+  return <RoutineDetailClient routineId={id} />;
 }

--- a/apps/web/app/(tempo)/routines/page.tsx
+++ b/apps/web/app/(tempo)/routines/page.tsx
@@ -1,23 +1,5 @@
-/**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
- * @screen: routines
- * @category: Library
- * @source: docs/design/claude-export/design-system/screens-3.jsx
- * @summary: Routine library.
- * @queries: routines.list
- * @mutations: routines.create
- * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
- */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { RoutinesPageClient } from "@/components/routines/RoutinesPageClient";
 
 export default function Page() {
-  return (
-    <ScaffoldScreen
-      title="Routines"
-      category="Library"
-      source="screens-3.jsx"
-      summary="Routine library."
-    />
-  );
+  return <RoutinesPageClient />;
 }

--- a/apps/web/components/routines/RoutineDetailClient.tsx
+++ b/apps/web/components/routines/RoutineDetailClient.tsx
@@ -21,7 +21,7 @@ export function RoutineDetailClient({ routineId }: RoutineDetailClientProps) {
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
   const routine = useQuery(
     api.routines.getWithItems,
-    isAuthenticated ? { routineId: routineId as Id<"routines"> } : "skip"
+    isAuthenticated ? { routineId } : "skip"
   );
   const completeItem = useMutation(api.routines.completeItem);
   const [pendingItemId, setPendingItemId] = useState<string | null>(null);

--- a/apps/web/components/routines/RoutineDetailClient.tsx
+++ b/apps/web/components/routines/RoutineDetailClient.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import Link from "next/link";
+import { useState } from "react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { useLocalDayBounds } from "@/lib/useLocalDayBounds";
+
+type RoutineDetailClientProps = {
+  routineId: string;
+};
+
+function isWithinToday(timestamp: number | undefined, startMs: number, endMs: number) {
+  return timestamp !== undefined && timestamp >= startMs && timestamp < endMs;
+}
+
+export function RoutineDetailClient({ routineId }: RoutineDetailClientProps) {
+  const bounds = useLocalDayBounds();
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const routine = useQuery(
+    api.routines.getWithItems,
+    isAuthenticated ? { routineId: routineId as Id<"routines"> } : "skip"
+  );
+  const completeItem = useMutation(api.routines.completeItem);
+  const [pendingItemId, setPendingItemId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLoading = isAuthLoading || (isAuthenticated && routine === undefined);
+
+  async function handleComplete(routineItemId: Id<"routineItems">) {
+    setPendingItemId(routineItemId);
+    setError(null);
+    try {
+      await completeItem({ routineItemId });
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "We couldn't complete that item yet.");
+    } finally {
+      setPendingItemId(null);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-8">
+        <div className="h-10 w-64 animate-pulse rounded-xl bg-muted" />
+        <div className="h-72 animate-pulse rounded-3xl bg-muted" />
+      </main>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-8">
+        <SoftCard padding="lg" className="text-center">
+          <h1 className="text-h2 font-serif">Sign in to run this routine</h1>
+          <p className="mt-3 text-body text-muted-foreground">
+            Your routine items are private, so sign in to continue.
+          </p>
+          <Link
+            href={`/sign-in?next=/routines/${routineId}`}
+            className="mt-6 inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 font-medium text-primary-foreground"
+          >
+            Sign in
+          </Link>
+        </SoftCard>
+      </main>
+    );
+  }
+
+  if (routine === null) {
+    return (
+      <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-8">
+        <SoftCard padding="lg" className="text-center">
+          <h1 className="text-h2 font-serif">Routine not found</h1>
+          <p className="mt-3 text-body text-muted-foreground">
+            It may have been moved or removed. Your routine library is still available.
+          </p>
+          <Link
+            href="/routines"
+            className="mt-6 inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 font-medium text-primary-foreground"
+          >
+            Back to routines
+          </Link>
+        </SoftCard>
+      </main>
+    );
+  }
+
+  if (routine === undefined) {
+    return null;
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 p-8">
+      <header className="space-y-4">
+        <Link href="/routines" className="text-small font-medium text-primary hover:underline">
+          Back to routines
+        </Link>
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-3">
+            <Pill tone="orange">Routine run</Pill>
+            <Pill tone="moss">Completable items</Pill>
+          </div>
+          <h1 className="text-h1 font-serif">{routine.name}</h1>
+          <p className="max-w-2xl text-body leading-relaxed text-muted-foreground">
+            Move through the habit and task together. Completing either one here updates its source
+            record too.
+          </p>
+        </div>
+      </header>
+
+      {error ? (
+        <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-small text-destructive">
+          {error}
+        </p>
+      ) : null}
+
+      <section className="grid gap-4" aria-label="Routine items">
+        {routine.items.map((item) => {
+          if (item.itemType === "habit") {
+            const doneToday = isWithinToday(
+              item.habit.lastCompletedAt,
+              bounds.startMs,
+              bounds.endMs
+            );
+            return (
+              <SoftCard key={item._id} as="article" padding="lg" className="space-y-4">
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div className="space-y-2">
+                    <Pill tone="moss">Habit</Pill>
+                    <div>
+                      <h2 className="text-h2 font-serif">{item.habit.name}</h2>
+                      <p className="text-small text-muted-foreground">
+                        Daily cadence · current streak {item.habit.currentStreak}
+                      </p>
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    variant={doneToday ? "subtle" : "primary"}
+                    disabled={doneToday || pendingItemId === item._id}
+                    onClick={() => {
+                      void handleComplete(item._id);
+                    }}
+                  >
+                    {doneToday
+                      ? "Habit complete today"
+                      : pendingItemId === item._id
+                        ? "Completing..."
+                        : "Complete habit"}
+                  </Button>
+                </div>
+                <Link
+                  href={`/habits/${item.habit._id}`}
+                  className="inline-flex text-small font-medium text-primary hover:underline"
+                >
+                  Open habit detail
+                </Link>
+              </SoftCard>
+            );
+          }
+
+          const taskDone = item.task.status === "done";
+          return (
+            <SoftCard key={item._id} as="article" padding="lg" className="space-y-4">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="space-y-2">
+                  <Pill tone="slate">Task</Pill>
+                  <div>
+                    <h2 className="text-h2 font-serif">{item.task.title}</h2>
+                    <p className="text-small text-muted-foreground">
+                      Priority {item.task.priority} · status {item.task.status.replace("_", " ")}
+                    </p>
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  variant={taskDone ? "subtle" : "primary"}
+                  disabled={taskDone || pendingItemId === item._id}
+                  onClick={() => {
+                    void handleComplete(item._id);
+                  }}
+                >
+                  {taskDone
+                    ? "Task complete"
+                    : pendingItemId === item._id
+                      ? "Completing..."
+                      : "Complete task"}
+                </Button>
+              </div>
+              <Link
+                href="/tasks"
+                className="inline-flex text-small font-medium text-primary hover:underline"
+              >
+                Open tasks
+              </Link>
+            </SoftCard>
+          );
+        })}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/components/routines/RoutinesPageClient.tsx
+++ b/apps/web/components/routines/RoutinesPageClient.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { type FormEvent, useState } from "react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+
+type RoutineFormState = {
+  name: string;
+  habitName: string;
+  taskTitle: string;
+};
+
+const initialFormState: RoutineFormState = {
+  name: "",
+  habitName: "",
+  taskTitle: "",
+};
+
+export function RoutinesPageClient() {
+  const router = useRouter();
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const routines = useQuery(api.routines.list, isAuthenticated ? {} : "skip");
+  const createRoutine = useMutation(api.routines.createWithItems);
+  const [form, setForm] = useState<RoutineFormState>(initialFormState);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isLoading = isAuthLoading || (isAuthenticated && routines === undefined);
+  const canSubmit =
+    form.name.trim().length > 0 &&
+    form.habitName.trim().length > 0 &&
+    form.taskTitle.trim().length > 0 &&
+    !isSubmitting;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const routineId: Id<"routines"> = await createRoutine({
+        name: form.name,
+        habitName: form.habitName,
+        taskTitle: form.taskTitle,
+      });
+      setForm(initialFormState);
+      router.push(`/routines/${routineId}`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "We couldn't create that routine yet.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-8">
+        <div className="h-10 w-56 animate-pulse rounded-xl bg-muted" />
+        <div className="h-64 animate-pulse rounded-3xl bg-muted" />
+        <div className="h-40 animate-pulse rounded-3xl bg-muted" />
+      </main>
+    );
+  }
+
+  if (!isAuthenticated || !routines) {
+    return (
+      <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-8">
+        <SoftCard padding="lg" className="text-center">
+          <h1 className="text-h2 font-serif">Sign in to build routines</h1>
+          <p className="mt-3 text-body text-muted-foreground">
+            Your routine library lives with your tasks and habits, so sign in to keep it together.
+          </p>
+          <Link
+            href="/sign-in?next=/routines"
+            className="mt-6 inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 font-medium text-primary-foreground"
+          >
+            Sign in
+          </Link>
+        </SoftCard>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 p-8">
+      <header className="space-y-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <Pill tone="orange">Library</Pill>
+          <Pill tone="moss">Habits + tasks</Pill>
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-h1 font-serif">Routines</h1>
+          <p className="max-w-2xl text-body leading-relaxed text-muted-foreground">
+            Bundle a small repeating habit with a concrete task, then run both from one calm view.
+          </p>
+        </div>
+      </header>
+
+      <SoftCard as="section" padding="lg" aria-labelledby="create-routine-heading">
+        <div className="grid gap-6 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+          <div className="space-y-3">
+            <h2 id="create-routine-heading" className="text-h2 font-serif">
+              Create a starter routine
+            </h2>
+            <p className="text-small leading-relaxed text-muted-foreground">
+              Add one habit and one task. You can complete both from the routine view after it is
+              created.
+            </p>
+          </div>
+
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <label htmlFor="routine-name" className="text-small font-medium">
+                Routine name
+              </label>
+              <input
+                id="routine-name"
+                name="routineName"
+                value={form.name}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, name: event.target.value }))
+                }
+                className="h-11 w-full rounded-xl border border-border bg-background px-4 text-body text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-primary"
+                placeholder="Morning reset"
+                autoComplete="off"
+              />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label htmlFor="routine-habit" className="text-small font-medium">
+                  Habit
+                </label>
+                <input
+                  id="routine-habit"
+                  name="habitName"
+                  value={form.habitName}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, habitName: event.target.value }))
+                  }
+                  className="h-11 w-full rounded-xl border border-border bg-background px-4 text-body text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-primary"
+                  placeholder="Drink water"
+                  autoComplete="off"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="routine-task" className="text-small font-medium">
+                  Task
+                </label>
+                <input
+                  id="routine-task"
+                  name="taskTitle"
+                  value={form.taskTitle}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, taskTitle: event.target.value }))
+                  }
+                  className="h-11 w-full rounded-xl border border-border bg-background px-4 text-body text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-primary"
+                  placeholder="Pack tomorrow's bag"
+                  autoComplete="off"
+                />
+              </div>
+            </div>
+
+            {error ? (
+              <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-small text-destructive">
+                {error}
+              </p>
+            ) : null}
+
+            <Button type="submit" disabled={!canSubmit}>
+              {isSubmitting ? "Creating routine..." : "Create routine"}
+            </Button>
+          </form>
+        </div>
+      </SoftCard>
+
+      <section className="space-y-4" aria-labelledby="routine-library-heading">
+        <div className="flex items-end justify-between gap-4">
+          <div>
+            <h2 id="routine-library-heading" className="text-h2 font-serif">
+              Routine library
+            </h2>
+            <p className="text-small text-muted-foreground">
+              {routines.length === 0
+                ? "No routines yet. One gentle starter is enough."
+                : `${routines.length} ${routines.length === 1 ? "routine" : "routines"} ready.`}
+            </p>
+          </div>
+        </div>
+
+        {routines.length === 0 ? (
+          <SoftCard tone="sunken" padding="lg" className="text-center">
+            <p className="text-body text-foreground">Your first routine can be tiny.</p>
+            <p className="mt-2 text-small text-muted-foreground">
+              Try pairing one body cue with one task you want to make easier to start.
+            </p>
+          </SoftCard>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            {routines.map((routine) => (
+              <SoftCard key={routine._id} as="article" padding="md" className="flex flex-col gap-4">
+                <div className="space-y-2">
+                  <h3 className="text-h3 font-serif">{routine.name}</h3>
+                  <div className="flex flex-wrap gap-2">
+                    <Pill tone="moss">{routine.habitCount} habit</Pill>
+                    <Pill tone="slate">{routine.taskCount} task</Pill>
+                  </div>
+                </div>
+                <Link
+                  href={`/routines/${routine._id}`}
+                  className="mt-auto inline-flex h-10 items-center justify-center rounded-lg border border-border bg-card px-4 text-small font-medium transition hover:bg-surface-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
+                  Open routine
+                </Link>
+              </SoftCard>
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
+        "@playwright/test": "^1.61.1",
         "@types/bun": "^1.3.13",
         "@types/node": "^20.19.0",
         "turbo": "^2.3.3",
@@ -573,6 +574,8 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
+
     "@polar-sh/adapter-utils": ["@polar-sh/adapter-utils@0.4.4", "", { "dependencies": { "@polar-sh/sdk": "^0.46.0" } }, "sha512-0fvscT82EMoo+otgnw7YsbzxmatxTpc457DytZY9Lr+6B9XNBI/wP7THK0nV3Qdaipd66Pp9hyZI9Dzusj1KzQ=="],
 
     "@polar-sh/nextjs": ["@polar-sh/nextjs@0.9.4", "", { "dependencies": { "@polar-sh/adapter-utils": "0.4.4", "@polar-sh/sdk": "^0.46.0" }, "peerDependencies": { "next": "^15.0.0 || ^16.0.0" } }, "sha512-CN6qjaVXVR5OojcpjtlXF7FcVnCEXAKB4vyOECP3n3YjD7DdJ4/PPtKvc2/TVXC9bM8m6pcUOI7Y9f7K5T0jNA=="],
@@ -1099,7 +1102,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1420,6 +1423,10 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
@@ -1893,6 +1900,8 @@
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -1930,6 +1939,8 @@
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -24,6 +24,7 @@ import type * as memories from "../memories.js";
 import type * as messages from "../messages.js";
 import type * as notes from "../notes.js";
 import type * as revenuecat from "../revenuecat.js";
+import type * as routines from "../routines.js";
 import type * as streaks from "../streaks.js";
 import type * as tasks from "../tasks.js";
 import type * as users from "../users.js";
@@ -51,6 +52,7 @@ declare const fullApi: ApiFromModules<{
   messages: typeof messages;
   notes: typeof notes;
   revenuecat: typeof revenuecat;
+  routines: typeof routines;
   streaks: typeof streaks;
   tasks: typeof tasks;
   users: typeof users;

--- a/convex/routines.ts
+++ b/convex/routines.ts
@@ -177,11 +177,15 @@ export const list = query({
 });
 
 export const getWithItems = query({
-  args: { routineId: v.id("routines") },
+  args: { routineId: v.string() },
   returns: v.union(routineDetailValidator, v.null()),
   handler: async (ctx, args) => {
     const user = await requireUser(ctx);
-    const routine = await ctx.db.get(args.routineId);
+    const routineId = ctx.db.normalizeId("routines", args.routineId);
+    if (!routineId) {
+      return null;
+    }
+    const routine = await ctx.db.get(routineId);
     if (!routine || routine.userId !== user._id || routine.deletedAt !== undefined) {
       return null;
     }

--- a/convex/routines.ts
+++ b/convex/routines.ts
@@ -1,0 +1,338 @@
+import { v } from "convex/values";
+import type { Doc, Id } from "./_generated/dataModel";
+import { mutation, type MutationCtx, query, type QueryCtx } from "./_generated/server";
+import { requireUser } from "./lib/requireUser";
+
+type ConvexCtx = QueryCtx | MutationCtx;
+type ResolvedRoutineItem =
+  | {
+      _id: Id<"routineItems">;
+      itemType: "habit";
+      position: number;
+      habit: {
+        _id: Id<"habits">;
+        name: string;
+        cadence: "daily" | "weekly";
+        currentStreak: number;
+        longestStreak: number;
+        lastCompletedAt?: number;
+      };
+    }
+  | {
+      _id: Id<"routineItems">;
+      itemType: "task";
+      position: number;
+      task: {
+        _id: Id<"tasks">;
+        title: string;
+        description?: string;
+        status: "todo" | "in_progress" | "done" | "cancelled";
+        priority: "low" | "medium" | "high";
+        dueAt?: number;
+      };
+    };
+
+const trimmedString = (value: string, label: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${label} cannot be empty.`);
+  }
+  return trimmed;
+};
+
+const taskStatusValidator = v.union(
+  v.literal("todo"),
+  v.literal("in_progress"),
+  v.literal("done"),
+  v.literal("cancelled"),
+);
+
+const priorityValidator = v.union(v.literal("low"), v.literal("medium"), v.literal("high"));
+
+const routineSummaryValidator = v.object({
+  _id: v.id("routines"),
+  name: v.string(),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+  habitCount: v.number(),
+  taskCount: v.number(),
+});
+
+const habitItemValidator = v.object({
+  _id: v.id("routineItems"),
+  itemType: v.literal("habit"),
+  position: v.number(),
+  habit: v.object({
+    _id: v.id("habits"),
+    name: v.string(),
+    cadence: v.union(v.literal("daily"), v.literal("weekly")),
+    currentStreak: v.number(),
+    longestStreak: v.number(),
+    lastCompletedAt: v.optional(v.number()),
+  }),
+});
+
+const taskItemValidator = v.object({
+  _id: v.id("routineItems"),
+  itemType: v.literal("task"),
+  position: v.number(),
+  task: v.object({
+    _id: v.id("tasks"),
+    title: v.string(),
+    description: v.optional(v.string()),
+    status: taskStatusValidator,
+    priority: priorityValidator,
+    dueAt: v.optional(v.number()),
+  }),
+});
+
+const routineDetailValidator = v.object({
+  _id: v.id("routines"),
+  name: v.string(),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+  items: v.array(v.union(habitItemValidator, taskItemValidator)),
+});
+
+const completionResultValidator = v.object({
+  routineItemId: v.id("routineItems"),
+  itemType: v.union(v.literal("habit"), v.literal("task")),
+  completed: v.boolean(),
+});
+
+async function getOwnedRoutine(
+  ctx: ConvexCtx,
+  routineId: Id<"routines">,
+  userId: Id<"users">,
+) {
+  const routine = await ctx.db.get(routineId);
+  if (!routine || routine.userId !== userId || routine.deletedAt !== undefined) {
+    throw new Error("Routine not found");
+  }
+  return routine;
+}
+
+async function completeHabit(ctx: MutationCtx, habit: Doc<"habits">) {
+  const now = Date.now();
+  const dayMs = 24 * 60 * 60 * 1000;
+  let current = habit.currentStreak;
+
+  if (habit.lastCompletedAt !== undefined) {
+    const daysSince = Math.floor((now - habit.lastCompletedAt) / dayMs);
+    if (daysSince === 0) {
+      return;
+    }
+    current = daysSince === 1 ? current + 1 : 1;
+  } else {
+    current = 1;
+  }
+
+  await ctx.db.patch(habit._id, {
+    currentStreak: current,
+    longestStreak: Math.max(habit.longestStreak, current),
+    lastCompletedAt: now,
+    updatedAt: now,
+  });
+}
+
+export const list = query({
+  args: {},
+  returns: v.array(routineSummaryValidator),
+  handler: async (ctx) => {
+    const user = await requireUser(ctx);
+    const routines = await ctx.db
+      .query("routines")
+      .withIndex("by_userId_deletedAt", (q) => q.eq("userId", user._id).eq("deletedAt", undefined))
+      .collect();
+    const items = await ctx.db
+      .query("routineItems")
+      .withIndex("by_userId_deletedAt", (q) => q.eq("userId", user._id).eq("deletedAt", undefined))
+      .collect();
+    const itemCounts = new Map<Id<"routines">, { habitCount: number; taskCount: number }>();
+
+    for (const item of items) {
+      const current = itemCounts.get(item.routineId) ?? { habitCount: 0, taskCount: 0 };
+      if (item.itemType === "habit") {
+        current.habitCount += 1;
+      } else {
+        current.taskCount += 1;
+      }
+      itemCounts.set(item.routineId, current);
+    }
+
+    return routines
+      .map((routine) => {
+        const counts = itemCounts.get(routine._id) ?? { habitCount: 0, taskCount: 0 };
+        return {
+          _id: routine._id,
+          name: routine.name,
+          createdAt: routine.createdAt,
+          updatedAt: routine.updatedAt,
+          habitCount: counts.habitCount,
+          taskCount: counts.taskCount,
+        };
+      })
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+  },
+});
+
+export const getWithItems = query({
+  args: { routineId: v.id("routines") },
+  returns: v.union(routineDetailValidator, v.null()),
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const routine = await ctx.db.get(args.routineId);
+    if (!routine || routine.userId !== user._id || routine.deletedAt !== undefined) {
+      return null;
+    }
+
+    const items = await ctx.db
+      .query("routineItems")
+      .withIndex("by_routineId_deletedAt", (q) =>
+        q.eq("routineId", routine._id).eq("deletedAt", undefined),
+      )
+      .collect();
+    const resolvedItems: ResolvedRoutineItem[] = [];
+
+    for (const item of items.toSorted((a, b) => a.position - b.position)) {
+      if (item.itemType === "habit" && item.habitId) {
+        const habit = await ctx.db.get(item.habitId);
+        if (habit && habit.userId === user._id && habit.deletedAt === undefined) {
+          resolvedItems.push({
+            _id: item._id,
+            itemType: "habit" as const,
+            position: item.position,
+            habit: {
+              _id: habit._id,
+              name: habit.name,
+              cadence: habit.cadence,
+              currentStreak: habit.currentStreak,
+              longestStreak: habit.longestStreak,
+              lastCompletedAt: habit.lastCompletedAt,
+            },
+          });
+        }
+      }
+
+      if (item.itemType === "task" && item.taskId) {
+        const task = await ctx.db.get(item.taskId);
+        if (task && task.userId === user._id && task.deletedAt === undefined) {
+          resolvedItems.push({
+            _id: item._id,
+            itemType: "task" as const,
+            position: item.position,
+            task: {
+              _id: task._id,
+              title: task.title,
+              description: task.description,
+              status: task.status,
+              priority: task.priority,
+              dueAt: task.dueAt,
+            },
+          });
+        }
+      }
+    }
+
+    return {
+      _id: routine._id,
+      name: routine.name,
+      createdAt: routine.createdAt,
+      updatedAt: routine.updatedAt,
+      items: resolvedItems,
+    };
+  },
+});
+
+export const createWithItems = mutation({
+  args: {
+    name: v.string(),
+    habitName: v.string(),
+    taskTitle: v.string(),
+  },
+  returns: v.id("routines"),
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const now = Date.now();
+    const routineId = await ctx.db.insert("routines", {
+      userId: user._id,
+      name: trimmedString(args.name, "Routine name"),
+      createdAt: now,
+      updatedAt: now,
+    });
+    const habitId = await ctx.db.insert("habits", {
+      userId: user._id,
+      name: trimmedString(args.habitName, "Habit name"),
+      cadence: "daily",
+      currentStreak: 0,
+      longestStreak: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const taskId = await ctx.db.insert("tasks", {
+      userId: user._id,
+      title: trimmedString(args.taskTitle, "Task title"),
+      status: "todo",
+      priority: "medium",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await ctx.db.insert("routineItems", {
+      userId: user._id,
+      routineId,
+      itemType: "habit",
+      habitId,
+      position: 0,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await ctx.db.insert("routineItems", {
+      userId: user._id,
+      routineId,
+      itemType: "task",
+      taskId,
+      position: 1,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return routineId;
+  },
+});
+
+export const completeItem = mutation({
+  args: { routineItemId: v.id("routineItems") },
+  returns: completionResultValidator,
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const item = await ctx.db.get(args.routineItemId);
+    if (!item || item.userId !== user._id || item.deletedAt !== undefined) {
+      throw new Error("Routine item not found");
+    }
+    await getOwnedRoutine(ctx, item.routineId, user._id);
+
+    if (item.itemType === "habit") {
+      if (!item.habitId) {
+        throw new Error("Routine habit not found");
+      }
+      const habit = await ctx.db.get(item.habitId);
+      if (!habit || habit.userId !== user._id || habit.deletedAt !== undefined) {
+        throw new Error("Habit not found");
+      }
+      await completeHabit(ctx, habit);
+    } else {
+      if (!item.taskId) {
+        throw new Error("Routine task not found");
+      }
+      const task = await ctx.db.get(item.taskId);
+      if (!task || task.userId !== user._id || task.deletedAt !== undefined) {
+        throw new Error("Task not found");
+      }
+      await ctx.db.patch(task._id, { status: "done", updatedAt: Date.now() });
+    }
+
+    await ctx.db.patch(item._id, { updatedAt: Date.now() });
+    return { routineItemId: item._id, itemType: item.itemType, completed: true };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -179,6 +179,31 @@ export default defineSchema({
     .index("by_userId", ["userId"])
     .index("by_userId_deletedAt", ["userId", "deletedAt"]),
 
+  routines: defineTable({
+    userId: v.id("users"),
+    name: v.string(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    deletedAt: v.optional(v.number()),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_userId_deletedAt", ["userId", "deletedAt"]),
+
+  routineItems: defineTable({
+    userId: v.id("users"),
+    routineId: v.id("routines"),
+    itemType: v.union(v.literal("habit"), v.literal("task")),
+    habitId: v.optional(v.id("habits")),
+    taskId: v.optional(v.id("tasks")),
+    position: v.number(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    deletedAt: v.optional(v.number()),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_routineId_deletedAt", ["routineId", "deletedAt"])
+    .index("by_userId_deletedAt", ["userId", "deletedAt"]),
+
   goals: defineTable({
     userId: v.id("users"),
     title: v.string(),

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
+    "@playwright/test": "^1.61.1",
     "@types/bun": "^1.3.13",
     "@types/node": "^20.19.0",
     "turbo": "^2.3.3"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "@playwright/test";
+
+const convexUrl = "http://127.0.0.1:3210";
+const webUrl = "http://127.0.0.1:3000";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  workers: 1,
+  reporter: [["list"]],
+  use: {
+    baseURL: webUrl,
+    trace: "retain-on-failure",
+  },
+  webServer: [
+    {
+      command:
+        "CONVEX_AGENT_MODE=anonymous BETA_ALLOWLIST_EMAILS=e2e-routines@tempo.test BETA_MAX_TESTERS=100 bun x convex dev",
+      url: convexUrl,
+      timeout: 120_000,
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: `NEXT_PUBLIC_CONVEX_URL=${convexUrl} bun --cwd apps/web run dev --hostname 127.0.0.1 --port 3000`,
+      url: webUrl,
+      timeout: 120_000,
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,7 @@ const webUrl = "http://127.0.0.1:3000";
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: false,
+  timeout: 60_000,
   workers: 1,
   reporter: [["list"]],
   use: {
@@ -14,8 +15,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      command:
-        "CONVEX_AGENT_MODE=anonymous BETA_ALLOWLIST_EMAILS=e2e-routines@tempo.test BETA_MAX_TESTERS=100 bun x convex dev",
+      command: "CONVEX_AGENT_MODE=anonymous bun x convex dev",
       url: convexUrl,
       timeout: 120_000,
       reuseExistingServer: !process.env.CI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
     },
     {
-      command: `NEXT_PUBLIC_CONVEX_URL=${convexUrl} bun --cwd apps/web run dev -- --hostname 127.0.0.1 --port 3000`,
+      command: `NEXT_PUBLIC_CONVEX_URL=${convexUrl} bun run --cwd apps/web dev --hostname 127.0.0.1 --port 3000`,
       url: webUrl,
       timeout: 120_000,
       reuseExistingServer: !process.env.CI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
     },
     {
-      command: `NEXT_PUBLIC_CONVEX_URL=${convexUrl} bun --cwd apps/web run dev --hostname 127.0.0.1 --port 3000`,
+      command: `NEXT_PUBLIC_CONVEX_URL=${convexUrl} bun --cwd apps/web run dev -- --hostname 127.0.0.1 --port 3000`,
       url: webUrl,
       timeout: 120_000,
       reuseExistingServer: !process.env.CI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,13 +18,13 @@ export default defineConfig({
       command: "bash scripts/start-convex-e2e.sh",
       url: convexUrl,
       timeout: 120_000,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
     },
     {
       command: `NEXT_PUBLIC_CONVEX_URL=${convexUrl} bun run --cwd apps/web dev --hostname 127.0.0.1 --port 3000`,
       url: webUrl,
       timeout: 120_000,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
     },
   ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: "CONVEX_AGENT_MODE=anonymous bun x convex dev",
+      command: "bash scripts/start-convex-e2e.sh",
       url: convexUrl,
       timeout: 120_000,
       reuseExistingServer: !process.env.CI,

--- a/scripts/start-convex-e2e.sh
+++ b/scripts/start-convex-e2e.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONVEX_AGENT_MODE=anonymous bun x convex dev --tail-logs disable &
+convex_pid=$!
+
+cleanup() {
+  kill "$convex_pid" 2>/dev/null || true
+  wait "$convex_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+ready=0
+for _ in {1..120}; do
+  if bun -e 'const response = await fetch("http://127.0.0.1:3210").catch(() => null); process.exit(response?.ok ? 0 : 1);' >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 0.25
+done
+
+if [ "$ready" -ne 1 ]; then
+  echo "Convex local backend did not become ready." >&2
+  exit 1
+fi
+
+jwt_private_key="$(
+  bun -e 'const { generateKeyPairSync } = await import("node:crypto"); const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 }); const pkcs8 = privateKey.export({ type: "pkcs8", format: "pem" }); console.log(String(pkcs8).trimEnd().replace(/\n/g, " "));'
+)"
+
+printf "%s" "$jwt_private_key" | bun x convex env set JWT_PRIVATE_KEY >/dev/null
+printf "http://127.0.0.1:3000" | bun x convex env set SITE_URL >/dev/null
+
+wait "$convex_pid"

--- a/scripts/start-convex-e2e.sh
+++ b/scripts/start-convex-e2e.sh
@@ -31,8 +31,16 @@ keys_json="$(
 jwt_private_key="$(printf "%s" "$keys_json" | bun -e 'const input = await new Response(Bun.stdin.stream()).json(); console.log(input.jwtPrivateKey);')"
 jwks="$(printf "%s" "$keys_json" | bun -e 'const input = await new Response(Bun.stdin.stream()).json(); console.log(input.jwks);')"
 
-printf "%s" "$jwt_private_key" | bun x convex env set JWT_PRIVATE_KEY >/dev/null
-printf "%s" "$jwks" | bun x convex env set JWKS >/dev/null
-printf "http://127.0.0.1:3000" | bun x convex env set SITE_URL >/dev/null
+set_convex_env() {
+  local name="$1"
+  local value="$2"
+  printf "%s" "$value" | CONVEX_AGENT_MODE=anonymous bun x convex env set "$name" >/dev/null
+}
+
+set_convex_env JWT_PRIVATE_KEY "$jwt_private_key"
+set_convex_env JWKS "$jwks"
+set_convex_env SITE_URL "http://127.0.0.1:3000"
+set_convex_env BETA_ALLOWLIST_EMAILS "e2e-routines@tempo.test"
+set_convex_env BETA_MAX_TESTERS "100"
 
 wait "$convex_pid"

--- a/scripts/start-convex-e2e.sh
+++ b/scripts/start-convex-e2e.sh
@@ -24,11 +24,15 @@ if [ "$ready" -ne 1 ]; then
   exit 1
 fi
 
-jwt_private_key="$(
-  bun -e 'const { generateKeyPairSync } = await import("node:crypto"); const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 }); const pkcs8 = privateKey.export({ type: "pkcs8", format: "pem" }); console.log(String(pkcs8).trimEnd().replace(/\n/g, " "));'
+keys_json="$(
+  bun -e 'const { generateKeyPairSync } = await import("node:crypto"); const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 }); const pkcs8 = String(privateKey.export({ type: "pkcs8", format: "pem" })).trimEnd().replace(/\n/g, " "); const jwk = publicKey.export({ format: "jwk" }); console.log(JSON.stringify({ jwtPrivateKey: pkcs8, jwks: JSON.stringify({ keys: [{ use: "sig", ...jwk }] }) }));'
 )"
 
+jwt_private_key="$(printf "%s" "$keys_json" | bun -e 'const input = await new Response(Bun.stdin.stream()).json(); console.log(input.jwtPrivateKey);')"
+jwks="$(printf "%s" "$keys_json" | bun -e 'const input = await new Response(Bun.stdin.stream()).json(); console.log(input.jwks);')"
+
 printf "%s" "$jwt_private_key" | bun x convex env set JWT_PRIVATE_KEY >/dev/null
+printf "%s" "$jwks" | bun x convex env set JWKS >/dev/null
 printf "http://127.0.0.1:3000" | bun x convex env set SITE_URL >/dev/null
 
 wait "$convex_pid"

--- a/tests/e2e/routines.spec.ts
+++ b/tests/e2e/routines.spec.ts
@@ -3,12 +3,18 @@ import { expect, type Page, test } from "@playwright/test";
 const testEmail = "amitlevin65@protonmail.com";
 const testPassword = "TempoRoutinesE2E!2026";
 
+async function waitForRoutinesPath(page: Page) {
+  await page.waitForFunction(() => window.location.pathname === "/routines", undefined, {
+    timeout: 20_000,
+  });
+}
+
 async function signIn(page: Page) {
   await page.goto("/sign-in?next=/routines");
   await page.locator("#signin-email").fill(testEmail);
   await page.locator("#signin-password").fill(testPassword);
   await page.getByRole("button", { name: "Sign in" }).click();
-  await expect(page).toHaveURL(/\/routines$/, { timeout: 20_000 });
+  await waitForRoutinesPath(page);
 }
 
 async function ensureSignedIn(page: Page) {
@@ -19,7 +25,7 @@ async function ensureSignedIn(page: Page) {
   await page.getByRole("button", { name: "Create account" }).click();
 
   try {
-    await expect(page).toHaveURL(/\/routines$/, { timeout: 20_000 });
+    await waitForRoutinesPath(page);
   } catch {
     await signIn(page);
   }

--- a/tests/e2e/routines.spec.ts
+++ b/tests/e2e/routines.spec.ts
@@ -1,0 +1,63 @@
+import { expect, type Page, test } from "@playwright/test";
+
+const testEmail = "e2e-routines@tempo.test";
+const testPassword = "TempoRoutinesE2E!2026";
+
+async function signIn(page: Page) {
+  await page.goto("/sign-in?next=/routines");
+  await page.locator("#signin-email").fill(testEmail);
+  await page.locator("#signin-password").fill(testPassword);
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.waitForURL("**/routines", { timeout: 20_000 });
+}
+
+async function ensureSignedIn(page: Page) {
+  await page.goto("/sign-up?next=/routines");
+  await page.locator("#signup-email").fill(testEmail);
+  await page.locator("#signup-password").fill(testPassword);
+  await page.getByRole("button", { name: "Accept terms and privacy policy" }).click();
+  await page.getByRole("button", { name: "Create account" }).click();
+
+  try {
+    await page.waitForURL("**/routines", { timeout: 20_000 });
+  } catch {
+    await expect(page.getByText("That email already has an account")).toBeVisible({
+      timeout: 5_000,
+    });
+    await signIn(page);
+  }
+}
+
+test("creates a routine containing a habit and a task, then completes both from the routine view", async ({
+  page,
+}) => {
+  await ensureSignedIn(page);
+
+  const suffix = Date.now();
+  const routineName = `Morning reset ${suffix}`;
+  const habitName = `Drink water ${suffix}`;
+  const taskTitle = `Pack bag ${suffix}`;
+
+  await page.getByLabel("Routine name").fill(routineName);
+  await page.getByLabel("Habit").fill(habitName);
+  await page.getByLabel("Task").fill(taskTitle);
+  await page.getByRole("button", { name: "Create routine" }).click();
+
+  await page.waitForURL(/\/routines\/[^/]+$/, { timeout: 20_000 });
+  await expect(page.getByRole("heading", { name: routineName })).toBeVisible();
+
+  await expect(page.getByRole("heading", { name: habitName })).toBeVisible();
+  await expect(page.getByRole("heading", { name: taskTitle })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Open habit detail" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Open tasks" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Complete habit" }).click();
+  await expect(page.getByRole("button", { name: "Habit complete today" })).toBeVisible({
+    timeout: 20_000,
+  });
+
+  await page.getByRole("button", { name: "Complete task" }).click();
+  await expect(page.getByRole("button", { name: "Task complete" })).toBeVisible({
+    timeout: 20_000,
+  });
+});

--- a/tests/e2e/routines.spec.ts
+++ b/tests/e2e/routines.spec.ts
@@ -11,6 +11,12 @@ async function waitForRoutinesPath(page: Page) {
 
 async function signIn(page: Page) {
   await page.goto("/sign-in?next=/routines");
+  try {
+    await waitForRoutinesPath(page);
+    return;
+  } catch {
+    // Not already authenticated; continue with the password form below.
+  }
   await page.locator("#signin-email").fill(testEmail);
   await page.locator("#signin-password").fill(testPassword);
   await page.getByRole("button", { name: "Sign in" }).click();

--- a/tests/e2e/routines.spec.ts
+++ b/tests/e2e/routines.spec.ts
@@ -8,7 +8,7 @@ async function signIn(page: Page) {
   await page.locator("#signin-email").fill(testEmail);
   await page.locator("#signin-password").fill(testPassword);
   await page.getByRole("button", { name: "Sign in" }).click();
-  await page.waitForURL("**/routines", { timeout: 20_000 });
+  await expect(page).toHaveURL(/\/routines$/, { timeout: 20_000 });
 }
 
 async function ensureSignedIn(page: Page) {
@@ -19,11 +19,8 @@ async function ensureSignedIn(page: Page) {
   await page.getByRole("button", { name: "Create account" }).click();
 
   try {
-    await page.waitForURL("**/routines", { timeout: 20_000 });
+    await expect(page).toHaveURL(/\/routines$/, { timeout: 20_000 });
   } catch {
-    await expect(page.getByText("That email already has an account")).toBeVisible({
-      timeout: 5_000,
-    });
     await signIn(page);
   }
 }

--- a/tests/e2e/routines.spec.ts
+++ b/tests/e2e/routines.spec.ts
@@ -1,6 +1,6 @@
 import { expect, type Page, test } from "@playwright/test";
 
-const testEmail = "amitlevin65@protonmail.com";
+const testEmail = "e2e-routines@tempo.test";
 const testPassword = "TempoRoutinesE2E!2026";
 
 async function waitForRoutinesPath(page: Page) {

--- a/tests/e2e/routines.spec.ts
+++ b/tests/e2e/routines.spec.ts
@@ -1,6 +1,6 @@
 import { expect, type Page, test } from "@playwright/test";
 
-const testEmail = "e2e-routines@tempo.test";
+const testEmail = "amitlevin65@protonmail.com";
 const testPassword = "TempoRoutinesE2E!2026";
 
 async function signIn(page: Page) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the independently verifiable routines slice for TEMPO-152 / T-007b by adding routines that bundle one habit and one task. The web routine library can create that starter bundle, and the routine detail view exposes both linked items with completion actions.

## Linked task(s)

Task: T-007b
Linear: TEMPO-152

## Screenshots / screen recording

[routines_create_complete_flow.mp4](https://cursor.com/agents/bc-c1cf13db-ec96-4232-9bac-adad4c399ac0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froutines_create_complete_flow.mp4)

## Test plan

- [x] Local `bun run typecheck` passes
- [x] Local `bun run lint` passes (pre-existing warning remains in `packages/ui/src/icons/index.tsx`)
- [x] `bash -n scripts/start-convex-e2e.sh` passes
- [x] Convex schema/functions validated with `CONVEX_AGENT_MODE=anonymous ... bun x convex dev --once`
- [x] Relevant e2e test added: `tests/e2e/routines.spec.ts`
- [x] Required done_when: `bunx playwright test tests/e2e/routines.spec.ts`
- [x] Manual QA / walkthrough artifact recorded and reviewed
- [x] Reproduces the acceptance criteria below

### Required done_when evidence

```bash
bunx playwright test tests/e2e/routines.spec.ts
```

```text
Running 1 test using 1 worker
  ✓  1 tests/e2e/routines.spec.ts:40:5 › creates a routine containing a habit and a task, then completes both from the routine view (1.3s)

  1 passed (5.1s)
```

Terminal state: PASS

## Acceptance criteria

A routine can be created containing at least one habit and one task; both items are reachable/completable from the routine view.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). N/A — no AI-originated user mutation added.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5).
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7).
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8).
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13). N/A — no new runtime env vars; e2e generates local-only Convex Auth keys at runtime.
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9).

## Owner tag (§14)

- [ ] `cursor-ide`
- [x] `cursor-cloud-1`
- [ ] `cursor-cloud-2`
- [ ] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

## Reviewer

Amit (`human-amit`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TEMPO-152](https://linear.app/amit-levin/issue/TEMPO-152/t-007b-routines-containing-habits-tasks)

<div><a href="https://cursor.com/agents/bc-c1cf13db-ec96-4232-9bac-adad4c399ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1cf13db-ec96-4232-9bac-adad4c399ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

