### PR TITLE
feat(today): complete core flow for TEMPO-115

### DIFF
--- a/apps/web/components/today/TodayAgenda.tsx
+++ b/apps/web/components/today/TodayAgenda.tsx
@@ -1,0 +1,65 @@
+import { CalendarDays } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+type TodayAgendaEvent = {
+  id: string;
+  title: string;
+  timeLabel: string;
+  location?: string;
+};
+
+type TodayAgendaProps = {
+  events?: TodayAgendaEvent[];
+};
+
+export function TodayAgenda({ events = [] }: TodayAgendaProps) {
+  return (
+    <section
+      className="rounded-3xl border border-border/80 bg-card/90 p-5 shadow-[0_10px_30px_rgba(26,25,23,0.08)]"
+      aria-labelledby="today-agenda-heading"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <CalendarDays className="h-5 w-5" aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2 id="today-agenda-heading" className="font-heading text-xl font-semibold text-foreground">
+            Today&apos;s agenda
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Calendar events will appear here when a calendar source is connected.
+          </p>
+        </div>
+      </div>
+
+      {events.length > 0 ? (
+        <ol className="mt-5 space-y-3">
+          {events.map((event) => (
+            <li
+              key={event.id}
+              className="rounded-2xl border border-border/70 bg-background/70 px-4 py-3"
+            >
+              <p className="text-sm font-semibold text-primary">{event.timeLabel}</p>
+              <p className="mt-1 font-medium text-foreground">{event.title}</p>
+              {event.location ? (
+                <p className="mt-1 text-sm text-muted-foreground">{event.location}</p>
+              ) : null}
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <div className="mt-5 rounded-2xl border border-dashed border-border bg-muted/30 px-4 py-5">
+          <p className="text-sm font-medium text-foreground">No calendar events for today yet.</p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            If nothing is scheduled, that can be useful information too. You can keep the day simple
+            or add events from Calendar when that flow is ready.
+          </p>
+          <Button asChild variant="outline" className="mt-4 rounded-full">
+            <Link href="/calendar">Open Calendar</Link>
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/today/TodayHabitStrip.tsx
+++ b/apps/web/components/today/TodayHabitStrip.tsx
@@ -1,0 +1,74 @@
+import type { Id } from "@/convex/_generated/dataModel";
+import { Flame } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+type TodayHabit = {
+  _id: Id<"habits">;
+  name: string;
+  cadence: "daily" | "weekly";
+  currentStreak: number;
+};
+
+type TodayHabitStripProps = {
+  habits: TodayHabit[];
+};
+
+export function TodayHabitStrip({ habits }: TodayHabitStripProps) {
+  const visibleHabits = habits.slice(0, 5);
+  const hiddenHabitCount = Math.max(habits.length - visibleHabits.length, 0);
+
+  return (
+    <section
+      className="rounded-3xl border border-border/80 bg-card/90 p-5 shadow-[0_10px_30px_rgba(26,25,23,0.08)]"
+      aria-labelledby="today-habit-strip-heading"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <Flame className="h-5 w-5" aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2 id="today-habit-strip-heading" className="font-heading text-xl font-semibold text-foreground">
+            Habit strip
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            A small glance at routines you may want to keep in view today.
+          </p>
+        </div>
+      </div>
+
+      {visibleHabits.length > 0 ? (
+        <div className="mt-5 flex flex-wrap gap-3">
+          {visibleHabits.map((habit) => (
+            <Link
+              key={habit._id}
+              href={`/habits/${habit._id}`}
+              className="min-h-11 rounded-full border border-border bg-background/75 px-4 py-2 text-sm transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+            >
+              <span className="font-medium text-foreground">{habit.name}</span>
+              <span className="ml-2 text-muted-foreground">
+                {habit.currentStreak > 0 ? `${habit.currentStreak} in a row` : habit.cadence}
+              </span>
+            </Link>
+          ))}
+          {hiddenHabitCount > 0 ? (
+            <span className="inline-flex min-h-11 items-center rounded-full border border-dashed border-border px-4 py-2 text-sm text-muted-foreground">
+              +{hiddenHabitCount} more
+            </span>
+          ) : null}
+        </div>
+      ) : (
+        <div className="mt-5 rounded-2xl border border-dashed border-border bg-muted/30 px-4 py-5">
+          <p className="text-sm font-medium text-foreground">No habits pinned here yet.</p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Habits can stay gentle. Add one tiny repeatable thing when you want this strip to
+            hold it for you.
+          </p>
+          <Button asChild variant="outline" className="mt-4 rounded-full">
+            <Link href="/habits">Open Habits</Link>
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/today/TodayScreen.tsx
+++ b/apps/web/components/today/TodayScreen.tsx
@@ -6,8 +6,10 @@ import { SoftCard } from "@/components/soft-editorial/SoftCard";
 import { Button } from "@/components/ui/button";
 import { api } from "@/convex/_generated/api";
 import { useLocalDayBounds } from "@/lib/useLocalDayBounds";
+import { TodayAgenda } from "./TodayAgenda";
 import { TodayBrainDumpPanel } from "./TodayBrainDumpPanel";
 import { TodayGreeting } from "./TodayGreeting";
+import { TodayHabitStrip } from "./TodayHabitStrip";
 import { TodayQuickAdd } from "./TodayQuickAdd";
 import { TodayTaskList } from "./TodayTaskList";
 
@@ -26,10 +28,13 @@ export function TodayScreen() {
     api.tasks.listToday,
     isAuthenticated && hasConvexUser ? { dueFrom: bounds.startMs, dueTo: bounds.endMs } : "skip"
   );
+  const habits = useQuery(api.habits.list, isAuthenticated && hasConvexUser ? {} : "skip");
 
   const isLoading =
     isAuthLoading ||
-    (isAuthenticated && (profile === undefined || (hasConvexUser && todayTasks === undefined)));
+    (isAuthenticated &&
+      (profile === undefined ||
+        (hasConvexUser && (todayTasks === undefined || habits === undefined))));
 
   if (isLoading) {
     return (
@@ -46,7 +51,7 @@ export function TodayScreen() {
     );
   }
 
-  if (!isAuthenticated || !profile || !todayTasks) {
+  if (!isAuthenticated || !profile || !todayTasks || !habits) {
     return (
       <div className="container mx-auto max-w-5xl px-6 py-16 text-center">
         <SoftCard className="mx-auto max-w-xl">
@@ -67,6 +72,10 @@ export function TodayScreen() {
       <div className="space-y-8">
         <TodayGreeting greetingName={profile.greetingName} />
         <TodayBrainDumpPanel dueAt={bounds.endMs - 1} />
+        <div className="grid gap-6 xl:grid-cols-2">
+          <TodayAgenda />
+          <TodayHabitStrip habits={habits} />
+        </div>
         <div className="grid gap-6 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] xl:items-start">
           <TodayQuickAdd dueAt={bounds.endMs - 1} />
           <TodayTaskList tasks={todayTasks} />

--- a/apps/web/components/today/TodayTaskList.tsx
+++ b/apps/web/components/today/TodayTaskList.tsx
@@ -35,8 +35,6 @@ export function TodayTaskList({ tasks }: TodayTaskListProps) {
   const toggleCompletion = useMutation(api.tasks.toggleCompletion);
 
   const activeTasks = tasks.filter((task) => task.status !== "done");
-  const visibleTasks = activeTasks.slice(0, 3);
-  const hiddenTaskCount = Math.max(activeTasks.length - visibleTasks.length, 0);
   const hasCompletedEverything = tasks.length > 0 && activeTasks.length === 0;
 
   return (
@@ -60,9 +58,7 @@ export function TodayTaskList({ tasks }: TodayTaskListProps) {
               ? "Nothing on the plan yet."
               : hasCompletedEverything
                 ? "Everything due today is done."
-                : hiddenTaskCount > 0
-                  ? `Showing ${visibleTasks.length} of ${activeTasks.length} open today.`
-                  : `${activeTasks.length} still open today.`}
+                : `${activeTasks.length} still open today.`}
           </p>
         </div>
       </div>
@@ -80,7 +76,7 @@ export function TodayTaskList({ tasks }: TodayTaskListProps) {
       ) : (
         <div className="space-y-3">
           <ul className="space-y-3">
-            {visibleTasks.map((task) => {
+            {activeTasks.map((task) => {
               const isDone = task.status === "done";
 
               return (
@@ -144,15 +140,13 @@ export function TodayTaskList({ tasks }: TodayTaskListProps) {
             })}
           </ul>
 
-          {hiddenTaskCount > 0 ? (
-            <p className="text-sm text-muted-foreground">
-              {hiddenTaskCount} more open {hiddenTaskCount === 1 ? "task is" : "tasks are"} waiting in{" "}
-              <Link href="/tasks" className="font-semibold text-primary underline-offset-4 hover:underline">
-                Tasks
-              </Link>
-              .
-            </p>
-          ) : null}
+          <p className="text-sm text-muted-foreground">
+            Want the full library view?{" "}
+            <Link href="/tasks" className="font-semibold text-primary underline-offset-4 hover:underline">
+              Open Tasks
+            </Link>
+            .
+          </p>
         </div>
       )}
     </section>

--- a/apps/web/lib/todayBounds.test.ts
+++ b/apps/web/lib/todayBounds.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { getLocalDayBoundsMs, nextLocalDayRolloverDelayMs } from "./todayBounds";
 
 describe("getLocalDayBoundsMs", () => {
-  test("returns a 24h half-open window in local time", () => {
+  test("returns a half-open local-day window", () => {
     const noon = new Date(2026, 3, 15, 12, 30, 45);
     const bounds = getLocalDayBoundsMs(noon);
-    expect(bounds.endMs - bounds.startMs).toBe(24 * 60 * 60 * 1000);
     expect(bounds.startMs).toBeLessThanOrEqual(noon.getTime());
     expect(bounds.endMs).toBeGreaterThan(noon.getTime());
   });

--- a/apps/web/lib/todayBounds.ts
+++ b/apps/web/lib/todayBounds.ts
@@ -1,7 +1,7 @@
 /** Start/end of the local calendar day as Unix ms; `endMs` is exclusive. */
 export function getLocalDayBoundsMs(d = new Date()): { startMs: number; endMs: number } {
   const start = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-  const end = start + 24 * 60 * 60 * 1000;
+  const end = new Date(d.getFullYear(), d.getMonth(), d.getDate() + 1).getTime();
   return { startMs: start, endMs: end };
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
+        "@playwright/test": "^1.61.1",
         "@types/bun": "^1.3.13",
         "@types/node": "^20.19.0",
         "turbo": "^2.3.3",
@@ -573,6 +574,8 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
+
     "@polar-sh/adapter-utils": ["@polar-sh/adapter-utils@0.4.4", "", { "dependencies": { "@polar-sh/sdk": "^0.46.0" } }, "sha512-0fvscT82EMoo+otgnw7YsbzxmatxTpc457DytZY9Lr+6B9XNBI/wP7THK0nV3Qdaipd66Pp9hyZI9Dzusj1KzQ=="],
 
     "@polar-sh/nextjs": ["@polar-sh/nextjs@0.9.4", "", { "dependencies": { "@polar-sh/adapter-utils": "0.4.4", "@polar-sh/sdk": "^0.46.0" }, "peerDependencies": { "next": "^15.0.0 || ^16.0.0" } }, "sha512-CN6qjaVXVR5OojcpjtlXF7FcVnCEXAKB4vyOECP3n3YjD7DdJ4/PPtKvc2/TVXC9bM8m6pcUOI7Y9f7K5T0jNA=="],
@@ -1099,7 +1102,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1420,6 +1423,10 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
@@ -1893,6 +1900,8 @@
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -1930,6 +1939,8 @@
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -1,7 +1,6 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { requireUser } from "./lib/requireUser";
-import { fetchCurrentUser } from "./users";
 
 export const list = query({
   args: {
@@ -193,13 +192,7 @@ export const listToday = query({
     dueTo: v.number(),
   },
   handler: async (ctx, args) => {
-    // Match `users.getProfile` (fetchCurrentUser), not requireUser: avoids throwing when
-    // the client auth race briefly has no `email` on the identity, and returns [] if
-    // there is no signed-in app user.
-    const user = await fetchCurrentUser(ctx);
-    if (!user) {
-      return [];
-    }
+    const user = await requireUser(ctx);
     const rows = await ctx.db
       .query("tasks")
       .withIndex("by_userId", (q) => q.eq("userId", user._id))

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -3,223 +3,256 @@ import { mutation, query } from "./_generated/server";
 import { requireUser } from "./lib/requireUser";
 
 export const list = query({
-  args: {
-    status: v.optional(
-      v.union(
-        v.literal("todo"),
-        v.literal("in_progress"),
-        v.literal("done"),
-        v.literal("cancelled"),
-      ),
-    ),
-    search: v.optional(v.string()),
-    /** When both set, only tasks with `dueAt` in [dueFrom, dueTo) (e.g. client “today” window). */
-    dueFrom: v.optional(v.number()),
-    dueTo: v.optional(v.number()),
-  },
-  handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
-    let rows = await ctx.db
-      .query("tasks")
-      .withIndex("by_userId", (q) => q.eq("userId", user._id))
-      .collect();
+	args: {
+		status: v.optional(
+			v.union(
+				v.literal("todo"),
+				v.literal("in_progress"),
+				v.literal("done"),
+				v.literal("cancelled"),
+			),
+		),
+		search: v.optional(v.string()),
+		/** When both set, only tasks with `dueAt` in [dueFrom, dueTo) (e.g. client “today” window). */
+		dueFrom: v.optional(v.number()),
+		dueTo: v.optional(v.number()),
+	},
+	handler: async (ctx, args) => {
+		const user = await requireUser(ctx);
+		let rows = await ctx.db
+			.query("tasks")
+			.withIndex("by_userId", (q) => q.eq("userId", user._id))
+			.collect();
 
-    if (args.status) {
-      rows = rows.filter((t) => t.status === args.status);
-    }
-    if (args.search?.trim()) {
-      const q = args.search.trim().toLowerCase();
-      rows = rows.filter(
-        (t) =>
-          t.title.toLowerCase().includes(q) ||
-          (t.description?.toLowerCase().includes(q) ?? false),
-      );
-    }
-    if (args.dueFrom !== undefined && args.dueTo !== undefined) {
-      rows = rows.filter(
-        (t) =>
-          t.dueAt !== undefined &&
-          t.dueAt >= args.dueFrom! &&
-          t.dueAt < args.dueTo!,
-      );
-    }
-    rows.sort((a, b) => (b.updatedAt ?? b.createdAt) - (a.updatedAt ?? a.createdAt));
-    return rows;
-  },
+		if (args.status) {
+			rows = rows.filter((t) => t.status === args.status);
+		}
+		if (args.search?.trim()) {
+			const q = args.search.trim().toLowerCase();
+			rows = rows.filter(
+				(t) =>
+					t.title.toLowerCase().includes(q) ||
+					(t.description?.toLowerCase().includes(q) ?? false),
+			);
+		}
+		if (args.dueFrom !== undefined && args.dueTo !== undefined) {
+			rows = rows.filter(
+				(t) =>
+					t.dueAt !== undefined &&
+					t.dueAt >= args.dueFrom! &&
+					t.dueAt < args.dueTo!,
+			);
+		}
+		rows.sort(
+			(a, b) => (b.updatedAt ?? b.createdAt) - (a.updatedAt ?? a.createdAt),
+		);
+		return rows;
+	},
 });
 
 /** Tasks due on a given calendar day (local interpretation: day boundaries passed as ms). */
 export const listDueInRange = query({
-  args: {
-    startMs: v.number(),
-    endMs: v.number(),
-  },
-  handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
-    const rows = await ctx.db
-      .query("tasks")
-      .withIndex("by_userId", (q) => q.eq("userId", user._id))
-      .collect();
-    return rows.filter(
-      (t) =>
-        t.dueAt !== undefined &&
-        t.dueAt >= args.startMs &&
-        t.dueAt < args.endMs &&
-        t.status !== "cancelled",
-    );
-  },
+	args: {
+		startMs: v.number(),
+		endMs: v.number(),
+	},
+	handler: async (ctx, args) => {
+		const user = await requireUser(ctx);
+		const rows = await ctx.db
+			.query("tasks")
+			.withIndex("by_userId", (q) => q.eq("userId", user._id))
+			.collect();
+		return rows.filter(
+			(t) =>
+				t.dueAt !== undefined &&
+				t.dueAt >= args.startMs &&
+				t.dueAt < args.endMs &&
+				t.status !== "cancelled",
+		);
+	},
 });
 
 export const create = mutation({
-  args: {
-    title: v.string(),
-    description: v.optional(v.string()),
-    status: v.optional(
-      v.union(
-        v.literal("todo"),
-        v.literal("in_progress"),
-        v.literal("done"),
-        v.literal("cancelled"),
-      ),
-    ),
-    priority: v.optional(
-      v.union(v.literal("low"), v.literal("medium"), v.literal("high")),
-    ),
-    dueAt: v.optional(v.number()),
-  },
-  handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
-    const now = Date.now();
-    return ctx.db.insert("tasks", {
-      userId: user._id,
-      title: args.title.trim(),
-      description: args.description?.trim(),
-      status: args.status ?? "todo",
-      priority: args.priority ?? "medium",
-      dueAt: args.dueAt,
-      createdAt: now,
-      updatedAt: now,
-    });
-  },
+	args: {
+		title: v.string(),
+		description: v.optional(v.string()),
+		status: v.optional(
+			v.union(
+				v.literal("todo"),
+				v.literal("in_progress"),
+				v.literal("done"),
+				v.literal("cancelled"),
+			),
+		),
+		priority: v.optional(
+			v.union(v.literal("low"), v.literal("medium"), v.literal("high")),
+		),
+		dueAt: v.optional(v.number()),
+	},
+	handler: async (ctx, args) => {
+		const user = await requireUser(ctx);
+		const now = Date.now();
+		return ctx.db.insert("tasks", {
+			userId: user._id,
+			title: args.title.trim(),
+			description: args.description?.trim(),
+			status: args.status ?? "todo",
+			priority: args.priority ?? "medium",
+			dueAt: args.dueAt,
+			createdAt: now,
+			updatedAt: now,
+		});
+	},
 });
 
 export const update = mutation({
-  args: {
-    taskId: v.id("tasks"),
-    title: v.optional(v.string()),
-    description: v.optional(v.union(v.string(), v.null())),
-    status: v.optional(
-      v.union(
-        v.literal("todo"),
-        v.literal("in_progress"),
-        v.literal("done"),
-        v.literal("cancelled"),
-      ),
-    ),
-    priority: v.optional(
-      v.union(v.literal("low"), v.literal("medium"), v.literal("high")),
-    ),
-    dueAt: v.optional(v.union(v.number(), v.null())),
-  },
-  handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
-    const task = await ctx.db.get(args.taskId);
-    if (!task || task.userId !== user._id) {
-      throw new Error("Task not found");
-    }
-    const now = Date.now();
-    const patch: Record<string, unknown> = { updatedAt: now };
-    if (args.title !== undefined) patch.title = args.title.trim();
-    if (args.description !== undefined) {
-      patch.description = args.description === null ? undefined : args.description;
-    }
-    if (args.status !== undefined) patch.status = args.status;
-    if (args.priority !== undefined) patch.priority = args.priority;
-    if (args.dueAt !== undefined) {
-      patch.dueAt = args.dueAt === null ? undefined : args.dueAt;
-    }
-    await ctx.db.patch(args.taskId, patch as typeof task);
-    return args.taskId;
-  },
+	args: {
+		taskId: v.id("tasks"),
+		title: v.optional(v.string()),
+		description: v.optional(v.union(v.string(), v.null())),
+		status: v.optional(
+			v.union(
+				v.literal("todo"),
+				v.literal("in_progress"),
+				v.literal("done"),
+				v.literal("cancelled"),
+			),
+		),
+		priority: v.optional(
+			v.union(v.literal("low"), v.literal("medium"), v.literal("high")),
+		),
+		dueAt: v.optional(v.union(v.number(), v.null())),
+	},
+	handler: async (ctx, args) => {
+		const user = await requireUser(ctx);
+		const task = await ctx.db.get(args.taskId);
+		if (!task || task.userId !== user._id) {
+			throw new Error("Task not found");
+		}
+		const now = Date.now();
+		const patch: Record<string, unknown> = { updatedAt: now };
+		if (args.title !== undefined) patch.title = args.title.trim();
+		if (args.description !== undefined) {
+			patch.description =
+				args.description === null ? undefined : args.description;
+		}
+		if (args.status !== undefined) patch.status = args.status;
+		if (args.priority !== undefined) patch.priority = args.priority;
+		if (args.dueAt !== undefined) {
+			patch.dueAt = args.dueAt === null ? undefined : args.dueAt;
+		}
+		await ctx.db.patch(args.taskId, patch as typeof task);
+		return args.taskId;
+	},
 });
 
 export const remove = mutation({
-  args: { taskId: v.id("tasks") },
-  handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
-    const task = await ctx.db.get(args.taskId);
-    if (!task || task.userId !== user._id) {
-      throw new Error("Task not found");
-    }
-    await ctx.db.delete(args.taskId);
-    return { success: true };
-  },
+	args: { taskId: v.id("tasks") },
+	handler: async (ctx, args) => {
+		const user = await requireUser(ctx);
+		const task = await ctx.db.get(args.taskId);
+		if (!task || task.userId !== user._id) {
+			throw new Error("Task not found");
+		}
+		await ctx.db.delete(args.taskId);
+		return { success: true };
+	},
 });
 
 const QUICK_TITLE_MAX = 280;
 
+const taskStatusValidator = v.union(
+	v.literal("todo"),
+	v.literal("in_progress"),
+	v.literal("done"),
+	v.literal("cancelled"),
+);
+
+const taskPriorityValidator = v.union(
+	v.literal("low"),
+	v.literal("medium"),
+	v.literal("high"),
+);
+
+const todayTaskValidator = v.object({
+	_id: v.id("tasks"),
+	_creationTime: v.number(),
+	userId: v.id("users"),
+	title: v.string(),
+	description: v.optional(v.string()),
+	status: taskStatusValidator,
+	priority: taskPriorityValidator,
+	dueAt: v.optional(v.number()),
+	createdAt: v.number(),
+	updatedAt: v.number(),
+	deletedAt: v.optional(v.number()),
+});
+
 /** Quick-add a task for today — minimal args, sensible defaults. */
 export const createQuick = mutation({
-  args: {
-    title: v.string(),
-    dueAt: v.optional(v.number()),
-  },
-  handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
-    const trimmed = args.title.trim();
-    if (!trimmed) {
-      throw new Error("Title cannot be empty.");
-    }
-    const title =
-      trimmed.length > QUICK_TITLE_MAX ? `${trimmed.slice(0, QUICK_TITLE_MAX - 3)}...` : trimmed;
-    const now = Date.now();
-    return ctx.db.insert("tasks", {
-      userId: user._id,
-      title,
-      status: "todo",
-      priority: "medium",
-      dueAt: args.dueAt,
-      createdAt: now,
-      updatedAt: now,
-    });
-  },
+	args: {
+		title: v.string(),
+		dueAt: v.optional(v.number()),
+	},
+	handler: async (ctx, args) => {
+		const user = await requireUser(ctx);
+		const trimmed = args.title.trim();
+		if (!trimmed) {
+			throw new Error("Title cannot be empty.");
+		}
+		const title =
+			trimmed.length > QUICK_TITLE_MAX
+				? `${trimmed.slice(0, QUICK_TITLE_MAX - 3)}...`
+				: trimmed;
+		const now = Date.now();
+		return ctx.db.insert("tasks", {
+			userId: user._id,
+			title,
+			status: "todo",
+			priority: "medium",
+			dueAt: args.dueAt,
+			createdAt: now,
+			updatedAt: now,
+		});
+	},
 });
 
 /** Tasks due within a local-day window — used by the Today screen. */
 export const listToday = query({
-  args: {
-    dueFrom: v.number(),
-    dueTo: v.number(),
-  },
-  handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
-    const rows = await ctx.db
-      .query("tasks")
-      .withIndex("by_userId", (q) => q.eq("userId", user._id))
-      .collect();
-    return rows
-      .filter(
-        (t) =>
-          t.dueAt !== undefined &&
-          t.dueAt >= args.dueFrom &&
-          t.dueAt < args.dueTo &&
-          t.status !== "cancelled",
-      )
-      .sort((a, b) => (a.dueAt ?? 0) - (b.dueAt ?? 0));
-  },
+	args: {
+		dueFrom: v.number(),
+		dueTo: v.number(),
+	},
+	returns: v.array(todayTaskValidator),
+	handler: async (ctx, args) => {
+		const user = await requireUser(ctx);
+		const rows = await ctx.db
+			.query("tasks")
+			.withIndex("by_userId", (q) => q.eq("userId", user._id))
+			.collect();
+		return rows
+			.filter(
+				(t) =>
+					t.dueAt !== undefined &&
+					t.dueAt >= args.dueFrom &&
+					t.dueAt < args.dueTo &&
+					t.status !== "cancelled",
+			)
+			.sort((a, b) => (a.dueAt ?? 0) - (b.dueAt ?? 0));
+	},
 });
 
 /** Toggle a task between todo and done. */
 export const toggleCompletion = mutation({
-  args: { taskId: v.id("tasks") },
-  handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
-    const task = await ctx.db.get(args.taskId);
-    if (!task || task.userId !== user._id) {
-      throw new Error("Task not found");
-    }
-    const next = task.status === "done" ? "todo" : "done";
-    await ctx.db.patch(args.taskId, { status: next, updatedAt: Date.now() });
-    return { taskId: args.taskId, status: next };
-  },
+	args: { taskId: v.id("tasks") },
+	handler: async (ctx, args) => {
+		const user = await requireUser(ctx);
+		const task = await ctx.db.get(args.taskId);
+		if (!task || task.userId !== user._id) {
+			throw new Error("Task not found");
+		}
+		const next = task.status === "done" ? "todo" : "done";
+		await ctx.db.patch(args.taskId, { status: next, updatedAt: Date.now() });
+		return { taskId: args.taskId, status: next };
+	},
 });

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
+    "@playwright/test": "^1.61.1",
     "@types/bun": "^1.3.13",
     "@types/node": "^20.19.0",
     "turbo": "^2.3.3"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "@playwright/test";
+
+const port = 3100;
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 120_000,
+  expect: {
+    timeout: 20_000,
+  },
+  use: {
+    baseURL,
+    channel: "chrome",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: [
+      "CONVEX_AGENT_MODE=anonymous",
+      "NEXT_TELEMETRY_DISABLED=1",
+      "bun x convex dev --typecheck disable --tail-logs disable --run-sh 'set -a; . ./.env.local; set +a; node tests/e2e/setup-convex-auth-env.mjs && cd apps/web && NEXT_PUBLIC_CONVEX_URL=\"$CONVEX_URL\" CONVEX_SITE_URL=\"$CONVEX_SITE_URL\" bun run dev -- --port 3100 --hostname 127.0.0.1'",
+    ].join(" "),
+    url: `${baseURL}/sign-up`,
+    timeout: 180_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/e2e/setup-convex-auth-env.mjs
+++ b/tests/e2e/setup-convex-auth-env.mjs
@@ -1,0 +1,29 @@
+import { spawnSync } from "node:child_process";
+import { generateKeyPairSync } from "node:crypto";
+
+function runConvexEnvSet(name, value) {
+  const result = spawnSync("bun", ["x", "convex", "env", "set", name, "--", value], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+});
+const privateKeyPem = privateKey
+  .export({ format: "pem", type: "pkcs8" })
+  .toString()
+  .trimEnd()
+  .replace(/\n/g, " ");
+const publicJwk = publicKey.export({ format: "jwk" });
+const jwks = JSON.stringify({ keys: [{ use: "sig", ...publicJwk }] });
+
+runConvexEnvSet("JWT_PRIVATE_KEY", privateKeyPem);
+runConvexEnvSet("JWKS", jwks);
+runConvexEnvSet("BETA_ALLOWLIST_EMAILS", "today-e2e@example.com,today-e2e-clean@example.com");
+runConvexEnvSet("BETA_FOUNDER_EMAIL", "today-e2e-founder@example.com");

--- a/tests/e2e/today.spec.ts
+++ b/tests/e2e/today.spec.ts
@@ -1,55 +1,74 @@
 import { expect, test } from "@playwright/test";
 
-test("Today core flow creates, completes, and reloads a persisted task", async ({ page }) => {
-  const consoleErrors: string[] = [];
-  page.on("console", (message) => {
-    if (message.type() === "error") {
-      consoleErrors.push(message.text());
-    }
-  });
+const isBunTestRunner = typeof Bun !== "undefined";
 
-  const email = "today-e2e-clean@example.com";
-  const password = "today-e2e-pass-1234";
-  const taskTitle = `Tiny next step ${Date.now()}`;
+if (!isBunTestRunner) {
+	test("Today core flow creates, completes, and reloads a persisted task", async ({
+		page,
+	}) => {
+		const consoleErrors: string[] = [];
+		page.on("console", (message) => {
+			if (message.type() === "error") {
+				consoleErrors.push(message.text());
+			}
+		});
 
-  await page.goto(`/sign-up?next=${encodeURIComponent("/today")}`);
-  await page.getByLabel("Email").fill(email);
-  await page.getByRole("textbox", { name: "Password" }).fill(password);
-  await page.getByLabel("Accept terms and privacy policy").click();
-  await page.getByRole("button", { name: "Create account" }).click();
+		const email = "today-e2e-clean@example.com";
+		const password = "today-e2e-pass-1234";
+		const taskTitle = `Tiny next step ${Date.now()}`;
 
-  const signUpResult = await Promise.race([
-    page.waitForURL(/\/today$/, { timeout: 20_000 }).then(() => "signed-up" as const),
-    page.getByRole("alert").waitFor({ timeout: 20_000 }).then(() => "sign-up-error" as const),
-  ]);
+		await page.goto(`/sign-up?next=${encodeURIComponent("/today")}`);
+		await page.getByLabel("Email").fill(email);
+		await page.getByRole("textbox", { name: "Password" }).fill(password);
+		await page.getByLabel("Accept terms and privacy policy").click();
+		await page.getByRole("button", { name: "Create account" }).click();
 
-  if (signUpResult === "sign-up-error") {
-    await page.goto(`/sign-in?next=${encodeURIComponent("/today")}`);
-    await page.getByLabel("Email").fill(email);
-    await page.getByRole("textbox", { name: "Password" }).fill(password);
-    await page.getByRole("button", { name: "Sign in" }).click();
-  }
+		const signUpResult = await Promise.race([
+			page
+				.waitForURL(/\/today$/, { timeout: 20_000 })
+				.then(() => "signed-up" as const),
+			page
+				.getByRole("alert")
+				.waitFor({ timeout: 20_000 })
+				.then(() => "sign-up-error" as const),
+		]);
 
-  await expect(page).toHaveURL(/\/today$/);
-  await expect(page.getByRole("heading", { name: /^Hi,/ })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Today's agenda" })).toBeVisible();
-  await expect(page.getByText("No calendar events for today yet.")).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Habit strip" })).toBeVisible();
-  await expect(page.getByText("Brain dump to plan")).toBeVisible();
+		if (signUpResult === "sign-up-error") {
+			await page.goto(`/sign-in?next=${encodeURIComponent("/today")}`);
+			await page.getByLabel("Email").fill(email);
+			await page.getByRole("textbox", { name: "Password" }).fill(password);
+			await page.getByRole("button", { name: "Sign in" }).click();
+		}
 
-  const quickAddInput = page.getByLabel("Add something small for today");
-  await quickAddInput.fill(taskTitle);
-  await page.getByRole("button", { name: /^Add$/ }).click();
-  await expect(quickAddInput).toHaveValue("");
-  await page.reload();
-  await expect(page.getByText(taskTitle)).toBeVisible();
+		await expect(page).toHaveURL(/\/today$/);
+		await expect(page.getByRole("heading", { name: /^Hi,/ })).toBeVisible();
+		await expect(
+			page.getByRole("heading", { name: "Today's agenda" }),
+		).toBeVisible();
+		await expect(
+			page.getByText("No calendar events for today yet."),
+		).toBeVisible();
+		await expect(
+			page.getByRole("heading", { name: "Habit strip" }),
+		).toBeVisible();
+		await expect(page.getByText("Brain dump to plan")).toBeVisible();
 
-  await page.getByRole("button", { name: `Mark ${taskTitle} complete` }).click();
-  await expect(page.getByText(taskTitle)).not.toBeVisible();
+		const quickAddInput = page.getByLabel("Add something small for today");
+		await quickAddInput.fill(taskTitle);
+		await page.getByRole("button", { name: /^Add$/ }).click();
+		await expect(quickAddInput).toHaveValue("");
+		await page.reload();
+		await expect(page.getByText(taskTitle)).toBeVisible();
 
-  await page.reload();
-  await expect(page.getByText(taskTitle)).not.toBeVisible();
+		await page
+			.getByRole("button", { name: `Mark ${taskTitle} complete` })
+			.click();
+		await expect(page.getByText(taskTitle)).not.toBeVisible();
 
-  await page.waitForLoadState("networkidle");
-  expect(consoleErrors).toEqual([]);
-});
+		await page.reload();
+		await expect(page.getByText(taskTitle)).not.toBeVisible();
+
+		await page.waitForLoadState("networkidle");
+		expect(consoleErrors).toEqual([]);
+	});
+}

--- a/tests/e2e/today.spec.ts
+++ b/tests/e2e/today.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+
+test("Today core flow creates, completes, and reloads a persisted task", async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  const email = "today-e2e-clean@example.com";
+  const password = "today-e2e-pass-1234";
+  const taskTitle = `Tiny next step ${Date.now()}`;
+
+  await page.goto(`/sign-up?next=${encodeURIComponent("/today")}`);
+  await page.getByLabel("Email").fill(email);
+  await page.getByRole("textbox", { name: "Password" }).fill(password);
+  await page.getByLabel("Accept terms and privacy policy").click();
+  await page.getByRole("button", { name: "Create account" }).click();
+
+  const signUpResult = await Promise.race([
+    page.waitForURL(/\/today$/, { timeout: 20_000 }).then(() => "signed-up" as const),
+    page.getByRole("alert").waitFor({ timeout: 20_000 }).then(() => "sign-up-error" as const),
+  ]);
+
+  if (signUpResult === "sign-up-error") {
+    await page.goto(`/sign-in?next=${encodeURIComponent("/today")}`);
+    await page.getByLabel("Email").fill(email);
+    await page.getByRole("textbox", { name: "Password" }).fill(password);
+    await page.getByRole("button", { name: "Sign in" }).click();
+  }
+
+  await expect(page).toHaveURL(/\/today$/);
+  await expect(page.getByRole("heading", { name: /^Hi,/ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Today's agenda" })).toBeVisible();
+  await expect(page.getByText("No calendar events for today yet.")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Habit strip" })).toBeVisible();
+  await expect(page.getByText("Brain dump to plan")).toBeVisible();
+
+  const quickAddInput = page.getByLabel("Add something small for today");
+  await quickAddInput.fill(taskTitle);
+  await page.getByRole("button", { name: /^Add$/ }).click();
+  await expect(quickAddInput).toHaveValue("");
+  await page.reload();
+  await expect(page.getByText(taskTitle)).toBeVisible();
+
+  await page.getByRole("button", { name: `Mark ${taskTitle} complete` }).click();
+  await expect(page.getByText(taskTitle)).not.toBeVisible();
+
+  await page.reload();
+  await expect(page.getByText(taskTitle)).not.toBeVisible();
+
+  await page.waitForLoadState("networkidle");
+  expect(consoleErrors).toEqual([]);
+});

--- a/tests/unit/today_date.test.ts
+++ b/tests/unit/today_date.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { getLocalDayBoundsMs, nextLocalDayRolloverDelayMs } from "../../apps/web/lib/todayBounds";
+
+process.env.TZ = "America/New_York";
+
+describe("Today local date helpers", () => {
+  test("uses the next local midnight as the exclusive end on DST spring-forward days", () => {
+    const sample = new Date(2026, 2, 8, 12, 0, 0);
+    const bounds = getLocalDayBoundsMs(sample);
+    const end = new Date(bounds.endMs);
+
+    expect(end.getFullYear()).toBe(2026);
+    expect(end.getMonth()).toBe(2);
+    expect(end.getDate()).toBe(9);
+    expect(end.getHours()).toBe(0);
+    expect(end.getMinutes()).toBe(0);
+    expect(bounds.endMs - bounds.startMs).toBe(23 * 60 * 60 * 1000);
+  });
+
+  test("keeps quick-add dueAt = endMs - 1 inside the local day", () => {
+    const bounds = getLocalDayBoundsMs(new Date(2026, 10, 1, 9, 30, 0));
+    const dueAt = bounds.endMs - 1;
+
+    expect(dueAt).toBeGreaterThanOrEqual(bounds.startMs);
+    expect(dueAt).toBeLessThan(bounds.endMs);
+  });
+
+  test("schedules the next rollover after the exclusive end of today", () => {
+    const almostMidnight = new Date(2026, 2, 8, 23, 59, 59, 900).getTime();
+    const delay = nextLocalDayRolloverDelayMs(almostMidnight);
+    const { endMs } = getLocalDayBoundsMs(new Date(almostMidnight));
+
+    expect(almostMidnight + delay).toBeGreaterThanOrEqual(endMs);
+    expect(delay).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Today is the MVP execution home, so this change fills the missing agenda and habit-strip surfaces and hardens the task read/write path used by quick add and completion. It also adds the requested objective verification commands so future runs can prove create, complete, reload persistence, local-day bounds, and console health.

## Linked task(s)

Task: T-003
Linear: TEMPO-115

## Screenshots / screen recording

[today_core_flow_walkthrough.mp4](https://cursor.com/agents/bc-e13547cf-bd32-4525-bfa5-496eea94f992/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoday_core_flow_walkthrough.mp4)

## Test plan

- [x] Local `bun run typecheck` passes
- [x] Local `bun run lint` passes (existing `@tempo/ui` warning: unused suppression in `src/icons/index.tsx`)
- [x] Root `bun test` passes
- [x] Local `bun x convex codegen` passes
- [x] Relevant unit / integration tests added or updated
- [x] Manual QA performed: sign in, verify Today sections, quick-add task, reload, complete task, reload again
- [x] Reproduces the acceptance criteria below
- [x] `bun test tests/unit/today_date.test.ts`
- [x] `bunx playwright test tests/e2e/today.spec.ts`

## Acceptance criteria

- [x] Today route loads after login.
- [x] Quick task add persists.
- [x] Task completion persists.
- [x] Today's agenda uses real calendar/event data if available, or a clear empty state.
- [x] Brain dump panel is reachable.
- [x] Habit strip is visible.

Objective verification:

- [x] Browser proof: create task.
- [x] Browser proof: complete task.
- [x] Reload proof.
- [x] Local day/date tests.
- [x] Console/error check.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). N/A: no AI-originated writes added.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). N/A: no schema changes; changed public query now has an explicit `returns` validator.
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7).
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8).
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13). N/A: Playwright generates throwaway local Convex Auth keys at runtime only.
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9).

## Owner tag (§14)

- [ ] `cursor-ide`
- [x] `cursor-cloud-1`
- [ ] `cursor-cloud-2`
- [ ] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

## Reviewer

Amit (`human-amit`).

## Notes

The graph/code inspection showed no calendar/event primitive exists yet, so the Today agenda intentionally renders the required clear empty state instead of inventing a calendar table or API.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TEMPO-115](https://linear.app/amit-levin/issue/TEMPO-115/t-003-today-core-flow)

<div><a href="https://cursor.com/agents/bc-e13547cf-bd32-4525-bfa5-496eea94f992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e13547cf-bd32-4525-bfa5-496eea94f992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

