### PR TITLE
feat(calendar): share event source across views

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -29,3 +29,7 @@ NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
 # Set to "true" to expose the passkey (WebAuthn) settings page and sign-in
 # button. Leave unset or empty to hide passkeys from the UI (flag-off state).
 NEXT_PUBLIC_ENABLE_PASSKEYS=
+
+# Test-only: set to "1" while running calendar e2e tests against local dev.
+# Ignored in production; never configure in Vercel Production/Preview.
+TEMPO_E2E_PUBLIC_CALENDAR=

--- a/apps/web/app/(tempo)/calendar/error.tsx
+++ b/apps/web/app/(tempo)/calendar/error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+export default function CalendarError({
+  error: _error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col gap-5 p-8">
+      <div className="rounded-3xl border border-border bg-card p-6 shadow-soft">
+        <p className="font-eyebrow text-muted-foreground">Calendar</p>
+        <h1 className="mt-3 text-h2 font-serif">We could not load this calendar view.</h1>
+        <p className="mt-3 text-body leading-relaxed text-muted-foreground">
+          Your events are still safe. Try again, or come back after a breather.
+        </p>
+        <button
+          className="mt-6 min-h-11 rounded-2xl bg-primary px-5 py-3 font-medium text-primary-foreground transition hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/30"
+          onClick={reset}
+          type="button"
+        >
+          Try again
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/(tempo)/calendar/page.tsx
+++ b/apps/web/app/(tempo)/calendar/page.tsx
@@ -1,23 +1,10 @@
-/**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
- * @screen: calendar
- * @category: Library
- * @source: docs/design/claude-export/design-system/screens-3.jsx
- * @summary: Week + month calendar with task overlay.
- * @queries: calendar.list
- * @mutations: calendar.schedule
- * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
- */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { CalendarViews } from "@/components/calendar/CalendarViews";
 
 export default function Page() {
-  return (
-    <ScaffoldScreen
-      title="Calendar"
-      category="Library"
-      source="screens-3.jsx"
-      summary="Week + month calendar with task overlay."
-    />
-  );
+  const eventSourceMode =
+    process.env.NODE_ENV !== "production" && process.env.TEMPO_E2E_PUBLIC_CALENDAR === "1"
+      ? "local"
+      : "convex";
+
+  return <CalendarViews eventSourceMode={eventSourceMode} />;
 }

--- a/apps/web/components/calendar/CalendarViews.tsx
+++ b/apps/web/components/calendar/CalendarViews.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { api } from "@/convex/_generated/api";
+import {
+  fromDateInputValue,
+  getCalendarRangeMs,
+  getEventsInRange,
+  parseDateInputValue,
+  toDateInputValue,
+  type CalendarViewMode,
+} from "@/lib/calendar/date-math";
+import {
+  createLocalCalendarEvent,
+  loadCalendarEvents,
+  saveCalendarEvents,
+  type StoredCalendarEvent,
+} from "@/lib/calendar/event-source";
+
+const viewOptions: Array<{ mode: CalendarViewMode; label: string }> = [
+  { mode: "day", label: "Day" },
+  { mode: "week", label: "Week" },
+  { mode: "month", label: "Month" },
+];
+
+function formatRange(mode: CalendarViewMode, range: { startMs: number; endMs: number }): string {
+  const start = new Date(range.startMs);
+  const endInclusive = new Date(range.endMs - 1);
+
+  if (mode === "day") {
+    return start.toLocaleDateString(undefined, {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    });
+  }
+
+  return `${start.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  })} - ${endInclusive.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })}`;
+}
+
+type DisplayCalendarEvent = {
+  id: string;
+  title: string;
+  startsAtMs: number;
+};
+
+function EventList({
+  events,
+  mode,
+}: {
+  events: DisplayCalendarEvent[];
+  mode: CalendarViewMode;
+}) {
+  return (
+    <section
+      aria-label={`${mode} events`}
+      className="rounded-3xl border border-border bg-card/80 p-5 shadow-soft"
+      data-testid={`${mode}-events`}
+    >
+      <h2 className="font-eyebrow">{mode} events</h2>
+      {events.length > 0 ? (
+        <ul className="mt-4 space-y-3">
+          {events.map((event) => (
+            <li
+              className="rounded-2xl border border-border/70 bg-background/80 px-4 py-3"
+              key={event.id}
+            >
+              <p className="font-medium text-foreground">{event.title}</p>
+              <p className="mt-1 text-caption text-muted-foreground">
+                {new Date(event.startsAtMs).toLocaleDateString(undefined, {
+                  weekday: "short",
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })}
+              </p>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-4 text-small text-muted-foreground">
+          No events in this window yet. Add one when you know where it belongs.
+        </p>
+      )}
+    </section>
+  );
+}
+
+export function CalendarViews({ eventSourceMode }: { eventSourceMode: "convex" | "local" }) {
+  const [view, setView] = useState<CalendarViewMode>("day");
+  const [selectedDateValue, setSelectedDateValue] = useState(() => toDateInputValue(new Date()));
+  const [title, setTitle] = useState("");
+  const [localEvents, setLocalEvents] = useState<StoredCalendarEvent[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const createConvexEvent = useMutation(api.calendar_events.create);
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const profile = useQuery(
+    api.users.getProfile,
+    eventSourceMode === "convex" && isAuthenticated ? {} : "skip",
+  );
+
+  useEffect(() => {
+    if (eventSourceMode === "local") {
+      setLocalEvents(loadCalendarEvents());
+    }
+  }, [eventSourceMode]);
+
+  const selectedDate = useMemo(() => parseDateInputValue(selectedDateValue), [selectedDateValue]);
+  const range = useMemo(
+    () => getCalendarRangeMs(view, selectedDate ?? new Date()),
+    [selectedDate, view],
+  );
+  const hasConvexUser = eventSourceMode === "convex" && profile != null;
+  const convexEvents = useQuery(
+    api.calendar_events.listInRange,
+    hasConvexUser ? { startMs: range.startMs, endMs: range.endMs } : "skip",
+  );
+  const events = useMemo<DisplayCalendarEvent[]>(() => {
+    if (eventSourceMode === "local") {
+      return localEvents;
+    }
+
+    return (convexEvents ?? []).map((event) => ({
+      id: event._id,
+      title: event.title,
+      startsAtMs: event.startsAtMs,
+    }));
+  }, [convexEvents, eventSourceMode, localEvents]);
+  const visibleEvents = useMemo(() => getEventsInRange(events, range), [events, range]);
+  const isLoading =
+    eventSourceMode === "convex" &&
+    (isAuthLoading || (isAuthenticated && (profile === undefined || convexEvents === undefined)));
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    try {
+      const startsAtMs = fromDateInputValue(selectedDateValue).getTime();
+      const cleanTitle = title.trim();
+      if (!cleanTitle) {
+        throw new Error("Give the event a gentle label first.");
+      }
+
+      setIsSubmitting(true);
+      if (eventSourceMode === "local") {
+        const created = createLocalCalendarEvent({
+          title: cleanTitle,
+          startsAtMs,
+        });
+        const nextEvents = [...localEvents, created].toSorted((a, b) => a.startsAtMs - b.startsAtMs);
+        saveCalendarEvents(nextEvents);
+        setLocalEvents(nextEvents);
+      } else {
+        if (!isAuthenticated || !profile) {
+          throw new Error("Sign in again to add calendar events.");
+        }
+        await createConvexEvent({ title: cleanTitle, startsAtMs });
+      }
+      setTitle("");
+      setView("day");
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "We could not add that event yet.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-6 md:p-8">
+      <header className="space-y-3">
+        <p className="font-eyebrow text-muted-foreground">Calendar</p>
+        <h1 className="text-h1 font-serif">One source for every calendar view</h1>
+        <p className="max-w-2xl text-body leading-relaxed text-muted-foreground">
+          Add an event once, then switch between Day, Week, and Month without losing the
+          thread.
+        </p>
+      </header>
+
+      <form
+        className="grid gap-4 rounded-3xl border border-border bg-card p-5 shadow-soft md:grid-cols-[1fr_12rem_auto]"
+        onSubmit={handleSubmit}
+      >
+        <label className="flex flex-col gap-2 text-small font-medium text-foreground">
+          Event title
+          <input
+            className="rounded-2xl border border-border bg-background px-4 py-3 text-body outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+            name="title"
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="Planning call"
+            value={title}
+          />
+        </label>
+
+        <label className="flex flex-col gap-2 text-small font-medium text-foreground">
+          Event date
+          <input
+            className="rounded-2xl border border-border bg-background px-4 py-3 text-body outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+            name="date"
+            onChange={(event) => setSelectedDateValue(event.target.value)}
+            type="date"
+            value={selectedDateValue}
+          />
+        </label>
+
+        <div className="flex flex-col justify-end">
+          <button
+            className="min-h-11 rounded-2xl bg-primary px-5 py-3 font-medium text-primary-foreground transition hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary/30"
+            disabled={isSubmitting}
+            type="submit"
+          >
+            {isSubmitting ? "Adding..." : "Add event"}
+          </button>
+        </div>
+
+        {error ? (
+          <p className="text-small text-destructive md:col-span-3" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </form>
+
+      <section className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-border bg-muted/40 p-4">
+        <fieldset className="flex flex-wrap gap-2 border-0 p-0">
+          <legend className="sr-only">Calendar views</legend>
+          {viewOptions.map((option) => (
+            <button
+              aria-pressed={view === option.mode}
+              className={`min-h-11 rounded-2xl px-4 py-2 text-small font-medium transition ${
+                view === option.mode
+                  ? "bg-foreground text-background"
+                  : "bg-background text-muted-foreground hover:text-foreground"
+              }`}
+              key={option.mode}
+              onClick={() => setView(option.mode)}
+              type="button"
+            >
+              {option.label}
+            </button>
+          ))}
+        </fieldset>
+        <p className="text-small text-muted-foreground">{formatRange(view, range)}</p>
+      </section>
+
+      {isLoading ? (
+        <section className="rounded-3xl border border-border bg-card/80 p-5 shadow-soft">
+          <div className="h-4 w-28 animate-pulse rounded-full bg-muted" />
+          <div className="mt-4 h-20 animate-pulse rounded-2xl bg-muted" />
+        </section>
+      ) : (
+        <EventList events={visibleEvents} mode={view} />
+      )}
+    </main>
+  );
+}

--- a/apps/web/lib/calendar/date-math.ts
+++ b/apps/web/lib/calendar/date-math.ts
@@ -1,0 +1,97 @@
+export type CalendarViewMode = "day" | "week" | "month";
+
+export type CalendarRange = {
+  startMs: number;
+  endMs: number;
+};
+
+export type CalendarEvent = {
+  id: string;
+  title: string;
+  startsAtMs: number;
+};
+
+export function getLocalDayStartMs(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+function getLocalWeekStartMondayMs(date: Date): number {
+  const day = date.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + diff).getTime();
+}
+
+function getLocalMonthStartMs(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), 1).getTime();
+}
+
+export function getCalendarRangeMs(mode: CalendarViewMode, date: Date): CalendarRange {
+  if (mode === "day") {
+    const startMs = getLocalDayStartMs(date);
+    return {
+      startMs,
+      endMs: new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1).getTime(),
+    };
+  }
+
+  if (mode === "week") {
+    const startMs = getLocalWeekStartMondayMs(date);
+    const start = new Date(startMs);
+    return {
+      startMs,
+      endMs: new Date(start.getFullYear(), start.getMonth(), start.getDate() + 7).getTime(),
+    };
+  }
+
+  return {
+    startMs: getLocalMonthStartMs(date),
+    endMs: new Date(date.getFullYear(), date.getMonth() + 1, 1).getTime(),
+  };
+}
+
+export function getEventsInRange<T extends CalendarEvent>(
+  events: readonly T[],
+  range: CalendarRange,
+): T[] {
+  return events
+    .filter((event) => event.startsAtMs >= range.startMs && event.startsAtMs < range.endMs)
+    .toSorted((a, b) => a.startsAtMs - b.startsAtMs || a.title.localeCompare(b.title));
+}
+
+export function toDateInputValue(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function fromDateInputValue(value: string): Date {
+  const parsed = parseDateInputValue(value);
+  if (!parsed) {
+    throw new Error("Choose a calendar date.");
+  }
+
+  return parsed;
+}
+
+export function parseDateInputValue(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const parsed = new Date(year, month - 1, day);
+
+  if (
+    parsed.getFullYear() !== year ||
+    parsed.getMonth() !== month - 1 ||
+    parsed.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsed;
+}

--- a/apps/web/lib/calendar/event-source.ts
+++ b/apps/web/lib/calendar/event-source.ts
@@ -1,0 +1,72 @@
+import type { CalendarEvent } from "./date-math";
+
+const storageKey = "tempo:calendar-events:e2e:v1";
+
+export type StoredCalendarEvent = CalendarEvent & {
+  createdAtMs: number;
+};
+
+function isStoredCalendarEvent(value: unknown): value is StoredCalendarEvent {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.title === "string" &&
+    typeof candidate.startsAtMs === "number" &&
+    typeof candidate.createdAtMs === "number"
+  );
+}
+
+export function loadCalendarEvents(): StoredCalendarEvent[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) {
+      return [];
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(isStoredCalendarEvent).toSorted((a, b) => a.startsAtMs - b.startsAtMs);
+  } catch {
+    return [];
+  }
+}
+
+export function saveCalendarEvents(events: readonly StoredCalendarEvent[]): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(storageKey, JSON.stringify(events));
+}
+
+export function createLocalCalendarEvent({
+  title,
+  startsAtMs,
+}: {
+  title: string;
+  startsAtMs: number;
+}): StoredCalendarEvent {
+  const cleanTitle = title.trim();
+  if (!cleanTitle) {
+    throw new Error("Give the event a gentle label first.");
+  }
+
+  const now = Date.now();
+  return {
+    id: `calendar-event-${now}-${Math.random().toString(36).slice(2)}`,
+    title: cleanTitle,
+    startsAtMs,
+    createdAtMs: now,
+  };
+}

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -17,6 +17,10 @@ const isPublicRoute = createRouteMatcher([
 
 export default convexAuthNextjsMiddleware(async (request: NextRequest, ctx) => {
   const { convexAuth } = ctx;
+  const isCalendarE2EBypass =
+    process.env.NODE_ENV !== "production" &&
+    process.env.TEMPO_E2E_PUBLIC_CALENDAR === "1" &&
+    request.nextUrl.pathname === "/calendar";
   let isAuthenticated = false;
   try {
     isAuthenticated = await convexAuth.isAuthenticated();
@@ -24,7 +28,7 @@ export default convexAuthNextjsMiddleware(async (request: NextRequest, ctx) => {
     isAuthenticated = false;
   }
 
-  if (!(isPublicRoute(request) || isAuthenticated)) {
+  if (!(isPublicRoute(request) || isCalendarE2EBypass || isAuthenticated)) {
     const nextPath = `${request.nextUrl.pathname}${request.nextUrl.search}`;
     const params = new URLSearchParams({ next: nextPath });
     return nextjsMiddlewareRedirect(request, `/sign-in?${params.toString()}`);

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
+        "@playwright/test": "^1.61.1",
         "@types/bun": "^1.3.13",
         "@types/node": "^20.19.0",
         "turbo": "^2.3.3",
@@ -573,6 +574,8 @@
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
+
     "@polar-sh/adapter-utils": ["@polar-sh/adapter-utils@0.4.4", "", { "dependencies": { "@polar-sh/sdk": "^0.46.0" } }, "sha512-0fvscT82EMoo+otgnw7YsbzxmatxTpc457DytZY9Lr+6B9XNBI/wP7THK0nV3Qdaipd66Pp9hyZI9Dzusj1KzQ=="],
 
     "@polar-sh/nextjs": ["@polar-sh/nextjs@0.9.4", "", { "dependencies": { "@polar-sh/adapter-utils": "0.4.4", "@polar-sh/sdk": "^0.46.0" }, "peerDependencies": { "next": "^15.0.0 || ^16.0.0" } }, "sha512-CN6qjaVXVR5OojcpjtlXF7FcVnCEXAKB4vyOECP3n3YjD7DdJ4/PPtKvc2/TVXC9bM8m6pcUOI7Y9f7K5T0jNA=="],
@@ -1099,7 +1102,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1420,6 +1423,10 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
@@ -1893,6 +1900,8 @@
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -1930,6 +1939,8 @@
     "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as ai_smoke from "../ai_smoke.js";
 import type * as analytics from "../analytics.js";
 import type * as auth from "../auth.js";
 import type * as brain_dump from "../brain_dump.js";
+import type * as calendar_events from "../calendar_events.js";
 import type * as coach from "../coach.js";
 import type * as conversations from "../conversations.js";
 import type * as goals from "../goals.js";
@@ -39,6 +40,7 @@ declare const fullApi: ApiFromModules<{
   analytics: typeof analytics;
   auth: typeof auth;
   brain_dump: typeof brain_dump;
+  calendar_events: typeof calendar_events;
   coach: typeof coach;
   conversations: typeof conversations;
   goals: typeof goals;

--- a/convex/calendar_events.ts
+++ b/convex/calendar_events.ts
@@ -1,0 +1,66 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { requireUser } from "./lib/requireUser";
+
+const maxCalendarRangeMs = 32 * 24 * 60 * 60 * 1000;
+
+const calendarEventValidator = v.object({
+  _id: v.id("calendarEvents"),
+  _creationTime: v.number(),
+  title: v.string(),
+  startsAtMs: v.number(),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+});
+
+export const listInRange = query({
+  args: {
+    startMs: v.number(),
+    endMs: v.number(),
+  },
+  returns: v.array(calendarEventValidator),
+  handler: async (ctx, args) => {
+    if (args.endMs <= args.startMs) {
+      throw new Error("Calendar range must end after it starts.");
+    }
+    if (args.endMs - args.startMs > maxCalendarRangeMs) {
+      throw new Error("Calendar range is too large.");
+    }
+
+    const user = await requireUser(ctx);
+    return await ctx.db
+      .query("calendarEvents")
+      .withIndex("by_userId_deletedAt_startsAtMs", (q) =>
+        q
+          .eq("userId", user._id)
+          .eq("deletedAt", undefined)
+          .gte("startsAtMs", args.startMs)
+          .lt("startsAtMs", args.endMs),
+      )
+      .collect();
+  },
+});
+
+export const create = mutation({
+  args: {
+    title: v.string(),
+    startsAtMs: v.number(),
+  },
+  returns: v.id("calendarEvents"),
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const title = args.title.trim();
+    if (!title) {
+      throw new Error("Give the event a gentle label first.");
+    }
+
+    const now = Date.now();
+    return await ctx.db.insert("calendarEvents", {
+      userId: user._id,
+      title,
+      startsAtMs: args.startsAtMs,
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -144,6 +144,18 @@ export default defineSchema({
     .index("by_userId_dueAt", ["userId", "dueAt"])
     .index("by_userId_deletedAt", ["userId", "deletedAt"]),
 
+  calendarEvents: defineTable({
+    userId: v.id("users"),
+    title: v.string(),
+    startsAtMs: v.number(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    deletedAt: v.optional(v.number()),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_userId_deletedAt_startsAtMs", ["userId", "deletedAt", "startsAtMs"])
+    .index("by_userId_deletedAt", ["userId", "deletedAt"]),
+
   notes: defineTable({
     userId: v.id("users"),
     title: v.string(),

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
+    "@playwright/test": "^1.61.1",
     "@types/bun": "^1.3.13",
     "@types/node": "^20.19.0",
     "turbo": "^2.3.3"

--- a/tests/e2e/calendar-views.spec.ts
+++ b/tests/e2e/calendar-views.spec.ts
@@ -1,0 +1,100 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { request } from "node:http";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+
+const port = 3211;
+const fallbackBaseUrl = `http://127.0.0.1:${port}`;
+let baseUrl = fallbackBaseUrl;
+let calendarUrl = `${baseUrl}/calendar`;
+const readyTimeoutMs = 45_000;
+
+let server: ChildProcessWithoutNullStreams | undefined;
+let ownsServer = false;
+
+async function canReachCalendar(url: string): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const req = request(`${url}/calendar`, (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      res.on("end", () => {
+        resolve(res.statusCode === 200 && body.includes("One source for every calendar view"));
+      });
+    });
+    req.on("error", () => resolve(false));
+    req.setTimeout(1_000, () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.end();
+  });
+}
+
+async function waitForServer(url: string): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < readyTimeoutMs) {
+    if (await canReachCalendar(url)) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`Next dev server did not become ready at ${url}/calendar`);
+}
+
+test.beforeAll(async () => {
+  const reusableBaseUrl = process.env.CALENDAR_E2E_BASE_URL ?? "http://127.0.0.1:3212";
+  if (await canReachCalendar(reusableBaseUrl)) {
+    baseUrl = reusableBaseUrl;
+    calendarUrl = `${baseUrl}/calendar`;
+    return;
+  }
+
+  ownsServer = true;
+  server = spawn("bun", ["run", "dev", "--hostname", "127.0.0.1", "--port", String(port)], {
+    cwd: path.join(process.cwd(), "apps/web"),
+    env: {
+      ...process.env,
+      TEMPO_E2E_PUBLIC_CALENDAR: "1",
+      NEXT_PUBLIC_CONVEX_URL:
+        process.env.NEXT_PUBLIC_CONVEX_URL ?? "https://precious-wildcat-890.convex.cloud",
+    },
+    stdio: "pipe",
+  });
+
+  server.stdout.on("data", (chunk) => process.stdout.write(chunk));
+  server.stderr.on("data", (chunk) => process.stderr.write(chunk));
+
+  await waitForServer(baseUrl);
+});
+
+test.afterAll(() => {
+  if (ownsServer && server && !server.killed) {
+    server.kill("SIGTERM");
+  }
+});
+
+test("event created in Day view appears in Week and Month views for that date", async ({
+  page,
+}) => {
+  await page.goto(calendarUrl);
+  await page.evaluate(() => window.localStorage.clear());
+  await page.reload();
+
+  await page.getByRole("textbox", { name: "Event title" }).fill("Boundary planning call");
+  await page.getByLabel("Event date").fill("2026-08-01");
+  await page.getByRole("button", { name: "Add event" }).click();
+
+  await expect(page.getByTestId("day-events")).toContainText("Boundary planning call");
+
+  await page.getByRole("button", { name: "Week" }).click();
+  await expect(page.getByTestId("week-events")).toContainText("Boundary planning call");
+
+  await page.getByRole("button", { name: "Month" }).click();
+  await expect(page.getByTestId("month-events")).toContainText("Boundary planning call");
+});

--- a/tests/unit/calendar_date_math.test.ts
+++ b/tests/unit/calendar_date_math.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getCalendarRangeMs,
+  getEventsInRange,
+  parseDateInputValue,
+  type CalendarEvent,
+} from "../../apps/web/lib/calendar/date-math";
+
+const dayMs = 24 * 60 * 60 * 1000;
+
+function eventAt(id: string, date: Date): CalendarEvent {
+  return {
+    id,
+    title: id,
+    startsAtMs: date.getTime(),
+  };
+}
+
+describe("calendar date math", () => {
+  test("day, week, and month ranges use half-open boundaries", () => {
+    const selected = new Date(2026, 6, 14, 12);
+    const day = getCalendarRangeMs("day", selected);
+    const week = getCalendarRangeMs("week", selected);
+    const month = getCalendarRangeMs("month", selected);
+    const events = [
+      eventAt("before-day", new Date(day.startMs - 1)),
+      eventAt("day-start", new Date(day.startMs)),
+      eventAt("day-end-minus-one", new Date(day.endMs - 1)),
+      eventAt("day-end", new Date(day.endMs)),
+      eventAt("week-end-minus-one", new Date(week.endMs - 1)),
+      eventAt("week-end", new Date(week.endMs)),
+      eventAt("month-end-minus-one", new Date(month.endMs - 1)),
+      eventAt("month-end", new Date(month.endMs)),
+    ];
+
+    expect(getEventsInRange(events, day).map((event) => event.id)).toEqual([
+      "day-start",
+      "day-end-minus-one",
+    ]);
+    expect(getEventsInRange(events, week).map((event) => event.id)).toContain(
+      "week-end-minus-one",
+    );
+    expect(getEventsInRange(events, week).map((event) => event.id)).not.toContain("week-end");
+    expect(getEventsInRange(events, month).map((event) => event.id)).toContain(
+      "month-end-minus-one",
+    );
+    expect(getEventsInRange(events, month).map((event) => event.id)).not.toContain("month-end");
+  });
+
+  test("week range rolls across month boundaries from Monday to Monday", () => {
+    const selected = new Date(2026, 7, 1, 12);
+    const range = getCalendarRangeMs("week", selected);
+
+    expect(new Date(range.startMs)).toEqual(new Date(2026, 6, 27, 0, 0, 0, 0));
+    expect(new Date(range.endMs)).toEqual(new Date(2026, 7, 3, 0, 0, 0, 0));
+    expect(range.endMs - range.startMs).toBe(7 * dayMs);
+  });
+
+  test("month range rolls from December into January", () => {
+    const selected = new Date(2026, 11, 31, 23, 30);
+    const range = getCalendarRangeMs("month", selected);
+
+    expect(new Date(range.startMs)).toEqual(new Date(2026, 11, 1, 0, 0, 0, 0));
+    expect(new Date(range.endMs)).toEqual(new Date(2027, 0, 1, 0, 0, 0, 0));
+  });
+
+  test("incomplete date input returns null instead of throwing during editing", () => {
+    expect(parseDateInputValue("")).toBeNull();
+    expect(parseDateInputValue("2026-")).toBeNull();
+    expect(parseDateInputValue("2026-02-31")).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Day, Week, and Month calendar views now derive from one event source instead of a scaffold, so the same event remains visible as the user changes calendar granularity. Production reads/writes authenticated Convex `calendarEvents`; the localStorage event source is restricted to non-production e2e bypass mode so Playwright can verify the flow without a real user session.

## Linked task(s)

Task: T-006a / TEMPO-148

## Screenshots / screen recording

[calendar_day_week_month_shared_event_source_clean.mp4](https://cursor.com/agents/bc-9299d03f-0654-4e29-aa49-74dd2a5cf135/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_day_week_month_shared_event_source_clean.mp4)

## Test plan

- [x] Local `bun run typecheck` passes
- [x] Local `bun run lint` passes (exits 0; output includes pre-existing `@tempo/ui` unused suppression warning)
- [x] Relevant unit / integration tests added or updated
- [x] Manual QA steps performed: recorded creating `Boundary planning call` in Day view and verifying it in Week and Month
- [x] Reproduces the acceptance criteria below
- [x] `bun test tests/unit/calendar_date_math.test.ts`
- [x] `bunx playwright test tests/e2e/calendar-views.spec.ts`
- [x] `CONVEX_AGENT_MODE=anonymous bun x convex dev --once --typecheck disable`
- [x] `tempo-reviewer` final pass: APPROVE

Terminal state: PASS — every done_when command exited 0.

## Acceptance criteria

An event created in Day view is visible in Week and Month views for the same date; date-math boundary tests (week/month rollover) pass.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). N/A — no AI-originated mutation.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5).
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7).
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8).
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13).
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9).

## Owner tag (§14)

- [ ] `cursor-ide`
- [x] `cursor-cloud-1`
- [ ] `cursor-cloud-2`
- [ ] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

## Reviewer

Amit (`human-amit`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [TEMPO-148](https://linear.app/amit-levin/issue/TEMPO-148/t-006a-dayweekmonth-share-one-event-source)

<div><a href="https://cursor.com/agents/bc-9299d03f-0654-4e29-aa49-74dd2a5cf135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9299d03f-0654-4e29-aa49-74dd2a5cf135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

