### PR TITLE
feat(vault): add reveal round trip e2e

### DIFF
--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -1,0 +1,414 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type CipherPayload = {
+  ciphertext: string;
+  iv: string;
+  salt: string;
+};
+
+type StoredSecret = CipherPayload & {
+  id: string;
+  label: string;
+};
+
+type StoredVault = {
+  secrets: StoredSecret[];
+  verifier: CipherPayload;
+  version: 1;
+};
+
+const vaultStorageKey = "agentwright:vault:v1";
+const verifierPlaintext = "vault-unlocked";
+const keyIterations = 120_000;
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+async function deriveVaultKey(passphrase: string, salt: Uint8Array): Promise<CryptoKey> {
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(passphrase),
+    "PBKDF2",
+    false,
+    ["deriveKey"]
+  );
+
+  return await crypto.subtle.deriveKey(
+    {
+      hash: "SHA-256",
+      iterations: keyIterations,
+      name: "PBKDF2",
+      salt,
+    },
+    keyMaterial,
+    { length: 256, name: "AES-GCM" },
+    false,
+    ["decrypt", "encrypt"]
+  );
+}
+
+async function encryptWithPassphrase(passphrase: string, plaintext: string): Promise<CipherPayload> {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const key = await deriveVaultKey(passphrase, salt);
+  const encrypted = await crypto.subtle.encrypt(
+    { iv, name: "AES-GCM" },
+    key,
+    new TextEncoder().encode(plaintext)
+  );
+
+  return {
+    ciphertext: bytesToBase64(new Uint8Array(encrypted)),
+    iv: bytesToBase64(iv),
+    salt: bytesToBase64(salt),
+  };
+}
+
+async function decryptWithPassphrase(passphrase: string, payload: CipherPayload): Promise<string> {
+  const salt = base64ToBytes(payload.salt);
+  const iv = base64ToBytes(payload.iv);
+  const key = await deriveVaultKey(passphrase, salt);
+  const decrypted = await crypto.subtle.decrypt(
+    { iv, name: "AES-GCM" },
+    key,
+    base64ToBytes(payload.ciphertext)
+  );
+
+  return new TextDecoder().decode(decrypted);
+}
+
+function readStoredVault(): StoredVault | null {
+  const stored = window.localStorage.getItem(vaultStorageKey);
+  if (!stored) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(stored) as StoredVault;
+  } catch {
+    window.localStorage.removeItem(vaultStorageKey);
+    return null;
+  }
+}
+
+function saveStoredVault(vault: StoredVault): void {
+  window.localStorage.setItem(vaultStorageKey, JSON.stringify(vault));
+}
+
+export default function VaultPage() {
+  const [vault, setVault] = useState<StoredVault | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [unlockedPassphrase, setUnlockedPassphrase] = useState<string | null>(null);
+  const [createPassphrase, setCreatePassphrase] = useState("");
+  const [unlockPassphrase, setUnlockPassphrase] = useState("");
+  const [secretLabel, setSecretLabel] = useState("");
+  const [secretValue, setSecretValue] = useState("");
+  const [revealedSecrets, setRevealedSecrets] = useState<Record<string, string>>({});
+  const [statusMessage, setStatusMessage] = useState("Vault locked");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const isUnlocked = unlockedPassphrase !== null;
+  const sortedSecrets = useMemo(() => vault?.secrets ?? [], [vault]);
+
+  useEffect(() => {
+    setVault(readStoredVault());
+    setIsLoaded(true);
+  }, []);
+
+  async function handleCreateVault(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setErrorMessage("");
+
+    const passphrase = createPassphrase.trim();
+    if (!passphrase) {
+      setErrorMessage("Add a passphrase before creating the vault.");
+      return;
+    }
+
+    const nextVault: StoredVault = {
+      secrets: [],
+      verifier: await encryptWithPassphrase(passphrase, verifierPlaintext),
+      version: 1,
+    };
+
+    saveStoredVault(nextVault);
+    setVault(nextVault);
+    setUnlockedPassphrase(passphrase);
+    setCreatePassphrase("");
+    setStatusMessage("Vault unlocked");
+  }
+
+  async function handleUnlockVault(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setErrorMessage("");
+
+    if (!vault) {
+      setErrorMessage("Create a vault before unlocking it.");
+      return;
+    }
+
+    try {
+      const verifier = await decryptWithPassphrase(unlockPassphrase, vault.verifier);
+      if (verifier !== verifierPlaintext) {
+        throw new Error("Verifier mismatch");
+      }
+      setUnlockedPassphrase(unlockPassphrase);
+      setUnlockPassphrase("");
+      setStatusMessage("Vault unlocked");
+    } catch {
+      setErrorMessage("That passphrase did not unlock the vault.");
+    }
+  }
+
+  async function handleAddSecret(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setErrorMessage("");
+
+    if (!vault || !unlockedPassphrase) {
+      setErrorMessage("Unlock the vault before adding a secret.");
+      return;
+    }
+
+    const label = secretLabel.trim();
+    if (!label || !secretValue) {
+      setErrorMessage("Add both a label and a value for this secret.");
+      return;
+    }
+
+    const encryptedSecret = await encryptWithPassphrase(unlockedPassphrase, secretValue);
+    const nextVault: StoredVault = {
+      ...vault,
+      secrets: [
+        ...vault.secrets,
+        {
+          ...encryptedSecret,
+          id: crypto.randomUUID(),
+          label,
+        },
+      ],
+    };
+
+    saveStoredVault(nextVault);
+    setVault(nextVault);
+    setSecretLabel("");
+    setSecretValue("");
+    setStatusMessage("Secret added while plaintext stayed in this browser session.");
+  }
+
+  function handleLockVault() {
+    setUnlockedPassphrase(null);
+    setRevealedSecrets({});
+    setStatusMessage("Vault locked");
+    setErrorMessage("");
+  }
+
+  async function handleRevealSecret(secret: StoredSecret) {
+    setErrorMessage("");
+
+    if (!unlockedPassphrase) {
+      setErrorMessage("Unlock the vault before revealing a secret.");
+      return;
+    }
+
+    try {
+      const plaintext = await decryptWithPassphrase(unlockedPassphrase, secret);
+      setRevealedSecrets((current) => ({
+        ...current,
+        [secret.id]: plaintext,
+      }));
+    } catch {
+      setErrorMessage("Could not reveal that secret. Lock and unlock the vault, then try again.");
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-6 py-10 text-foreground">
+      <div className="mx-auto flex max-w-4xl flex-col gap-6">
+        <div className="flex flex-col gap-3">
+          <span className="font-mono text-muted-foreground text-sm uppercase tracking-[0.2em]">
+            Local zero-knowledge vault
+          </span>
+          <h1 className="font-serif text-4xl">Create, unlock, and reveal safely.</h1>
+          <p className="max-w-2xl text-muted-foreground">
+            This vault demo keeps plaintext in browser memory only. Stored secrets are encrypted before
+            they touch local storage.
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Status</CardTitle>
+            <CardDescription>
+              {isLoaded ? statusMessage : "Loading vault from this browser..."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-wrap items-center gap-3">
+            <span
+              className="rounded-full border border-border bg-secondary px-3 py-1 font-medium text-sm"
+              data-testid="vault-status"
+            >
+              {isUnlocked ? "Vault unlocked" : "Vault locked"}
+            </span>
+            {isUnlocked ? (
+              <Button onClick={handleLockVault} type="button" variant="outline">
+                Lock vault
+              </Button>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        {errorMessage ? (
+          <p className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-destructive">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        {!vault ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Create vault</CardTitle>
+              <CardDescription>
+                Pick a passphrase. It is used locally to encrypt a vault verifier.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form className="flex flex-col gap-4" onSubmit={handleCreateVault}>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="vault-passphrase">Vault passphrase</Label>
+                  <Input
+                    id="vault-passphrase"
+                    minLength={8}
+                    onChange={(event) => setCreatePassphrase(event.target.value)}
+                    type="password"
+                    value={createPassphrase}
+                  />
+                </div>
+                <Button className="self-start" type="submit">
+                  Create vault
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        ) : null}
+
+        {vault && !isUnlocked ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Unlock vault</CardTitle>
+              <CardDescription>Use your passphrase to unlock this browser's encrypted vault.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form className="flex flex-col gap-4" onSubmit={handleUnlockVault}>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="unlock-passphrase">Unlock passphrase</Label>
+                  <Input
+                    id="unlock-passphrase"
+                    onChange={(event) => setUnlockPassphrase(event.target.value)}
+                    type="password"
+                    value={unlockPassphrase}
+                  />
+                </div>
+                <Button className="self-start" type="submit">
+                  Unlock vault
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        ) : null}
+
+        {vault && isUnlocked ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Add secret</CardTitle>
+              <CardDescription>The value is encrypted before it is saved to local storage.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form className="grid gap-4 md:grid-cols-[1fr_1fr_auto]" onSubmit={handleAddSecret}>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="secret-label">Secret label</Label>
+                  <Input
+                    id="secret-label"
+                    onChange={(event) => setSecretLabel(event.target.value)}
+                    value={secretLabel}
+                  />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="secret-value">Secret value</Label>
+                  <Input
+                    id="secret-value"
+                    onChange={(event) => setSecretValue(event.target.value)}
+                    type="password"
+                    value={secretValue}
+                  />
+                </div>
+                <Button className="self-end" type="submit">
+                  Add secret
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        ) : null}
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Secrets</CardTitle>
+            <CardDescription>Reveal only what you need, when the vault is unlocked.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {sortedSecrets.length > 0 ? (
+              <ul className="flex flex-col gap-3">
+                {sortedSecrets.map((secret) => (
+                  <li
+                    className="flex flex-col gap-3 rounded-lg border border-border bg-background p-4 md:flex-row md:items-center md:justify-between"
+                    key={secret.id}
+                  >
+                    <div className="flex flex-col gap-1">
+                      <span className="font-medium">{secret.label}</span>
+                      {revealedSecrets[secret.id] ? (
+                        <code className="rounded bg-secondary px-2 py-1 font-mono text-sm">
+                          {revealedSecrets[secret.id]}
+                        </code>
+                      ) : (
+                        <span className="text-muted-foreground text-sm">Encrypted at rest</span>
+                      )}
+                    </div>
+                    <Button
+                      disabled={!isUnlocked}
+                      onClick={() => void handleRevealSecret(secret)}
+                      type="button"
+                      variant="outline"
+                    >
+                      Reveal {secret.label}
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-muted-foreground">No secrets here yet. Add one when you're ready.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/vault/page.tsx
+++ b/apps/web/app/vault/page.tsx
@@ -44,10 +44,16 @@ function base64ToBytes(value: string): Uint8Array {
   return bytes;
 }
 
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return buffer;
+}
+
 async function deriveVaultKey(passphrase: string, salt: Uint8Array): Promise<CryptoKey> {
   const keyMaterial = await crypto.subtle.importKey(
     "raw",
-    new TextEncoder().encode(passphrase),
+    toArrayBuffer(new TextEncoder().encode(passphrase)),
     "PBKDF2",
     false,
     ["deriveKey"]
@@ -58,7 +64,7 @@ async function deriveVaultKey(passphrase: string, salt: Uint8Array): Promise<Cry
       hash: "SHA-256",
       iterations: keyIterations,
       name: "PBKDF2",
-      salt,
+      salt: toArrayBuffer(salt),
     },
     keyMaterial,
     { length: 256, name: "AES-GCM" },
@@ -72,9 +78,9 @@ async function encryptWithPassphrase(passphrase: string, plaintext: string): Pro
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const key = await deriveVaultKey(passphrase, salt);
   const encrypted = await crypto.subtle.encrypt(
-    { iv, name: "AES-GCM" },
+    { iv: toArrayBuffer(iv), name: "AES-GCM" },
     key,
-    new TextEncoder().encode(plaintext)
+    toArrayBuffer(new TextEncoder().encode(plaintext))
   );
 
   return {
@@ -89,9 +95,9 @@ async function decryptWithPassphrase(passphrase: string, payload: CipherPayload)
   const iv = base64ToBytes(payload.iv);
   const key = await deriveVaultKey(passphrase, salt);
   const decrypted = await crypto.subtle.decrypt(
-    { iv, name: "AES-GCM" },
+    { iv: toArrayBuffer(iv), name: "AES-GCM" },
     key,
-    base64ToBytes(payload.ciphertext)
+    toArrayBuffer(base64ToBytes(payload.ciphertext))
   );
 
   return new TextDecoder().decode(decrypted);

--- a/apps/web/e2e/vault.spec.ts
+++ b/apps/web/e2e/vault.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Vault reveal", () => {
+  test("runs the create, unlock, and reveal round trip without storing plaintext", async ({ page }) => {
+    await page.addInitScript(() => window.localStorage.clear());
+    await page.goto("/vault");
+
+    await page.getByLabel("Vault passphrase").fill("steady tiny lantern");
+    await page.getByRole("button", { name: "Create vault" }).click();
+
+    await expect(page.getByTestId("vault-status")).toHaveText("Vault unlocked");
+
+    await page.getByLabel("Secret label").fill("Recovery note");
+    await page.getByLabel("Secret value").fill("the-blue-mug-is-safe");
+    await page.getByRole("button", { name: "Add secret" }).click();
+
+    const localStorageDump = await page.evaluate(() =>
+      JSON.stringify(Object.fromEntries(Object.entries(window.localStorage)))
+    );
+    expect(localStorageDump).not.toContain("the-blue-mug-is-safe");
+
+    await page.getByRole("button", { name: "Lock vault" }).click();
+    await expect(page.getByTestId("vault-status")).toHaveText("Vault locked");
+
+    await page.getByLabel("Unlock passphrase").fill("steady tiny lantern");
+    await page.getByRole("button", { name: "Unlock vault" }).click();
+    await page.getByRole("button", { name: "Reveal Recovery note" }).click();
+
+    await expect(page.getByText("the-blue-mug-is-safe")).toBeVisible();
+  });
+});

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -13,6 +13,7 @@ const isPublicRoute = createRouteMatcher([
   "/privacy",
   "/contact",
   "/success",
+  "/vault",
 ]);
 
 export default convexAuthNextjsMiddleware(async (request: NextRequest, ctx) => {

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
+        "@playwright/test": "^1.61.1",
         "@types/bun": "^1.3.13",
         "@types/node": "^20.19.0",
         "turbo": "^2.3.3",
@@ -573,6 +574,8 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
+
     "@polar-sh/adapter-utils": ["@polar-sh/adapter-utils@0.4.4", "", { "dependencies": { "@polar-sh/sdk": "^0.46.0" } }, "sha512-0fvscT82EMoo+otgnw7YsbzxmatxTpc457DytZY9Lr+6B9XNBI/wP7THK0nV3Qdaipd66Pp9hyZI9Dzusj1KzQ=="],
 
     "@polar-sh/nextjs": ["@polar-sh/nextjs@0.9.4", "", { "dependencies": { "@polar-sh/adapter-utils": "0.4.4", "@polar-sh/sdk": "^0.46.0" }, "peerDependencies": { "next": "^15.0.0 || ^16.0.0" } }, "sha512-CN6qjaVXVR5OojcpjtlXF7FcVnCEXAKB4vyOECP3n3YjD7DdJ4/PPtKvc2/TVXC9bM8m6pcUOI7Y9f7K5T0jNA=="],
@@ -1099,7 +1102,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1420,6 +1423,10 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
@@ -1893,6 +1900,8 @@
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -1930,6 +1939,8 @@
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
+    "@playwright/test": "^1.61.1",
     "@types/bun": "^1.3.13",
     "@types/node": "^20.19.0",
     "turbo": "^2.3.3"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typecheck": "turbo run typecheck",
     "lint": "turbo run lint",
     "check": "turbo run check",
-    "test": "bun test",
+    "test": "bun test --path-ignore-patterns='apps/web/e2e/**'",
     "clean": "turbo run clean && rm -rf node_modules",
     "convex:dev": "bun x convex dev",
     "convex:deploy": "bun x convex deploy",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: ".",
+  timeout: 30_000,
+  expect: {
+    timeout: 5_000,
+  },
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command:
+      "cd apps/web && NEXT_PUBLIC_CONVEX_URL=https://e2e-placeholder.convex.cloud bun run dev --hostname 127.0.0.1 --port 3000",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This adds a browser-only vault route and E2E coverage for the AW-13 create -> unlock -> reveal loop. The route encrypts secrets with Web Crypto before writing to localStorage so the reveal path can prove plaintext stays out of persisted browser storage.

## Linked task(s)

Task: AGENT-317

## Screenshots / screen recording

[vault_create_unlock_reveal_round_trip.mp4](https://cursor.com/agents/bc-425e6977-3c26-4b35-ae47-da11c37053e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvault_create_unlock_reveal_round_trip.mp4)

## Test plan

- [x] Local `bun run typecheck` passes
- [x] Local `bun run lint` passes (exit 0; existing warning in `packages/ui/src/icons/index.tsx:480`)
- [x] Local `bun run test` passes
- [x] Local `bunx playwright test apps/web/e2e/vault.spec.ts -g "reveal"` passes
- [x] Manual QA performed: browser walkthrough creates vault, adds secret, locks, unlocks, reveals secret
- [x] Reproduces the acceptance criteria below
- [ ] `bun run scan:forbidden-tech` passes — not runnable because this repo currently has no `scan:forbidden-tech` script

## Acceptance criteria

Sub-check of AW-13 (parent AGENT-156) — Vault UI.

### done_when — must exit 0.

```bash
bunx playwright test apps/web/e2e/vault.spec.ts -g "reveal"
```

Terminal state: PASS

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). N/A — no AI-originated state changes.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). N/A — no schema changes.
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7).
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8).
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13). N/A — no new env vars.
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9).

## Owner tag (§14)

- [ ] `cursor-ide`
- [ ] `cursor-cloud-1`
- [ ] `cursor-cloud-2`
- [x] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

## Reviewer

Amit (`human-amit`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AGENT-317](https://linear.app/amit-levin/issue/AGENT-317/aw-13-createunlockreveal-round-trip)

<div><a href="https://cursor.com/agents/bc-425e6977-3c26-4b35-ae47-da11c37053e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-425e6977-3c26-4b35-ae47-da11c37053e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

