### PR TITLE
feat(mobile): add breathwork timer

### DIFF
--- a/apps/mobile/app/(tempo)/breathwork.tsx
+++ b/apps/mobile/app/(tempo)/breathwork.tsx
@@ -1,0 +1,63 @@
+import { useLocalSearchParams } from 'expo-router';
+import { ScrollView, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { BreathworkTimer } from '@/components/BreathworkTimer';
+import {
+  type BreathPatternId,
+  breathPatterns,
+} from '@/lib/breathwork/patterns';
+
+function isBreathPatternId(
+  value: string | undefined
+): value is BreathPatternId {
+  return value !== undefined && value in breathPatterns;
+}
+
+function parseLoops(value: string | undefined, fallback: number): number {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export default function BreathworkScreen() {
+  const params = useLocalSearchParams<{
+    autoplay?: string;
+    loops?: string;
+    pattern?: string;
+  }>();
+  const patternId = isBreathPatternId(params.pattern)
+    ? params.pattern
+    : '4-7-8';
+  const pattern = breathPatterns[patternId];
+  const loops = parseLoops(params.loops, pattern.defaultLoops);
+  const autoStart = params.autoplay === '1';
+
+  return (
+    <SafeAreaView className="flex-1 bg-background">
+      <ScrollView contentContainerClassName="gap-5 p-6">
+        <View className="gap-2">
+          <Text className="text-3xl font-semibold text-foreground">
+            Breathwork
+          </Text>
+          <Text className="text-base text-muted-foreground">
+            A calm, phase-driven timer. Patterns live in config, so adding a new
+            routine does not change timer logic.
+          </Text>
+        </View>
+
+        <BreathworkTimer
+          autoStart={autoStart}
+          loops={loops}
+          patternId={patternId}
+        />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/apps/mobile/components/BreathworkTimer.tsx
+++ b/apps/mobile/components/BreathworkTimer.tsx
@@ -1,0 +1,286 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Platform, Pressable, Text, Vibration, View } from 'react-native';
+import {
+  type BreathPatternId,
+  breathPatterns,
+} from '@/lib/breathwork/patterns';
+import {
+  getBreathworkSnapshot,
+  getPhaseBoundariesBetween,
+} from '@/lib/breathwork/timer';
+
+type TimerStatus = 'idle' | 'running' | 'complete';
+
+type BreathworkCueEvent = {
+  cue: 'audio' | 'haptic';
+  patternId: BreathPatternId;
+  phaseId: string;
+  phaseLabel: string;
+  elapsedMs: number;
+};
+
+type CueWindow = Window &
+  typeof globalThis & {
+    webkitAudioContext?: typeof AudioContext;
+    __tempoBreathworkEvents?: BreathworkCueEvent[];
+  };
+
+type BreathworkTimerProps = {
+  patternId?: BreathPatternId;
+  loops?: number;
+  autoStart?: boolean;
+};
+
+const tickIntervalMs = 100;
+
+function getNowMs(): number {
+  if (typeof performance !== 'undefined') {
+    return performance.now();
+  }
+
+  return Date.now();
+}
+
+function pushCueEvent(event: BreathworkCueEvent): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const cueWindow = window as CueWindow;
+  cueWindow.__tempoBreathworkEvents = [
+    ...(cueWindow.__tempoBreathworkEvents ?? []),
+    event,
+  ];
+  cueWindow.dispatchEvent(
+    new CustomEvent('tempo-breathwork-cue', { detail: event })
+  );
+}
+
+function playAudioCue(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const cueWindow = window as CueWindow;
+  const AudioContextCtor =
+    cueWindow.AudioContext ?? cueWindow.webkitAudioContext;
+  if (!AudioContextCtor) {
+    return;
+  }
+
+  const audioContext = new AudioContextCtor();
+  const oscillator = audioContext.createOscillator();
+  const gain = audioContext.createGain();
+  oscillator.frequency.value = 528;
+  gain.gain.value = 0.04;
+  oscillator.connect(gain);
+  gain.connect(audioContext.destination);
+  oscillator.start();
+  oscillator.stop(audioContext.currentTime + 0.08);
+  oscillator.addEventListener('ended', () => {
+    void audioContext.close();
+  });
+}
+
+function fireCue(event: Omit<BreathworkCueEvent, 'cue'>): void {
+  pushCueEvent({ ...event, cue: 'audio' });
+  playAudioCue();
+
+  pushCueEvent({ ...event, cue: 'haptic' });
+  if (Platform.OS === 'web' && typeof navigator !== 'undefined') {
+    navigator.vibrate?.(12);
+    return;
+  }
+
+  Vibration.vibrate(12);
+}
+
+function formatSeconds(ms: number): string {
+  return String(Math.max(0, Math.ceil(ms / 1_000)));
+}
+
+export function BreathworkTimer({
+  patternId = '4-7-8',
+  loops,
+  autoStart = false,
+}: BreathworkTimerProps) {
+  const pattern = breathPatterns[patternId];
+  const totalLoops = loops ?? pattern.defaultLoops;
+  const [status, setStatus] = useState<TimerStatus>(
+    autoStart ? 'running' : 'idle'
+  );
+  const [startedAtMs, setStartedAtMs] = useState(() => getNowMs());
+  const [nowMs, setNowMs] = useState(startedAtMs);
+  const lastCueElapsedMsRef = useRef(0);
+
+  const snapshot = useMemo(
+    () =>
+      getBreathworkSnapshot({
+        pattern,
+        loops: totalLoops,
+        startedAtMs,
+        nowMs,
+      }),
+    [nowMs, pattern, startedAtMs, totalLoops]
+  );
+
+  const progressPercent = Math.min(
+    100,
+    (snapshot.elapsedMs / snapshot.totalDurationMs) * 100
+  );
+
+  const start = useCallback(() => {
+    const nextStartedAtMs = getNowMs();
+    lastCueElapsedMsRef.current = 0;
+    setStartedAtMs(nextStartedAtMs);
+    setNowMs(nextStartedAtMs);
+    setStatus('running');
+  }, []);
+
+  const reset = useCallback(() => {
+    const nextStartedAtMs = getNowMs();
+    lastCueElapsedMsRef.current = 0;
+    setStartedAtMs(nextStartedAtMs);
+    setNowMs(nextStartedAtMs);
+    setStatus('idle');
+  }, []);
+
+  useEffect(() => {
+    if (status !== 'running') {
+      return;
+    }
+
+    function tick(): void {
+      const nextNowMs = getNowMs();
+      const nextSnapshot = getBreathworkSnapshot({
+        pattern,
+        loops: totalLoops,
+        startedAtMs,
+        nowMs: nextNowMs,
+      });
+      const phaseBoundaries = getPhaseBoundariesBetween({
+        pattern,
+        loops: totalLoops,
+        previousElapsedMs: lastCueElapsedMsRef.current,
+        nextElapsedMs: nextSnapshot.elapsedMs,
+      });
+
+      for (const boundary of phaseBoundaries) {
+        fireCue({
+          patternId,
+          phaseId: boundary.phase.id,
+          phaseLabel: boundary.phase.label,
+          elapsedMs: boundary.elapsedMs,
+        });
+      }
+
+      lastCueElapsedMsRef.current = nextSnapshot.elapsedMs;
+      setNowMs(nextNowMs);
+      if (nextSnapshot.isComplete) {
+        setStatus('complete');
+      }
+    }
+
+    const intervalId = setInterval(tick, tickIntervalMs);
+    const canListenForVisibility = typeof document !== 'undefined';
+    if (canListenForVisibility) {
+      document.addEventListener('visibilitychange', tick);
+    }
+    tick();
+
+    return () => {
+      clearInterval(intervalId);
+      if (canListenForVisibility) {
+        document.removeEventListener('visibilitychange', tick);
+      }
+    };
+  }, [pattern, patternId, startedAtMs, status, totalLoops]);
+
+  return (
+    <View className="gap-5 rounded-3xl border border-border bg-card p-5">
+      <View className="gap-2">
+        <Text className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Breathwork timer
+        </Text>
+        <Text className="text-3xl font-semibold text-foreground">
+          {pattern.name}
+        </Text>
+        <Text className="text-base text-muted-foreground">
+          {pattern.description}
+        </Text>
+      </View>
+
+      <View className="items-center gap-2 rounded-3xl bg-background p-6">
+        <Text
+          accessibilityLiveRegion="polite"
+          className="text-5xl font-semibold text-foreground"
+          testID="breathwork-phase"
+        >
+          {snapshot.phase.label}
+        </Text>
+        <Text className="text-lg text-muted-foreground" testID="phase-seconds">
+          {formatSeconds(snapshot.phaseRemainingMs)}
+        </Text>
+        <Text className="text-sm text-muted-foreground">
+          Loop {snapshot.loopIndex + 1} of {totalLoops}
+        </Text>
+      </View>
+
+      <View className="h-3 overflow-hidden rounded-full bg-muted">
+        <View
+          className="h-full rounded-full bg-primary"
+          style={{ width: `${progressPercent}%` }}
+          testID="breathwork-progress"
+        />
+      </View>
+
+      <View className="gap-2">
+        <Text className="text-base font-semibold text-foreground">
+          {snapshot.phase.instruction}
+        </Text>
+        <Text className="text-sm text-muted-foreground" testID="elapsed-ms">
+          Elapsed {Math.round(snapshot.elapsedMs)} ms
+        </Text>
+      </View>
+
+      <View className="flex-row gap-3">
+        <Pressable
+          accessibilityHint="Starts the selected breathing pattern."
+          accessibilityLabel="Start breathwork timer"
+          accessibilityRole="button"
+          accessible={true}
+          className="min-h-12 flex-1 items-center justify-center rounded-2xl bg-primary px-4 py-3"
+          disabled={status === 'running'}
+          onPress={start}
+          testID="start-breathwork"
+        >
+          <Text className="font-semibold text-primary-foreground">
+            {status === 'running' ? 'Running' : 'Start'}
+          </Text>
+        </Pressable>
+
+        <Pressable
+          accessibilityHint="Resets the breathwork timer to the beginning."
+          accessibilityLabel="Reset breathwork timer"
+          accessibilityRole="button"
+          accessible={true}
+          className="min-h-12 flex-1 items-center justify-center rounded-2xl border border-border px-4 py-3"
+          onPress={reset}
+          testID="reset-breathwork"
+        >
+          <Text className="font-semibold text-foreground">Reset</Text>
+        </Pressable>
+      </View>
+
+      {status === 'complete' ? (
+        <Text
+          accessibilityLiveRegion="polite"
+          className="text-center text-sm text-muted-foreground"
+          testID="breathwork-complete"
+        >
+          Cycle complete. Take a moment before you move on.
+        </Text>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/e2e/breathwork-timer.spec.ts
+++ b/apps/mobile/e2e/breathwork-timer.spec.ts
@@ -78,7 +78,7 @@ async function setVisibility(
 function registerBreathworkTimerSpec(): void {
   test.setTimeout(120_000);
 
-  test.beforeAll(async (_args, testInfo) => {
+  test.beforeAll(async ({ browserName: _browserName }, testInfo) => {
     testInfo.setTimeout(120_000);
     server = spawn(
       'bun',

--- a/apps/mobile/e2e/breathwork-timer.spec.ts
+++ b/apps/mobile/e2e/breathwork-timer.spec.ts
@@ -20,11 +20,23 @@ const baseUrl = `http://127.0.0.1:${port}`;
 const serverLines: string[] = [];
 
 let server: ChildProcessWithoutNullStreams | undefined;
+let serverExit:
+  | {
+      code: number | null;
+      signal: NodeJS.Signals | null;
+    }
+  | undefined;
 
 async function waitForServer(): Promise<void> {
   const deadline = Date.now() + 90_000;
   while (Date.now() < deadline) {
     try {
+      if (serverExit) {
+        throw new Error(
+          `Expo web server exited (${serverExit.code ?? serverExit.signal}).\n${serverLines.join('\n')}`
+        );
+      }
+
       const response = await fetch(baseUrl);
       if (response.ok || response.status < 500) {
         return;
@@ -64,6 +76,8 @@ async function setVisibility(
 }
 
 function registerBreathworkTimerSpec(): void {
+  test.setTimeout(120_000);
+
   test.beforeAll(async () => {
     server = spawn(
       'bun',
@@ -93,6 +107,9 @@ function registerBreathworkTimerSpec(): void {
     });
     server.stderr.on('data', (chunk: Buffer) => {
       serverLines.push(chunk.toString());
+    });
+    server.on('exit', (code, signal) => {
+      serverExit = { code, signal };
     });
 
     await waitForServer();

--- a/apps/mobile/e2e/breathwork-timer.spec.ts
+++ b/apps/mobile/e2e/breathwork-timer.spec.ts
@@ -1,5 +1,5 @@
 import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
-import { createRequire } from 'node:module';
+import { expect, type Page, test } from '@playwright/test';
 
 type BrowserCueEvent = {
   cue: 'audio' | 'haptic';
@@ -20,52 +20,6 @@ const baseUrl = `http://127.0.0.1:${port}`;
 const serverLines: string[] = [];
 
 let server: ChildProcessWithoutNullStreams | undefined;
-
-type LocatorLike = {
-  textContent: () => Promise<string | null>;
-};
-
-type PageLike = {
-  addInitScript: (callback: () => void) => Promise<void>;
-  evaluate: {
-    <Result>(callback: () => Result | Promise<Result>): Promise<Result>;
-    <Arg, Result>(
-      callback: (arg: Arg) => Result | Promise<Result>,
-      arg: Arg
-    ): Promise<Result>;
-  };
-  getByTestId: (testId: string) => LocatorLike;
-  goto: (url: string) => Promise<unknown>;
-  waitForTimeout: (timeoutMs: number) => Promise<void>;
-};
-
-type LocatorAssertion = {
-  toBeVisible: (options?: { timeout?: number }) => Promise<void>;
-  toHaveText: (text: string) => Promise<void>;
-};
-
-type ValueAssertion = {
-  toBeGreaterThanOrEqual: (expected: number) => void;
-  toBeLessThanOrEqual: (expected: number) => void;
-  toEqual: (expected: unknown) => void;
-  toHaveLength: (expected: number) => void;
-};
-
-type PlaywrightExpect = {
-  (actual: LocatorLike): LocatorAssertion;
-  (actual: unknown): ValueAssertion;
-};
-
-type PlaywrightTest = {
-  (title: string, callback: (args: { page: PageLike }) => Promise<void>): void;
-  afterAll: (callback: () => void) => void;
-  beforeAll: (callback: () => Promise<void>) => void;
-};
-
-type PlaywrightModule = {
-  expect: PlaywrightExpect;
-  test: PlaywrightTest;
-};
 
 async function waitForServer(): Promise<void> {
   const deadline = Date.now() + 90_000;
@@ -93,7 +47,7 @@ function readElapsedMs(text: string | null): number {
 }
 
 async function setVisibility(
-  page: PageLike,
+  page: Page,
   visibilityState: 'hidden' | 'visible'
 ): Promise<void> {
   await page.evaluate((nextVisibilityState) => {
@@ -109,7 +63,7 @@ async function setVisibility(
   }, visibilityState);
 }
 
-function registerBreathworkTimerSpec({ expect, test }: PlaywrightModule): void {
+function registerBreathworkTimerSpec(): void {
   test.beforeAll(async () => {
     server = spawn(
       'bun',
@@ -208,9 +162,5 @@ const launchedByPlaywright = process.argv.some((arg) =>
 );
 
 if (launchedByPlaywright) {
-  const requireFromSpec = createRequire(import.meta.url);
-  const playwrightModule = requireFromSpec(
-    '@playwright/test'
-  ) as PlaywrightModule;
-  registerBreathworkTimerSpec(playwrightModule);
+  registerBreathworkTimerSpec();
 }

--- a/apps/mobile/e2e/breathwork-timer.spec.ts
+++ b/apps/mobile/e2e/breathwork-timer.spec.ts
@@ -1,4 +1,5 @@
 import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
 
 type BrowserCueEvent = {
   cue: 'audio' | 'haptic';
@@ -207,12 +208,9 @@ const launchedByPlaywright = process.argv.some((arg) =>
 );
 
 if (launchedByPlaywright) {
-  const importPlaywright = new Function(
-    'specifier',
-    'return import(specifier)'
-  ) as (specifier: string) => Promise<unknown>;
-  const playwrightModule = (await importPlaywright(
+  const requireFromSpec = createRequire(import.meta.url);
+  const playwrightModule = requireFromSpec(
     '@playwright/test'
-  )) as PlaywrightModule;
+  ) as PlaywrightModule;
   registerBreathworkTimerSpec(playwrightModule);
 }

--- a/apps/mobile/e2e/breathwork-timer.spec.ts
+++ b/apps/mobile/e2e/breathwork-timer.spec.ts
@@ -78,7 +78,8 @@ async function setVisibility(
 function registerBreathworkTimerSpec(): void {
   test.setTimeout(120_000);
 
-  test.beforeAll(async () => {
+  test.beforeAll(async (_args, testInfo) => {
+    testInfo.setTimeout(120_000);
     server = spawn(
       'bun',
       [

--- a/apps/mobile/e2e/breathwork-timer.spec.ts
+++ b/apps/mobile/e2e/breathwork-timer.spec.ts
@@ -68,8 +68,6 @@ function registerBreathworkTimerSpec(): void {
     server = spawn(
       'bun',
       [
-        '--cwd',
-        'apps/mobile',
         'x',
         'expo',
         'start',
@@ -79,7 +77,7 @@ function registerBreathworkTimerSpec(): void {
         '--non-interactive',
       ],
       {
-        cwd: process.cwd(),
+        cwd: `${process.cwd()}/apps/mobile`,
         env: {
           ...process.env,
           CI: '1',

--- a/apps/mobile/e2e/breathwork-timer.spec.ts
+++ b/apps/mobile/e2e/breathwork-timer.spec.ts
@@ -1,5 +1,4 @@
 import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
-import { expect, type Page, test } from '@playwright/test';
 
 type BrowserCueEvent = {
   cue: 'audio' | 'haptic';
@@ -20,6 +19,52 @@ const baseUrl = `http://127.0.0.1:${port}`;
 const serverLines: string[] = [];
 
 let server: ChildProcessWithoutNullStreams | undefined;
+
+type LocatorLike = {
+  textContent: () => Promise<string | null>;
+};
+
+type PageLike = {
+  addInitScript: (callback: () => void) => Promise<void>;
+  evaluate: {
+    <Result>(callback: () => Result | Promise<Result>): Promise<Result>;
+    <Arg, Result>(
+      callback: (arg: Arg) => Result | Promise<Result>,
+      arg: Arg
+    ): Promise<Result>;
+  };
+  getByTestId: (testId: string) => LocatorLike;
+  goto: (url: string) => Promise<unknown>;
+  waitForTimeout: (timeoutMs: number) => Promise<void>;
+};
+
+type LocatorAssertion = {
+  toBeVisible: (options?: { timeout?: number }) => Promise<void>;
+  toHaveText: (text: string) => Promise<void>;
+};
+
+type ValueAssertion = {
+  toBeGreaterThanOrEqual: (expected: number) => void;
+  toBeLessThanOrEqual: (expected: number) => void;
+  toEqual: (expected: unknown) => void;
+  toHaveLength: (expected: number) => void;
+};
+
+type PlaywrightExpect = {
+  (actual: LocatorLike): LocatorAssertion;
+  (actual: unknown): ValueAssertion;
+};
+
+type PlaywrightTest = {
+  (title: string, callback: (args: { page: PageLike }) => Promise<void>): void;
+  afterAll: (callback: () => void) => void;
+  beforeAll: (callback: () => Promise<void>) => void;
+};
+
+type PlaywrightModule = {
+  expect: PlaywrightExpect;
+  test: PlaywrightTest;
+};
 
 async function waitForServer(): Promise<void> {
   const deadline = Date.now() + 90_000;
@@ -47,9 +92,9 @@ function readElapsedMs(text: string | null): number {
 }
 
 async function setVisibility(
-  page: Page,
+  page: PageLike,
   visibilityState: 'hidden' | 'visible'
-) {
+): Promise<void> {
   await page.evaluate((nextVisibilityState) => {
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
@@ -63,91 +108,111 @@ async function setVisibility(
   }, visibilityState);
 }
 
-test.beforeAll(async () => {
-  server = spawn(
-    'bun',
-    [
-      '--cwd',
-      'apps/mobile',
-      'x',
-      'expo',
-      'start',
-      '--web',
-      '--port',
-      String(port),
-      '--non-interactive',
-    ],
-    {
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        CI: '1',
-        EXPO_NO_TELEMETRY: '1',
-        EXPO_PUBLIC_CONVEX_URL: 'http://127.0.0.1:3210',
-      },
-      stdio: 'pipe',
-    }
-  );
+function registerBreathworkTimerSpec({ expect, test }: PlaywrightModule): void {
+  test.beforeAll(async () => {
+    server = spawn(
+      'bun',
+      [
+        '--cwd',
+        'apps/mobile',
+        'x',
+        'expo',
+        'start',
+        '--web',
+        '--port',
+        String(port),
+        '--non-interactive',
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          CI: '1',
+          EXPO_NO_TELEMETRY: '1',
+          EXPO_PUBLIC_CONVEX_URL: 'http://127.0.0.1:3210',
+        },
+        stdio: 'pipe',
+      }
+    );
 
-  server.stdout.on('data', (chunk: Buffer) => {
-    serverLines.push(chunk.toString());
-  });
-  server.stderr.on('data', (chunk: Buffer) => {
-    serverLines.push(chunk.toString());
-  });
+    server.stdout.on('data', (chunk: Buffer) => {
+      serverLines.push(chunk.toString());
+    });
+    server.stderr.on('data', (chunk: Buffer) => {
+      serverLines.push(chunk.toString());
+    });
 
-  await waitForServer();
-});
-
-test.afterAll(() => {
-  server?.kill('SIGTERM');
-});
-
-test('4-7-8 timer keeps wall-clock time and cues every phase change', async ({
-  page,
-}) => {
-  await page.addInitScript(() => {
-    window.__tempoBreathworkEvents = [];
+    await waitForServer();
   });
 
-  await page.goto(`${baseUrl}/breathwork?autoplay=1&loops=1`);
-  await expect(page.getByTestId('breathwork-phase')).toHaveText('Inhale');
-
-  await page.waitForTimeout(2_000);
-  await setVisibility(page, 'hidden');
-  await page.waitForTimeout(4_250);
-  await setVisibility(page, 'visible');
-
-  const elapsedAfterForeground = readElapsedMs(
-    await page.getByTestId('elapsed-ms').textContent()
-  );
-  expect(elapsedAfterForeground).toBeGreaterThanOrEqual(5_800);
-  expect(elapsedAfterForeground).toBeLessThanOrEqual(7_200);
-  await expect(page.getByTestId('breathwork-phase')).toHaveText('Hold');
-
-  await expect(page.getByTestId('breathwork-complete')).toBeVisible({
-    timeout: 15_000,
+  test.afterAll(() => {
+    server?.kill('SIGTERM');
   });
 
-  const finalElapsedMs = readElapsedMs(
-    await page.getByTestId('elapsed-ms').textContent()
-  );
-  const cueEvents = await page.evaluate(
-    () => window.__tempoBreathworkEvents ?? []
-  );
-  const audioEvents = cueEvents.filter((event) => event.cue === 'audio');
-  const hapticEvents = cueEvents.filter((event) => event.cue === 'haptic');
-  const phaseDurations = [
-    audioEvents[0]?.elapsedMs ?? 0,
-    (audioEvents[1]?.elapsedMs ?? 0) - (audioEvents[0]?.elapsedMs ?? 0),
-    finalElapsedMs - (audioEvents[1]?.elapsedMs ?? 0),
-  ];
+  test('4-7-8 timer keeps wall-clock time and cues every phase change', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.__tempoBreathworkEvents = [];
+    });
 
-  expect(phaseDurations).toEqual([4_000, 7_000, 8_000]);
-  expect(audioEvents.map((event) => event.phaseId)).toEqual(['hold', 'exhale']);
-  expect(hapticEvents.map((event) => event.phaseId)).toEqual([
-    'hold',
-    'exhale',
-  ]);
-  expect(audioEvents).toHaveLength(hapticEvents.length);
-});
+    await page.goto(`${baseUrl}/breathwork?autoplay=1&loops=1`);
+    await expect(page.getByTestId('breathwork-phase')).toHaveText('Inhale');
+
+    await page.waitForTimeout(2_000);
+    await setVisibility(page, 'hidden');
+    await page.waitForTimeout(4_250);
+    await setVisibility(page, 'visible');
+
+    const elapsedAfterForeground = readElapsedMs(
+      await page.getByTestId('elapsed-ms').textContent()
+    );
+    expect(elapsedAfterForeground).toBeGreaterThanOrEqual(5_800);
+    expect(elapsedAfterForeground).toBeLessThanOrEqual(7_200);
+    await expect(page.getByTestId('breathwork-phase')).toHaveText('Hold');
+
+    await expect(page.getByTestId('breathwork-complete')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const finalElapsedMs = readElapsedMs(
+      await page.getByTestId('elapsed-ms').textContent()
+    );
+    const cueEvents = await page.evaluate(
+      () => window.__tempoBreathworkEvents ?? []
+    );
+    const audioEvents = cueEvents.filter((event) => event.cue === 'audio');
+    const hapticEvents = cueEvents.filter((event) => event.cue === 'haptic');
+    const phaseDurations = [
+      audioEvents[0]?.elapsedMs ?? 0,
+      (audioEvents[1]?.elapsedMs ?? 0) - (audioEvents[0]?.elapsedMs ?? 0),
+      finalElapsedMs - (audioEvents[1]?.elapsedMs ?? 0),
+    ];
+
+    expect(phaseDurations).toEqual([4_000, 7_000, 8_000]);
+    expect(audioEvents.map((event) => event.phaseId)).toEqual([
+      'hold',
+      'exhale',
+    ]);
+    expect(hapticEvents.map((event) => event.phaseId)).toEqual([
+      'hold',
+      'exhale',
+    ]);
+    expect(audioEvents).toHaveLength(hapticEvents.length);
+  });
+}
+
+const launchedByPlaywright = process.argv.some((arg) =>
+  arg.toLowerCase().includes('playwright')
+);
+
+if (launchedByPlaywright) {
+  const importPlaywright = new Function(
+    'specifier',
+    'return import(specifier)'
+  ) as (specifier: string) => Promise<unknown>;
+  const playwrightModule = (await importPlaywright(
+    '@playwright/test'
+  )) as PlaywrightModule;
+  registerBreathworkTimerSpec(playwrightModule);
+}

--- a/apps/mobile/e2e/breathwork-timer.spec.ts
+++ b/apps/mobile/e2e/breathwork-timer.spec.ts
@@ -1,0 +1,153 @@
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import { expect, type Page, test } from '@playwright/test';
+
+type BrowserCueEvent = {
+  cue: 'audio' | 'haptic';
+  patternId: string;
+  phaseId: string;
+  phaseLabel: string;
+  elapsedMs: number;
+};
+
+declare global {
+  interface Window {
+    __tempoBreathworkEvents?: BrowserCueEvent[];
+  }
+}
+
+const port = 19086;
+const baseUrl = `http://127.0.0.1:${port}`;
+const serverLines: string[] = [];
+
+let server: ChildProcessWithoutNullStreams | undefined;
+
+async function waitForServer(): Promise<void> {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(baseUrl);
+      if (response.ok || response.status < 500) {
+        return;
+      }
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+
+  throw new Error(`Expo web server did not start.\n${serverLines.join('\n')}`);
+}
+
+function readElapsedMs(text: string | null): number {
+  const match = text?.match(/Elapsed (?<elapsed>\d+) ms/);
+  if (!match?.groups?.elapsed) {
+    throw new Error(`Could not read elapsed text: ${text ?? '<empty>'}`);
+  }
+
+  return Number.parseInt(match.groups.elapsed, 10);
+}
+
+async function setVisibility(
+  page: Page,
+  visibilityState: 'hidden' | 'visible'
+) {
+  await page.evaluate((nextVisibilityState) => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: nextVisibilityState,
+    });
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: nextVisibilityState === 'hidden',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  }, visibilityState);
+}
+
+test.beforeAll(async () => {
+  server = spawn(
+    'bun',
+    [
+      '--cwd',
+      'apps/mobile',
+      'x',
+      'expo',
+      'start',
+      '--web',
+      '--port',
+      String(port),
+      '--non-interactive',
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        CI: '1',
+        EXPO_NO_TELEMETRY: '1',
+        EXPO_PUBLIC_CONVEX_URL: 'http://127.0.0.1:3210',
+      },
+      stdio: 'pipe',
+    }
+  );
+
+  server.stdout.on('data', (chunk: Buffer) => {
+    serverLines.push(chunk.toString());
+  });
+  server.stderr.on('data', (chunk: Buffer) => {
+    serverLines.push(chunk.toString());
+  });
+
+  await waitForServer();
+});
+
+test.afterAll(() => {
+  server?.kill('SIGTERM');
+});
+
+test('4-7-8 timer keeps wall-clock time and cues every phase change', async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.__tempoBreathworkEvents = [];
+  });
+
+  await page.goto(`${baseUrl}/breathwork?autoplay=1&loops=1`);
+  await expect(page.getByTestId('breathwork-phase')).toHaveText('Inhale');
+
+  await page.waitForTimeout(2_000);
+  await setVisibility(page, 'hidden');
+  await page.waitForTimeout(4_250);
+  await setVisibility(page, 'visible');
+
+  const elapsedAfterForeground = readElapsedMs(
+    await page.getByTestId('elapsed-ms').textContent()
+  );
+  expect(elapsedAfterForeground).toBeGreaterThanOrEqual(5_800);
+  expect(elapsedAfterForeground).toBeLessThanOrEqual(7_200);
+  await expect(page.getByTestId('breathwork-phase')).toHaveText('Hold');
+
+  await expect(page.getByTestId('breathwork-complete')).toBeVisible({
+    timeout: 15_000,
+  });
+
+  const finalElapsedMs = readElapsedMs(
+    await page.getByTestId('elapsed-ms').textContent()
+  );
+  const cueEvents = await page.evaluate(
+    () => window.__tempoBreathworkEvents ?? []
+  );
+  const audioEvents = cueEvents.filter((event) => event.cue === 'audio');
+  const hapticEvents = cueEvents.filter((event) => event.cue === 'haptic');
+  const phaseDurations = [
+    audioEvents[0]?.elapsedMs ?? 0,
+    (audioEvents[1]?.elapsedMs ?? 0) - (audioEvents[0]?.elapsedMs ?? 0),
+    finalElapsedMs - (audioEvents[1]?.elapsedMs ?? 0),
+  ];
+
+  expect(phaseDurations).toEqual([4_000, 7_000, 8_000]);
+  expect(audioEvents.map((event) => event.phaseId)).toEqual(['hold', 'exhale']);
+  expect(hapticEvents.map((event) => event.phaseId)).toEqual([
+    'hold',
+    'exhale',
+  ]);
+  expect(audioEvents).toHaveLength(hapticEvents.length);
+});

--- a/apps/mobile/lib/breathwork/patterns.ts
+++ b/apps/mobile/lib/breathwork/patterns.ts
@@ -1,0 +1,138 @@
+export type BreathPhaseKind = 'inhale' | 'hold' | 'exhale' | 'rest';
+
+export type BreathPhase = {
+  id: string;
+  label: string;
+  kind: BreathPhaseKind;
+  durationMs: number;
+  instruction: string;
+};
+
+export type BreathPattern = {
+  id: string;
+  name: string;
+  description: string;
+  defaultLoops: number;
+  phases: readonly BreathPhase[];
+};
+
+export const breathPatterns = {
+  '4-7-8': {
+    id: '4-7-8',
+    name: '4-7-8',
+    description: 'Inhale for 4, hold for 7, exhale for 8.',
+    defaultLoops: 4,
+    phases: [
+      {
+        id: 'inhale',
+        label: 'Inhale',
+        kind: 'inhale',
+        durationMs: 4_000,
+        instruction: 'Breathe in gently.',
+      },
+      {
+        id: 'hold',
+        label: 'Hold',
+        kind: 'hold',
+        durationMs: 7_000,
+        instruction: 'Hold softly. No forcing.',
+      },
+      {
+        id: 'exhale',
+        label: 'Exhale',
+        kind: 'exhale',
+        durationMs: 8_000,
+        instruction: 'Let the breath out slowly.',
+      },
+    ],
+  },
+  box: {
+    id: 'box',
+    name: 'Box breathing',
+    description: 'Equal inhale, hold, exhale, and rest phases.',
+    defaultLoops: 4,
+    phases: [
+      {
+        id: 'inhale',
+        label: 'Inhale',
+        kind: 'inhale',
+        durationMs: 4_000,
+        instruction: 'Breathe in.',
+      },
+      {
+        id: 'hold-in',
+        label: 'Hold',
+        kind: 'hold',
+        durationMs: 4_000,
+        instruction: 'Hold with ease.',
+      },
+      {
+        id: 'exhale',
+        label: 'Exhale',
+        kind: 'exhale',
+        durationMs: 4_000,
+        instruction: 'Breathe out.',
+      },
+      {
+        id: 'hold-out',
+        label: 'Rest',
+        kind: 'rest',
+        durationMs: 4_000,
+        instruction: 'Rest before the next breath.',
+      },
+    ],
+  },
+  coherence: {
+    id: 'coherence',
+    name: 'Coherence',
+    description: 'A steady 5-second inhale and 5-second exhale.',
+    defaultLoops: 6,
+    phases: [
+      {
+        id: 'inhale',
+        label: 'Inhale',
+        kind: 'inhale',
+        durationMs: 5_000,
+        instruction: 'Breathe in at an easy pace.',
+      },
+      {
+        id: 'exhale',
+        label: 'Exhale',
+        kind: 'exhale',
+        durationMs: 5_000,
+        instruction: 'Breathe out at the same pace.',
+      },
+    ],
+  },
+  triangle: {
+    id: 'triangle',
+    name: 'Triangle breathing',
+    description: 'A config-only proof pattern: inhale, hold, exhale.',
+    defaultLoops: 3,
+    phases: [
+      {
+        id: 'inhale',
+        label: 'Inhale',
+        kind: 'inhale',
+        durationMs: 3_000,
+        instruction: 'Breathe in comfortably.',
+      },
+      {
+        id: 'hold',
+        label: 'Hold',
+        kind: 'hold',
+        durationMs: 3_000,
+        instruction: 'Pause without strain.',
+      },
+      {
+        id: 'exhale',
+        label: 'Exhale',
+        kind: 'exhale',
+        durationMs: 3_000,
+        instruction: 'Release the breath.',
+      },
+    ],
+  },
+} as const satisfies Record<string, BreathPattern>;
+
+export type BreathPatternId = keyof typeof breathPatterns;

--- a/apps/mobile/lib/breathwork/timer.test.ts
+++ b/apps/mobile/lib/breathwork/timer.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test';
+import type { BreathPattern } from './patterns';
+import { breathPatterns } from './patterns';
+import {
+  getBreathworkSnapshot,
+  getPhaseBoundariesBetween,
+  getPhaseDurationsSeconds,
+} from './timer';
+
+describe('breathwork timer config', () => {
+  test('4-7-8 counts exactly 4 -> 7 -> 8 seconds', () => {
+    expect(getPhaseDurationsSeconds(breathPatterns['4-7-8'])).toEqual([
+      4, 7, 8,
+    ]);
+  });
+
+  test('supports a new pattern as config only', () => {
+    const configOnlyPattern: BreathPattern = {
+      id: 'test-calm',
+      name: 'Test calm',
+      description: 'Added in a test without changing timer logic.',
+      defaultLoops: 1,
+      phases: [
+        {
+          id: 'inhale',
+          label: 'Inhale',
+          kind: 'inhale',
+          durationMs: 2_000,
+          instruction: 'Breathe in.',
+        },
+        {
+          id: 'exhale',
+          label: 'Exhale',
+          kind: 'exhale',
+          durationMs: 6_000,
+          instruction: 'Breathe out.',
+        },
+      ],
+    };
+
+    expect(getPhaseDurationsSeconds(configOnlyPattern)).toEqual([2, 6]);
+    expect(
+      getBreathworkSnapshot({
+        pattern: configOnlyPattern,
+        loops: 1,
+        startedAtMs: 1_000,
+        nowMs: 4_500,
+      }).phase.id
+    ).toBe('exhale');
+  });
+});
+
+describe('breathwork wall-clock timing', () => {
+  test('derives phase from elapsed wall time after a background gap', () => {
+    const snapshot = getBreathworkSnapshot({
+      pattern: breathPatterns['4-7-8'],
+      loops: 1,
+      startedAtMs: 10_000,
+      nowMs: 22_250,
+    });
+
+    expect(snapshot.phase.id).toBe('exhale');
+    expect(snapshot.phaseElapsedMs).toBe(1_250);
+    expect(snapshot.elapsedMs).toBe(12_250);
+  });
+
+  test('returns every phase boundary crossed between ticks', () => {
+    const boundaries = getPhaseBoundariesBetween({
+      pattern: breathPatterns['4-7-8'],
+      loops: 2,
+      previousElapsedMs: 3_900,
+      nextElapsedMs: 19_100,
+    });
+
+    expect(boundaries.map((boundary) => boundary.phase.id)).toEqual([
+      'hold',
+      'exhale',
+      'inhale',
+    ]);
+    expect(boundaries.map((boundary) => boundary.elapsedMs)).toEqual([
+      4_000, 11_000, 19_000,
+    ]);
+  });
+});

--- a/apps/mobile/lib/breathwork/timer.ts
+++ b/apps/mobile/lib/breathwork/timer.ts
@@ -1,0 +1,167 @@
+import type { BreathPattern, BreathPhase } from './patterns';
+
+export type BreathworkSnapshot = {
+  elapsedMs: number;
+  totalDurationMs: number;
+  loopIndex: number;
+  phaseIndex: number;
+  phase: BreathPhase;
+  phaseElapsedMs: number;
+  phaseRemainingMs: number;
+  isComplete: boolean;
+};
+
+export type PhaseBoundary = {
+  elapsedMs: number;
+  loopIndex: number;
+  phaseIndex: number;
+  phase: BreathPhase;
+};
+
+export function getPatternCycleDurationMs(pattern: BreathPattern): number {
+  return pattern.phases.reduce((total, phase) => total + phase.durationMs, 0);
+}
+
+export function getPatternTotalDurationMs(
+  pattern: BreathPattern,
+  loops: number
+): number {
+  return getPatternCycleDurationMs(pattern) * loops;
+}
+
+export function getPhaseDurationsSeconds(
+  pattern: BreathPattern
+): readonly number[] {
+  return pattern.phases.map((phase) => phase.durationMs / 1_000);
+}
+
+export function getBreathworkSnapshot({
+  pattern,
+  loops,
+  startedAtMs,
+  nowMs,
+}: {
+  pattern: BreathPattern;
+  loops: number;
+  startedAtMs: number;
+  nowMs: number;
+}): BreathworkSnapshot {
+  if (pattern.phases.length === 0) {
+    throw new Error('Breath pattern needs at least one phase.');
+  }
+
+  if (!Number.isFinite(loops) || loops < 1) {
+    throw new Error('Breath timer needs at least one loop.');
+  }
+
+  const cycleDurationMs = getPatternCycleDurationMs(pattern);
+  const totalDurationMs = cycleDurationMs * loops;
+  const elapsedMs = Math.max(0, Math.min(nowMs - startedAtMs, totalDurationMs));
+  const isComplete = elapsedMs >= totalDurationMs;
+  const activeElapsedMs = isComplete
+    ? Math.max(0, totalDurationMs - 1)
+    : elapsedMs;
+  const loopIndex = Math.min(
+    loops - 1,
+    Math.floor(activeElapsedMs / cycleDurationMs)
+  );
+  const elapsedInCycleMs = activeElapsedMs - loopIndex * cycleDurationMs;
+
+  let phaseStartMs = 0;
+  for (
+    let phaseIndex = 0;
+    phaseIndex < pattern.phases.length;
+    phaseIndex += 1
+  ) {
+    const phase = pattern.phases[phaseIndex];
+    if (!phase) {
+      break;
+    }
+
+    const phaseEndMs = phaseStartMs + phase.durationMs;
+    if (elapsedInCycleMs < phaseEndMs) {
+      const phaseElapsedMs = elapsedInCycleMs - phaseStartMs;
+      return {
+        elapsedMs,
+        totalDurationMs,
+        loopIndex,
+        phaseIndex,
+        phase,
+        phaseElapsedMs,
+        phaseRemainingMs: Math.max(0, phase.durationMs - phaseElapsedMs),
+        isComplete,
+      };
+    }
+
+    phaseStartMs = phaseEndMs;
+  }
+
+  const fallbackPhase = pattern.phases[pattern.phases.length - 1];
+  if (!fallbackPhase) {
+    throw new Error('Breath pattern needs at least one phase.');
+  }
+
+  return {
+    elapsedMs,
+    totalDurationMs,
+    loopIndex,
+    phaseIndex: pattern.phases.length - 1,
+    phase: fallbackPhase,
+    phaseElapsedMs: fallbackPhase.durationMs,
+    phaseRemainingMs: 0,
+    isComplete,
+  };
+}
+
+export function getPhaseBoundaries(
+  pattern: BreathPattern,
+  loops: number
+): readonly PhaseBoundary[] {
+  const cycleDurationMs = getPatternCycleDurationMs(pattern);
+  const boundaries: PhaseBoundary[] = [];
+
+  for (let loopIndex = 0; loopIndex < loops; loopIndex += 1) {
+    let phaseStartInCycleMs = 0;
+    for (
+      let phaseIndex = 0;
+      phaseIndex < pattern.phases.length;
+      phaseIndex += 1
+    ) {
+      const phase = pattern.phases[phaseIndex];
+      if (!phase) {
+        continue;
+      }
+
+      if (loopIndex > 0 || phaseIndex > 0) {
+        boundaries.push({
+          elapsedMs: loopIndex * cycleDurationMs + phaseStartInCycleMs,
+          loopIndex,
+          phaseIndex,
+          phase,
+        });
+      }
+
+      phaseStartInCycleMs += phase.durationMs;
+    }
+  }
+
+  return boundaries;
+}
+
+export function getPhaseBoundariesBetween({
+  pattern,
+  loops,
+  previousElapsedMs,
+  nextElapsedMs,
+}: {
+  pattern: BreathPattern;
+  loops: number;
+  previousElapsedMs: number;
+  nextElapsedMs: number;
+}): readonly PhaseBoundary[] {
+  return getPhaseBoundaries(pattern, loops).filter(
+    (boundary) =>
+      boundary.elapsedMs > previousElapsedMs &&
+      boundary.elapsedMs <= nextElapsedMs
+  );
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -63,6 +63,7 @@
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
+    "@babel/plugin-transform-react-jsx": "7.28.6",
     "@biomejs/biome": "2.3.8",
     "@types/react": "~19.1.17",
     "babel-preset-expo": "54.0.10",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -52,6 +52,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-css-interop": "0.2.2",
     "react-native-purchases": "^9.6.10",
     "react-native-reanimated": "~4.1.6",
     "react-native-safe-area-context": "~5.6.0",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
     "@types/react": "~19.1.17",
+    "babel-preset-expo": "54.0.10",
     "chalk": "^5.3.0",
     "react-test-renderer": "19.1.0",
     "tailwindcss": "^3.4.19",

--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
         "@types/react": "~19.1.17",
+        "babel-preset-expo": "54.0.10",
         "chalk": "^5.3.0",
         "react-test-renderer": "19.1.0",
         "tailwindcss": "^3.4.19",
@@ -1268,7 +1269,7 @@
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
-    "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lucia": ["lucia@3.2.2", "", { "dependencies": { "@oslojs/crypto": "^1.0.1", "@oslojs/encoding": "^1.1.0" } }, "sha512-P1FlFBGCMPMXu+EGdVD9W4Mjm0DqsusmKgO7Xc33mI5X1bklmsQb0hfzPhXomQr9waWIBDsiOjvr1e6BTaUqpA=="],
 
@@ -1792,8 +1793,6 @@
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
-
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -1958,6 +1957,8 @@
 
     "log-symbols/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
+    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
     "metro/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "metro/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -1999,6 +2000,8 @@
     "ora/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "path-scurry/lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
@@ -2063,8 +2066,6 @@
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
-
-    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@babel/highlight/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-css-interop": "0.2.2",
         "react-native-purchases": "^9.6.10",
         "react-native-reanimated": "~4.1.6",
         "react-native-safe-area-context": "~5.6.0",
@@ -970,7 +971,7 @@
 
     "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
 
-    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+    "detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
@@ -1232,29 +1233,29 @@
 
     "lighthouse-logger": ["lighthouse-logger@1.4.2", "", { "dependencies": { "debug": "^2.6.9", "marky": "^1.2.2" } }, "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g=="],
 
-    "lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
+    "lightningcss": ["lightningcss@1.27.0", "", { "dependencies": { "detect-libc": "^1.0.3" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.27.0", "lightningcss-darwin-x64": "1.27.0", "lightningcss-freebsd-x64": "1.27.0", "lightningcss-linux-arm-gnueabihf": "1.27.0", "lightningcss-linux-arm64-gnu": "1.27.0", "lightningcss-linux-arm64-musl": "1.27.0", "lightningcss-linux-x64-gnu": "1.27.0", "lightningcss-linux-x64-musl": "1.27.0", "lightningcss-win32-arm64-msvc": "1.27.0", "lightningcss-win32-x64-msvc": "1.27.0" } }, "sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ=="],
 
     "lightningcss-android-arm64": ["lightningcss-android-arm64@1.31.1", "", { "os": "android", "cpu": "arm64" }, "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg=="],
 
-    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.31.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg=="],
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ=="],
 
-    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.31.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA=="],
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg=="],
 
-    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.31.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A=="],
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA=="],
 
-    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.31.1", "", { "os": "linux", "cpu": "arm" }, "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g=="],
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA=="],
 
-    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg=="],
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A=="],
 
-    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg=="],
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg=="],
 
-    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA=="],
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A=="],
 
-    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA=="],
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA=="],
 
-    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.31.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w=="],
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ=="],
 
-    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
@@ -1824,6 +1825,8 @@
 
     "@expo/metro-config/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "@expo/metro-config/lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
+
     "@expo/metro-config/postcss": ["postcss@8.4.49", "", { "dependencies": { "nanoid": "^3.3.7", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA=="],
 
     "@expo/package-manager/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -1857,6 +1860,8 @@
     "@react-native/dev-middleware/ws": ["ws@6.2.3", "", { "dependencies": { "async-limiter": "~1.0.0" } }, "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA=="],
 
     "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "@tailwindcss/node/lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
 
     "@tailwindcss/node/tailwindcss": ["tailwindcss@4.2.1", "", {}, "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw=="],
 
@@ -1998,8 +2003,6 @@
 
     "react-native/ws": ["ws@6.2.3", "", { "dependencies": { "async-limiter": "~1.0.0" } }, "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA=="],
 
-    "react-native-css-interop/lightningcss": ["lightningcss@1.27.0", "", { "dependencies": { "detect-libc": "^1.0.3" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.27.0", "lightningcss-darwin-x64": "1.27.0", "lightningcss-freebsd-x64": "1.27.0", "lightningcss-linux-arm-gnueabihf": "1.27.0", "lightningcss-linux-arm64-gnu": "1.27.0", "lightningcss-linux-arm64-musl": "1.27.0", "lightningcss-linux-x64-gnu": "1.27.0", "lightningcss-linux-x64-musl": "1.27.0", "lightningcss-win32-arm64-msvc": "1.27.0", "lightningcss-win32-x64-msvc": "1.27.0" } }, "sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ=="],
-
     "react-native-reanimated/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "react-native-web/@react-native/normalize-colors": ["@react-native/normalize-colors@0.74.89", "", {}, "sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg=="],
@@ -2015,6 +2018,8 @@
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "sharp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "simple-plist/bplist-parser": ["bplist-parser@0.3.1", "", { "dependencies": { "big-integer": "1.6.x" } }, "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA=="],
 
@@ -2058,6 +2063,28 @@
 
     "@babel/highlight/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
+    "@expo/metro-config/lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "@expo/metro-config/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.31.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg=="],
+
+    "@expo/metro-config/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.31.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA=="],
+
+    "@expo/metro-config/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.31.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A=="],
+
+    "@expo/metro-config/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.31.1", "", { "os": "linux", "cpu": "arm" }, "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g=="],
+
+    "@expo/metro-config/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg=="],
+
+    "@expo/metro-config/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg=="],
+
+    "@expo/metro-config/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA=="],
+
+    "@expo/metro-config/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA=="],
+
+    "@expo/metro-config/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.31.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w=="],
+
+    "@expo/metro-config/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
+
     "@expo/metro/metro-source-map/ob1": ["ob1@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA=="],
 
     "@expo/metro/metro-source-map/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
@@ -2100,6 +2127,28 @@
 
     "@react-native/community-cli-plugin/metro-core/metro-resolver": ["metro-resolver@0.83.5", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-7p3GtzVUpbAweJeCcUJihJeOQl1bDuimO5ueo1K0BUpUtR41q5EilbQ3klt16UTPPMpA+tISWBtsrqU556mY1A=="],
 
+    "@tailwindcss/node/lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.31.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.31.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.31.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.31.1", "", { "os": "linux", "cpu": "arm" }, "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.31.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w=="],
+
+    "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
+
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -2133,28 +2182,6 @@
     "ora/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "ora/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
-
-    "react-native-css-interop/lightningcss/detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
-
-    "react-native-css-interop/lightningcss/lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ=="],
-
-    "react-native-css-interop/lightningcss/lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg=="],
-
-    "react-native-css-interop/lightningcss/lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA=="],
-
-    "react-native-css-interop/lightningcss/lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA=="],
-
-    "react-native-css-interop/lightningcss/lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A=="],
-
-    "react-native-css-interop/lightningcss/lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg=="],
-
-    "react-native-css-interop/lightningcss/lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A=="],
-
-    "react-native-css-interop/lightningcss/lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA=="],
-
-    "react-native-css-interop/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ=="],
-
-    "react-native-css-interop/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw=="],
 
     "react-native/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
+        "@playwright/test": "^1.61.1",
         "@types/bun": "^1.3.13",
         "@types/node": "^20.19.0",
         "turbo": "^2.3.3",
@@ -573,6 +574,8 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
+
     "@polar-sh/adapter-utils": ["@polar-sh/adapter-utils@0.4.4", "", { "dependencies": { "@polar-sh/sdk": "^0.46.0" } }, "sha512-0fvscT82EMoo+otgnw7YsbzxmatxTpc457DytZY9Lr+6B9XNBI/wP7THK0nV3Qdaipd66Pp9hyZI9Dzusj1KzQ=="],
 
     "@polar-sh/nextjs": ["@polar-sh/nextjs@0.9.4", "", { "dependencies": { "@polar-sh/adapter-utils": "0.4.4", "@polar-sh/sdk": "^0.46.0" }, "peerDependencies": { "next": "^15.0.0 || ^16.0.0" } }, "sha512-CN6qjaVXVR5OojcpjtlXF7FcVnCEXAKB4vyOECP3n3YjD7DdJ4/PPtKvc2/TVXC9bM8m6pcUOI7Y9f7K5T0jNA=="],
@@ -1099,7 +1102,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1420,6 +1423,10 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
@@ -1893,6 +1900,8 @@
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -1930,6 +1939,8 @@
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -60,6 +60,7 @@
         "tailwind-merge": "^3.4.0",
       },
       "devDependencies": {
+        "@babel/plugin-transform-react-jsx": "7.28.6",
         "@biomejs/biome": "2.3.8",
         "@types/react": "~19.1.17",
         "babel-preset-expo": "54.0.10",
@@ -143,7 +144,7 @@
 
     "@auth/core": ["@auth/core@0.37.4", "", { "dependencies": { "@panva/hkdf": "^1.2.1", "jose": "^5.9.6", "oauth4webapi": "^3.1.1", "preact": "10.24.3", "preact-render-to-string": "6.5.11" }, "peerDependencies": { "@simplewebauthn/browser": "^9.0.1", "@simplewebauthn/server": "^9.0.2", "nodemailer": "^6.8.0" }, "optionalPeers": ["@simplewebauthn/browser", "@simplewebauthn/server", "nodemailer"] }, "sha512-HOXJwXWXQRhbBDHlMU0K/6FT1v+wjtzdKhsNg0ZN7/gne6XPsIrjZ4daMcFnbq0Z/vsAbYBinQhhua0d77v7qw=="],
 
-    "@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
 
@@ -1789,8 +1790,6 @@
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
-
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -1803,13 +1802,9 @@
 
     "@babel/plugin-transform-runtime/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
-
-    "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
-
-    "@babel/traverse--for-generate-function-map/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
-
     "@expo/cli/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "@expo/config/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 
     "@expo/config-plugins/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1823,21 +1818,15 @@
 
     "@expo/image-utils/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "@expo/json-file/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
-
     "@expo/metro/metro-runtime": ["metro-runtime@0.83.3", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-JHCJb9ebr9rfJ+LcssFYA2x1qPYuSD/bbePupIGhpMrsla7RCwC/VL3yJ9cSU+nUhU4c9Ixxy8tBta+JbDeZWw=="],
 
     "@expo/metro/metro-source-map": ["metro-source-map@0.83.3", "", { "dependencies": { "@babel/traverse": "^7.25.3", "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3", "@babel/types": "^7.25.2", "flow-enums-runtime": "^0.0.6", "invariant": "^2.2.4", "metro-symbolicate": "0.83.3", "nullthrows": "^1.1.1", "ob1": "0.83.3", "source-map": "^0.5.6", "vlq": "^1.0.0" } }, "sha512-xkC3qwUBh2psVZgVavo8+r2C9Igkk3DibiOXSAht1aYRRcztEZNFtAMtfSB7sdO2iFMx2Mlyu++cBxz/fhdzQg=="],
-
-    "@expo/metro-config/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@expo/metro-config/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@expo/metro-config/postcss": ["postcss@8.4.49", "", { "dependencies": { "nanoid": "^3.3.7", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA=="],
 
     "@expo/package-manager/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "@expo/xcpretty/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@expo/xcpretty/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1941,8 +1930,6 @@
 
     "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
-
     "jest-message-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -1958,8 +1945,6 @@
     "log-symbols/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
-
-    "metro/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "metro/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -2080,8 +2065,6 @@
     "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "@react-native/codegen/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
-    "@react-native/community-cli-plugin/metro/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@react-native/community-cli-plugin/metro/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
+    "@playwright/test": "^1.61.1",
     "@types/bun": "^1.3.13",
     "@types/node": "^20.19.0",
     "turbo": "^2.3.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.base.json",
+  "files": [],
+  "references": [
+    { "path": "./apps/mobile" },
+    { "path": "./apps/web" },
+    { "path": "./convex" },
+    { "path": "./packages/types" },
+    { "path": "./packages/utils" },
+    { "path": "./packages/ui" }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This adds the mobile breathwork timer needed for Linear AGENT-125 so breathing routines can be represented as data instead of bespoke timer code. The timer uses wall-clock elapsed time for phase calculation, which keeps it accurate after app/tab backgrounding and makes phase-change cues testable.

## Linked task(s)

Task: AGENT-125 (Linear) — `docs/TASKS.md` does not contain this external Linear ticket, and `docs/brain/` is private to cloud agents per AGENTS.md.

## Screenshots / screen recording

General UI walkthrough artifact (exact timing is proven by Playwright below):

[breathwork_timer_478_phase_transitions.mp4](https://cursor.com/agents/bc-bd8d54d6-7232-424a-8d2d-5ff712c22a1f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbreathwork_timer_478_phase_transitions.mp4)

## Test plan

- [x] `bun test`
- [x] `bunx tsc --noEmit`
- [x] `bunx playwright test apps/mobile/e2e/breathwork-timer.spec.ts`
- [x] Relevant unit / integration tests added or updated
- [x] Reproduces the acceptance criteria below

Final command evidence:

```bash
bun test
# 40 pass, 0 fail, 100 expect() calls

bunx tsc --noEmit
# exits 0

bunx playwright test apps/mobile/e2e/breathwork-timer.spec.ts
# 1 passed (33.0s)
```

Note: Playwright browser binaries were installed in the cloud environment with `bunx playwright install chromium` before the e2e pass.

## Acceptance criteria

```yaml
done_when:
- a 4-7-8 pattern counts EXACTLY 4 -> 7 -> 8
- audio AND haptic cue fire on EVERY phase change
- a new breath pattern can be added as config only (proven by adding one)
- timer stays accurate when the screen is backgrounded
```

Loop contract commands:

```bash
bun test
bunx tsc --noEmit
bunx playwright test apps/mobile/e2e/breathwork-timer.spec.ts
```

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). N/A — no AI-originated user data mutation.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). N/A — no schema change.
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7).
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8).
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13). N/A — no new env vars.
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9).

## Owner tag (§14)

- [ ] `cursor-ide`
- [x] `cursor-cloud-1`
- [ ] `cursor-cloud-2`
- [ ] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

## Reviewer

Amit (`human-amit`).

## Graph notes

`graphify affected "BreathworkTimer" --depth 2` reported only the new `apps/mobile/app/(tempo)/breathwork.tsx` route importing the component. No graph contradiction with the task found; repo task-board instructions remain contradictory because the visible `docs/TASKS.md` does not contain AGENT-125.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGENT-125](https://linear.app/amit-levin/issue/AGENT-125/t5-breathwork-timer-component)

<div><a href="https://cursor.com/agents/bc-bd8d54d6-7232-424a-8d2d-5ff712c22a1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd8d54d6-7232-424a-8d2d-5ff712c22a1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

