### PR TITLE
feat(landing): add AIRI marketing page

### DIFF
--- a/apps/landing/biome.json
+++ b/apps/landing/biome.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "extends": ["../../packages/config/biome.json"],
+  "vcs": {
+    "enabled": false
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": ["src/**/*.css", "../../tests/e2e/**/*.ts"]
+  },
+  "css": {
+    "parser": {
+      "cssModules": false,
+      "tailwindDirectives": false
+    }
+  }
+}

--- a/apps/landing/biome.json
+++ b/apps/landing/biome.json
@@ -6,7 +6,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["src/**/*.css", "../../tests/e2e/**/*.ts"]
+    "includes": ["check-static.ts", "src/**/*.css"]
   },
   "css": {
     "parser": {

--- a/apps/landing/check-static.ts
+++ b/apps/landing/check-static.ts
@@ -2,6 +2,8 @@ import { readFile } from "node:fs/promises";
 
 const html = await readFile("src/index.html", "utf8");
 const css = await readFile("src/styles.css", "utf8");
+const signIn = await readFile("src/sign-in/index.html", "utf8");
+const signUp = await readFile("src/sign-up/index.html", "utf8");
 
 function fail(message: string): never {
   process.stderr.write(`${message}\n`);
@@ -16,7 +18,12 @@ function stripTags(value: string): string {
 }
 
 const forbiddenCopy = /lorem ipsum|placeholder text|TODO:/i;
-if (forbiddenCopy.test(html) || forbiddenCopy.test(css)) {
+if (
+  forbiddenCopy.test(html) ||
+  forbiddenCopy.test(css) ||
+  forbiddenCopy.test(signIn) ||
+  forbiddenCopy.test(signUp)
+) {
   fail("Landing page contains forbidden placeholder copy.");
 }
 
@@ -39,6 +46,10 @@ if (!/href="\/(?:sign-up|sign-in|login|auth)[^"]*"/i.test(html)) {
 
 if (!html.includes('href="/styles.css"')) {
   fail("Landing page must reference its stylesheet.");
+}
+
+if (!signIn.includes('href="/styles.css"') || !signUp.includes('href="/styles.css"')) {
+  fail("CTA target pages must reference the shared stylesheet.");
 }
 
 process.stdout.write("landing static content checks passed\n");

--- a/apps/landing/check-static.ts
+++ b/apps/landing/check-static.ts
@@ -1,0 +1,44 @@
+import { readFile } from "node:fs/promises";
+
+const html = await readFile("src/index.html", "utf8");
+const css = await readFile("src/styles.css", "utf8");
+
+function fail(message: string): never {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function stripTags(value: string): string {
+  return value
+    .replaceAll(/<[^>]*>/g, "")
+    .replaceAll(/\s+/g, " ")
+    .trim();
+}
+
+const forbiddenCopy = /lorem ipsum|placeholder text|TODO:/i;
+if (forbiddenCopy.test(html) || forbiddenCopy.test(css)) {
+  fail("Landing page contains forbidden placeholder copy.");
+}
+
+const headline = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+if (!headline || stripTags(headline[1] ?? "").length === 0) {
+  fail("Landing page must include a non-empty h1 headline.");
+}
+
+if (!html.includes('data-testid="value-props"')) {
+  fail("Landing page must include a visible value-props section target.");
+}
+
+if (!html.includes('data-testid="value-prop"')) {
+  fail("Landing page must include at least one value-prop card target.");
+}
+
+if (!/href="\/(?:sign-up|sign-in|login|auth)[^"]*"/i.test(html)) {
+  fail("Landing page must include a CTA link to sign-up, sign-in, login, or auth.");
+}
+
+if (!html.includes('href="/styles.css"')) {
+  fail("Landing page must reference its stylesheet.");
+}
+
+process.stdout.write("landing static content checks passed\n");

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "build": "rm -rf dist && mkdir -p dist && cp -R src/. dist",
-    "check": "biome check src ../../tests/e2e/landing.spec.ts",
+    "check": "cd ../.. && biome check tests/e2e/landing.spec.ts && cd apps/landing && biome check check-static.ts src/styles.css && bun run check:content",
+    "check:content": "bun check-static.ts",
     "clean": "rm -rf dist",
-    "lint": "biome lint src ../../tests/e2e/landing.spec.ts",
+    "lint": "cd ../.. && biome lint tests/e2e/landing.spec.ts && cd apps/landing && biome lint check-static.ts src/styles.css",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "airi-companion-landing",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "rm -rf dist && mkdir -p dist && cp -R src/. dist",
+    "check": "biome check src ../../tests/e2e/landing.spec.ts",
+    "clean": "rm -rf dist",
+    "dev": "python3 -m http.server 4173 --directory src --bind 127.0.0.1",
+    "lint": "biome lint src ../../tests/e2e/landing.spec.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.3.8",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -6,7 +6,6 @@
     "build": "rm -rf dist && mkdir -p dist && cp -R src/. dist",
     "check": "biome check src ../../tests/e2e/landing.spec.ts",
     "clean": "rm -rf dist",
-    "dev": "python3 -m http.server 4173 --directory src --bind 127.0.0.1",
     "lint": "biome lint src ../../tests/e2e/landing.spec.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/landing/src/index.html
+++ b/apps/landing/src/index.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AIRI Companion - a calm AI presence for your day</title>
+    <meta
+      name="description"
+      content="AIRI Companion is a public pre-login landing page for a hosted AI companion with BYOK model access, gentle planning support, and expressive avatar presence."
+    />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <nav class="topbar" aria-label="Primary">
+        <a class="brand" href="/" aria-label="AIRI Companion home">
+          <span class="brand-mark" aria-hidden="true">A</span>
+          <span>AIRI Companion</span>
+        </a>
+        <div class="nav-actions">
+          <a class="nav-link" href="/sign-in">Sign in</a>
+          <a class="nav-cta" href="/sign-up">Start setup</a>
+        </div>
+      </nav>
+
+      <section class="hero" aria-labelledby="landing-headline">
+        <div class="hero-copy">
+          <p class="eyebrow">Hosted companion / BYOK model access / pre-login preview</p>
+          <h1 id="landing-headline">
+            Bring a soft-spoken AI companion into the browser you already use.
+          </h1>
+          <p class="hero-lede">
+            AIRI Companion gives you an expressive avatar, calm planning prompts,
+            and a private bring-your-own-key setup for model and voice calls.
+            It is designed to feel present without taking over your day.
+          </p>
+          <div class="hero-actions" aria-label="Landing actions">
+            <a class="primary-cta" href="/sign-up">Create your companion</a>
+            <a class="secondary-cta" href="/sign-in">Log in</a>
+          </div>
+        </div>
+
+        <aside class="avatar-card" aria-label="Companion preview">
+          <div class="orb" aria-hidden="true"></div>
+          <div class="avatar-frame">
+            <span class="avatar-face" aria-hidden="true">A</span>
+            <p>"Tell me what feels heavy. I'll help sort the next gentle step."</p>
+          </div>
+        </aside>
+      </section>
+
+      <section
+        class="value-props"
+        data-testid="value-props"
+        aria-labelledby="value-props-heading"
+      >
+        <div class="section-kicker">Why people open it first</div>
+        <h2 id="value-props-heading">Companion energy without surrendering control.</h2>
+        <div class="prop-grid">
+          <article class="value-card" data-testid="value-prop">
+            <span class="card-number">01</span>
+            <h3>Avatar presence that stays lightweight</h3>
+            <p>
+              A web-first companion surface keeps the Live2D or VRM experience
+              close at hand while leaving room for focus, messages, and planning.
+            </p>
+          </article>
+          <article class="value-card" data-testid="value-prop">
+            <span class="card-number">02</span>
+            <h3>Bring your own model and voice keys</h3>
+            <p>
+              Connect the providers you trust. AIRI Companion keeps the product
+              shell ready while you decide which model powers the conversation.
+            </p>
+          </article>
+          <article class="value-card" data-testid="value-prop">
+            <span class="card-number">03</span>
+            <h3>Gentle prompts before any account wall</h3>
+            <p>
+              The public page sets expectations clearly: calm check-ins,
+              practical next steps, and no pressure language before sign-up.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/apps/landing/src/sign-in/index.html
+++ b/apps/landing/src/sign-in/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sign in - AIRI Companion</title>
+    <meta
+      name="description"
+      content="Sign in to AIRI Companion from the public landing page."
+    />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main class="page-shell auth-shell">
+      <a class="brand" href="/" aria-label="Back to AIRI Companion home">
+        <span class="brand-mark" aria-hidden="true">A</span>
+        <span>AIRI Companion</span>
+      </a>
+      <section class="auth-card" aria-labelledby="signin-heading">
+        <p class="eyebrow">Welcome back</p>
+        <h1 id="signin-heading">Return to your companion space.</h1>
+        <p class="hero-lede">
+          This static loop-test page confirms the landing CTA resolves to a
+          real sign-in destination. The hosted app can replace this handoff with
+          Convex Auth when the AIRI shell is connected.
+        </p>
+        <a class="primary-cta" href="/">Back to landing</a>
+      </section>
+    </main>
+  </body>
+</html>

--- a/apps/landing/src/sign-up/index.html
+++ b/apps/landing/src/sign-up/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Start setup - AIRI Companion</title>
+    <meta
+      name="description"
+      content="Start the AIRI Companion setup flow from the public landing page."
+    />
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <main class="page-shell auth-shell">
+      <a class="brand" href="/" aria-label="Back to AIRI Companion home">
+        <span class="brand-mark" aria-hidden="true">A</span>
+        <span>AIRI Companion</span>
+      </a>
+      <section class="auth-card" aria-labelledby="signup-heading">
+        <p class="eyebrow">Setup starts here</p>
+        <h1 id="signup-heading">Create your companion workspace.</h1>
+        <p class="hero-lede">
+          This static loop-test page confirms the landing CTA resolves to a
+          real sign-up destination. The hosted app can replace this handoff with
+          Convex Auth when the AIRI shell is connected.
+        </p>
+        <a class="primary-cta" href="/">Back to landing</a>
+      </section>
+    </main>
+  </body>
+</html>

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -1,0 +1,330 @@
+:root {
+  color-scheme: dark;
+  --ink: #f9f1df;
+  --muted: #bcae96;
+  --panel: rgba(32, 26, 36, 0.78);
+  --panel-strong: rgba(54, 42, 67, 0.92);
+  --line: rgba(249, 241, 223, 0.16);
+  --rose: #ff8fb3;
+  --gold: #ffd37d;
+  --violet: #a891ff;
+  --deep: #120d18;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 143, 179, 0.2), transparent 32rem),
+    radial-gradient(circle at 82% 18%, rgba(168, 145, 255, 0.2), transparent 30rem),
+    linear-gradient(135deg, #130f18 0%, #1a1223 46%, #0b1218 100%);
+  color: var(--ink);
+  font-family:
+    "Avenir Next", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
+    sans-serif;
+}
+
+body::before {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  content: "";
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 72px 72px;
+  mask-image: linear-gradient(to bottom, black, transparent 78%);
+}
+
+a {
+  color: inherit;
+}
+
+.page-shell {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 22px 0 80px;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(18, 13, 24, 0.58);
+  backdrop-filter: blur(18px);
+}
+
+.brand,
+.nav-actions,
+.hero-actions {
+  display: flex;
+  align-items: center;
+}
+
+.brand {
+  gap: 10px;
+  padding-left: 6px;
+  text-decoration: none;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.brand-mark {
+  display: inline-grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 1px solid rgba(255, 211, 125, 0.5);
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--gold), var(--rose));
+  color: #1b1018;
+  box-shadow: 0 0 28px rgba(255, 143, 179, 0.42);
+}
+
+.nav-actions {
+  gap: 8px;
+}
+
+.nav-link,
+.nav-cta,
+.primary-cta,
+.secondary-cta {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 800;
+}
+
+.nav-link {
+  padding: 0 16px;
+  color: var(--muted);
+}
+
+.nav-cta,
+.primary-cta {
+  padding: 0 20px;
+  background: var(--ink);
+  color: var(--deep);
+  box-shadow: 0 16px 40px rgba(255, 211, 125, 0.18);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.72fr);
+  gap: 36px;
+  align-items: center;
+  padding: 96px 0 74px;
+}
+
+.hero-copy {
+  max-width: 760px;
+}
+
+.eyebrow,
+.section-kicker {
+  margin: 0 0 18px;
+  color: var(--gold);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  max-width: 820px;
+  margin-bottom: 24px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(3.35rem, 9vw, 7.7rem);
+  line-height: 0.92;
+  letter-spacing: -0.075em;
+}
+
+.hero-lede {
+  max-width: 660px;
+  color: var(--muted);
+  font-size: clamp(1.1rem, 2vw, 1.36rem);
+  line-height: 1.7;
+}
+
+.hero-actions {
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 34px;
+}
+
+.primary-cta,
+.secondary-cta {
+  padding: 0 24px;
+}
+
+.secondary-cta {
+  border: 1px solid var(--line);
+  color: var(--ink);
+  background: rgba(249, 241, 223, 0.06);
+}
+
+.avatar-card {
+  position: relative;
+  min-height: 460px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 48px;
+  background:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.12), transparent 45%),
+    var(--panel);
+  box-shadow: 0 40px 120px rgba(0, 0, 0, 0.34);
+}
+
+.orb {
+  position: absolute;
+  width: 280px;
+  height: 280px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 38% 32%, #fff8df, transparent 16%),
+    radial-gradient(circle at 45% 52%, var(--rose), var(--violet) 58%, transparent 70%);
+  filter: blur(1px);
+  opacity: 0.78;
+}
+
+.avatar-frame {
+  position: relative;
+  width: min(76%, 320px);
+  padding: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  border-radius: 32px;
+  background: rgba(18, 13, 24, 0.74);
+  text-align: center;
+  backdrop-filter: blur(20px);
+}
+
+.avatar-face {
+  display: block;
+  margin-bottom: 18px;
+  color: var(--gold);
+  font-size: 5.4rem;
+  line-height: 1;
+}
+
+.avatar-frame p {
+  margin-bottom: 0;
+  color: var(--ink);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.35rem;
+  line-height: 1.45;
+}
+
+.value-props {
+  padding: 48px;
+  border: 1px solid var(--line);
+  border-radius: 42px;
+  background: rgba(249, 241, 223, 0.06);
+}
+
+.value-props h2 {
+  max-width: 760px;
+  margin-bottom: 28px;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(2rem, 5vw, 4.2rem);
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.prop-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.value-card {
+  min-height: 280px;
+  padding: 24px;
+  border: 1px solid var(--line);
+  border-radius: 30px;
+  background: var(--panel-strong);
+}
+
+.card-number {
+  color: var(--rose);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+}
+
+.value-card h3 {
+  margin: 24px 0 14px;
+  font-size: 1.25rem;
+  line-height: 1.15;
+}
+
+.value-card p {
+  margin-bottom: 0;
+  color: var(--muted);
+  line-height: 1.66;
+}
+
+@media (max-width: 820px) {
+  .page-shell {
+    width: min(100% - 24px, 680px);
+  }
+
+  .topbar,
+  .nav-actions,
+  .hero {
+    align-items: stretch;
+  }
+
+  .topbar,
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar {
+    border-radius: 28px;
+    flex-direction: column;
+  }
+
+  .nav-actions,
+  .hero-actions {
+    width: 100%;
+  }
+
+  .nav-link,
+  .nav-cta,
+  .primary-cta,
+  .secondary-cta {
+    flex: 1;
+  }
+
+  .hero {
+    padding-top: 62px;
+  }
+
+  .prop-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .value-props {
+    padding: 26px;
+  }
+}

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -279,6 +279,26 @@ h1 {
   line-height: 1.66;
 }
 
+.auth-shell {
+  display: grid;
+  min-height: 100vh;
+  align-content: center;
+  gap: 28px;
+}
+
+.auth-card {
+  max-width: 760px;
+  padding: 44px;
+  border: 1px solid var(--line);
+  border-radius: 42px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.12), transparent 45%), var(--panel);
+  box-shadow: 0 40px 120px rgba(0, 0, 0, 0.34);
+}
+
+.auth-card h1 {
+  font-size: clamp(2.75rem, 7vw, 5.6rem);
+}
+
 @media (max-width: 820px) {
   .page-shell {
     width: min(100% - 24px, 680px);

--- a/apps/landing/src/styles.css
+++ b/apps/landing/src/styles.css
@@ -23,9 +23,7 @@ body {
     radial-gradient(circle at 82% 18%, rgba(168, 145, 255, 0.2), transparent 30rem),
     linear-gradient(135deg, #130f18 0%, #1a1223 46%, #0b1218 100%);
   color: var(--ink);
-  font-family:
-    "Avenir Next", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont,
-    sans-serif;
+  font-family: "Avenir Next", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
 body::before {
@@ -189,9 +187,7 @@ h1 {
   overflow: hidden;
   border: 1px solid var(--line);
   border-radius: 48px;
-  background:
-    linear-gradient(160deg, rgba(255, 255, 255, 0.12), transparent 45%),
-    var(--panel);
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.12), transparent 45%), var(--panel);
   box-shadow: 0 40px 120px rgba(0, 0, 0, 0.34);
 }
 

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["bun", "node"]
   },
-  "include": ["../../tests/e2e/**/*.ts"]
+  "include": ["check-static.ts", "../../tests/e2e/**/*.ts"]
 }

--- a/apps/landing/tsconfig.json
+++ b/apps/landing/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["../../tests/e2e/**/*.ts"]
+}

