### PR TITLE
fix(tasks): normalize projectSlug so project view create matches filter

### DIFF
--- a/apps/web/components/tasks/TaskViewsScreen.tsx
+++ b/apps/web/components/tasks/TaskViewsScreen.tsx
@@ -142,7 +142,12 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
     }
   }, []);
 
-  const projectId = view === "project" ? (projectSlug ?? "home-reset") : undefined;
+  // Normalize URL slug the same way create does, so mixed-case / irregular
+  // slugs still match newly created tasks in this project view.
+  const projectId =
+    view === "project"
+      ? slugifyProjectName(projectSlug ?? "home-reset") || "home-reset"
+      : undefined;
   const projectName = view === "project" ? getViewTitle(view, projectSlug) : undefined;
   const usesConvex = isAuthenticated && convexTasks !== undefined;
   const usesLocalStore = !usesConvex && allowLocalTaskViews;
@@ -196,7 +201,12 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
 
     const normalizedProjectName =
       view === "project" ? (projectName ?? draft.projectName) : draft.projectName.trim();
-    const normalizedProjectId = slugifyProjectName(normalizedProjectName);
+    // Project view must reuse the filter's projectId — do not re-slugify the
+    // display title alone, or URL slug and stored id can diverge.
+    const normalizedProjectId =
+      view === "project" && projectId
+        ? projectId
+        : slugifyProjectName(normalizedProjectName);
     const dueAt = draft.dueToday ? bounds.endMs - 1 : undefined;
 
     if (usesConvex) {

--- a/tests/unit/task_filters.test.ts
+++ b/tests/unit/task_filters.test.ts
@@ -3,6 +3,8 @@ import {
   filterTasksForView,
   groupTasksByEnergy,
   groupTasksByPriority,
+  slugifyProjectName,
+  titleFromProjectSlug,
   type TaskViewRecord,
 } from "../../apps/web/lib/task-view-filters";
 
@@ -92,5 +94,36 @@ describe("task view filters", () => {
     expect(energyGroups.low.map((task) => task.id)).toEqual(["task-today"]);
     expect(energyGroups.medium.map((task) => task.id)).toEqual(["task-done"]);
     expect(energyGroups.high.map((task) => task.id)).toEqual(["task-inbox"]);
+  });
+
+  test("project view id from URL slug matches id stored on create for irregular slugs", () => {
+    const irregularSlugs = ["Home-Reset", "HOME-Reset", "my--project", "MyProject", "home_reset"];
+
+    for (const projectSlug of irregularSlugs) {
+      // Mirror TaskViewsScreen: filter uses slugified URL; create stores the same.
+      const filterProjectId = slugifyProjectName(projectSlug) || "home-reset";
+      const displayTitle = titleFromProjectSlug(projectSlug);
+      const createdProjectId = filterProjectId;
+
+      const created: TaskViewRecord = {
+        id: `created-${projectSlug}`,
+        title: "Created in project view",
+        status: "todo",
+        priority: "medium",
+        energy: "medium",
+        projectId: createdProjectId,
+        projectName: displayTitle,
+        updatedAt: 50,
+      };
+
+      const visible = filterTasksForView([...records, created], {
+        view: "project",
+        projectId: filterProjectId,
+      });
+
+      expect(visible.map((task) => task.id)).toContain(created.id);
+      // Raw URL slug must not be required for a match after normalization.
+      expect(createdProjectId).toBe(slugifyProjectName(projectSlug) || "home-reset");
+    }
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Project views filtered on the raw URL `projectSlug`, while create stored `slugifyProjectName` of the derived display title. Mixed-case or irregular slugs (`Home-Reset`, `my--project`, `home_reset`) made those values diverge, so tasks created in an open project view could miss that view’s filter.

This normalizes the URL slug with `slugifyProjectName` for both filter and create, so newly added tasks stay visible in the project they were created in.

## Linked task(s)

Task: T-005a (TEMPO-145 / core task views)

Note: `docs/brain/` is a private submodule and unavailable in this cloud agent checkout, so the private `TASKS.md` ID could not be confirmed here. Used the in-repo / Linear identifier above.

## Screenshots / screen recording

N/A — filter/create ID alignment; no visual chrome change.

## Test plan

- [x] `bun test tests/unit/task_filters.test.ts` passes (including new irregular-slug regression)
- [ ] Local `bun run typecheck` passes
- [ ] Local `bun run lint` passes
- [x] Relevant unit tests added
- [ ] Manual: open `/projects/Home-Reset` (or another mixed-case slug), create a task, confirm it appears in that project list

## Acceptance criteria

- Creating a task while a project view is open keeps that task visible in the same project view after create, including when the URL slug is mixed-case or irregular.
- Project filter and create use the same normalized `projectId`.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI-originated state changes N/A for this bugfix
- [x] Schema changes N/A
- [x] Styling N/A
- [x] Accessibility N/A
- [x] No secrets committed
- [x] Voice rules N/A (no new user-facing copy)

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Default: Amit (`human-amit`). Code agents do not merge this PR.

## Graph note

Could not rebuild/query the code knowledge graph in this run (`graphify` not required for this localized bugfix). The reported line ranges in `TaskViewsScreen.tsx` matched the live `integration` code and contradicted nothing in the filter helpers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b76ed5d-7944-4586-bb16-d2dc2f9a2ad0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b76ed5d-7944-4586-bb16-d2dc2f9a2ad0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