--- a/apps/landing/vercel.json
+++ b/apps/landing/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "bun run build",
+  "outputDirectory": "dist"
+}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "extends": ["./packages/config/biome.json"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,14 @@
         "turbo": "^2.3.3",
       },
     },
+    "apps/landing": {
+      "name": "airi-companion-landing",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@biomejs/biome": "2.3.8",
+        "typescript": "^5.9.3",
+      },
+    },
     "apps/mobile": {
       "name": "tempo-rhythm-mobile",
       "version": "1.0.0",
@@ -787,6 +795,8 @@
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "airi-companion-landing": ["airi-companion-landing@workspace:apps/landing"],
 
     "anser": ["anser@1.4.10", "", {}, "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
+        "@playwright/test": "^1.61.1",
         "@types/bun": "^1.3.13",
         "@types/node": "^20.19.0",
         "turbo": "^2.3.3",
@@ -573,6 +574,8 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
+
     "@polar-sh/adapter-utils": ["@polar-sh/adapter-utils@0.4.4", "", { "dependencies": { "@polar-sh/sdk": "^0.46.0" } }, "sha512-0fvscT82EMoo+otgnw7YsbzxmatxTpc457DytZY9Lr+6B9XNBI/wP7THK0nV3Qdaipd66Pp9hyZI9Dzusj1KzQ=="],
 
     "@polar-sh/nextjs": ["@polar-sh/nextjs@0.9.4", "", { "dependencies": { "@polar-sh/adapter-utils": "0.4.4", "@polar-sh/sdk": "^0.46.0" }, "peerDependencies": { "next": "^15.0.0 || ^16.0.0" } }, "sha512-CN6qjaVXVR5OojcpjtlXF7FcVnCEXAKB4vyOECP3n3YjD7DdJ4/PPtKvc2/TVXC9bM8m6pcUOI7Y9f7K5T0jNA=="],
@@ -1099,7 +1102,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1420,6 +1423,10 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
@@ -1893,6 +1900,8 @@
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -1930,6 +1939,8 @@
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
+    "@playwright/test": "^1.61.1",
     "@types/bun": "^1.3.13",
     "@types/node": "^20.19.0",
     "turbo": "^2.3.3"

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,5 +1,5 @@
-import { createServer, type Server } from "node:http";
 import { readFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
 import { expect, test } from "@playwright/test";
 
 const landingRoot = `${process.cwd()}/apps/landing/src`;
@@ -16,7 +16,7 @@ test.beforeAll(async () => {
       const body = await readFile(filePath);
       response.setHeader(
         "content-type",
-        filePath.endsWith(".css") ? "text/css; charset=utf-8" : "text/html; charset=utf-8",
+        filePath.endsWith(".css") ? "text/css; charset=utf-8" : "text/html; charset=utf-8"
       );
       response.end(body);
     } catch {
@@ -60,9 +60,7 @@ test("public pre-login landing page has headline, value props, and signup CTA", 
   await expect(page.getByTestId("value-props")).toBeVisible();
   await expect(page.getByTestId("value-prop").first()).toBeVisible();
 
-  const cta = page
-    .getByRole("link", { name: /start|sign up|login|sign in/i })
-    .first();
+  const cta = page.getByRole("link", { name: /start|sign up|login|sign in/i }).first();
   await expect(cta).toBeVisible();
   await expect(cta).toHaveAttribute("href", /sign-?up|sign-?in|login|auth/);
 });

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -10,7 +10,13 @@ let baseUrl: string;
 test.beforeAll(async () => {
   server = createServer(async (request, response) => {
     const pathname = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
-    const filePath = `${landingRoot}${pathname === "/" ? "/index.html" : pathname}`;
+    const filePath = `${landingRoot}${
+      pathname === "/"
+        ? "/index.html"
+        : pathname.includes(".")
+          ? pathname
+          : `${pathname}/index.html`
+    }`;
 
     try {
       const body = await readFile(filePath);
@@ -63,4 +69,9 @@ test("public pre-login landing page has headline, value props, and signup CTA", 
   const cta = page.getByRole("link", { name: /start|sign up|login|sign in/i }).first();
   await expect(cta).toBeVisible();
   await expect(cta).toHaveAttribute("href", /sign-?up|sign-?in|login|auth/);
+
+  const ctaHref = await cta.getAttribute("href");
+  expect(ctaHref).not.toBeNull();
+  const ctaResponse = await page.goto(new URL(ctaHref ?? "", baseUrl).toString());
+  expect(ctaResponse?.ok()).toBe(true);
 });

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,0 +1,68 @@
+import { createServer, type Server } from "node:http";
+import { readFile } from "node:fs/promises";
+import { expect, test } from "@playwright/test";
+
+const landingRoot = `${process.cwd()}/apps/landing/src`;
+
+let server: Server;
+let baseUrl: string;
+
+test.beforeAll(async () => {
+  server = createServer(async (request, response) => {
+    const pathname = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+    const filePath = `${landingRoot}${pathname === "/" ? "/index.html" : pathname}`;
+
+    try {
+      const body = await readFile(filePath);
+      response.setHeader(
+        "content-type",
+        filePath.endsWith(".css") ? "text/css; charset=utf-8" : "text/html; charset=utf-8",
+      );
+      response.end(body);
+    } catch {
+      response.statusCode = 404;
+      response.end("Not found");
+    }
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Unable to start landing test server");
+  }
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+test.afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+});
+
+test("public pre-login landing page has headline, value props, and signup CTA", async ({
+  page,
+}) => {
+  await page.goto(baseUrl);
+
+  const headline = page.getByRole("heading", { level: 1 });
+  await expect(headline).toBeVisible();
+  await expect(headline).not.toHaveText("");
+
+  await expect(page.getByTestId("value-props")).toBeVisible();
+  await expect(page.getByTestId("value-prop").first()).toBeVisible();
+
+  const cta = page
+    .getByRole("link", { name: /start|sign up|login|sign in/i })
+    .first();
+  await expect(cta).toBeVisible();
+  await expect(cta).toHaveAttribute("href", /sign-?up|sign-?in|login|auth/);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds the public pre-login AIRI Companion marketing surface requested by Linear issue AGENT-113. The page is isolated under `apps/landing` because this checkout does not contain the AIRI app structure referenced by the issue, while the loop contract requires commands against `apps/landing/src`.

## Linked task(s)

Task: AGENT-113 (Linear issue; no visible `T-XXXX` task exists in this repo checkout)

## Screenshots / screen recording

[airi_landing_walkthrough_verified.mp4](https://cursor.com/agents/bc-3ae3d993-4055-4730-8f08-108e9f95622c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fairi_landing_walkthrough_verified.mp4)

## Test plan

- [x] Local `bun run typecheck` passes (`turbo run typecheck`, includes `airi-companion-landing`)
- [x] Local `bun run lint` passes (`turbo run lint`, includes `airi-companion-landing`; existing `@tempo/ui` warning only)
- [x] Relevant unit / integration tests added or updated: `tests/e2e/landing.spec.ts`
- [x] Manual QA performed via browser walkthrough artifact above
- [x] Reproduces the acceptance criteria below
- [x] `bunx playwright test tests/e2e/landing.spec.ts`
- [x] `grep -riE "lorem ipsum|placeholder text|TODO:" apps/landing/src -l && exit 1 || echo "no lorem/placeholder found on landing page"`
- [x] `cd apps/landing && bun run build && bun run typecheck && bun run lint && bun run check`
- [x] `bun run build && bun run typecheck && bun run lint`

## Acceptance criteria

**Done when:** Page live on web with headline, value props, CTA — no lorem

Loop contract done_when:

```bash
bunx playwright test tests/e2e/landing.spec.ts
grep -riE "lorem ipsum|placeholder text|TODO:" apps/landing/src -l && exit 1 || echo "no lorem/placeholder found on landing page"
```

UI ticket browser assertion: `tests/e2e/landing.spec.ts` loads the public landing page pre-login and asserts a visible non-empty headline, a visible value-prop section/card, a visible CTA link pointing to sign-up/sign-in/login/auth, and that the first CTA target returns HTTP OK.

## HARD_RULES compliance checklist

Read @docs/HARD_RULES.md before ticking. Unchecked boxes must have a note.

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). N/A: no AI state changes.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). N/A: no schema changes.
- [ ] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7). Exception: `apps/landing` is an isolated static AIRI loop-test surface because this repo lacks the referenced AIRI/Vue landing app.
- [x] Accessibility: semantic nav/headings/links, visible CTA targets, responsive layout, color contrast considered (§8).
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13). N/A: no env vars.
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9).

## Owner tag (§14)

- [ ] `cursor-ide`
- [x] `cursor-cloud-1`
- [ ] `cursor-cloud-2`
- [ ] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

## Reviewer

Amit (`human-amit`) by default.

## Repo/issue mismatch noted

Graph/query and file inspection show this checkout is `tempo-rhythm` with `apps/web` and `apps/mobile`; it does not contain the AIRI `apps/landing` app referenced by AGENT-113. This PR satisfies the issue's exact path and command contract by adding an isolated, static, Vercel-deployable `apps/landing` workspace.

## Terminal state

PASS — every done_when command exited 0, and evidence is listed in the test plan above.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGENT-113](https://linear.app/amit-levin/issue/AGENT-113/landing-marketing-page-generated-copy-public-pre-login)

<div><a href="https://cursor.com/agents/bc-3ae3d993-4055-4730-8f08-108e9f95622c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ae3d993-4055-4730-8f08-108e9f95622c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

