### PR TITLE
fix(coach): replace hardcoded Hebrew replies with English-first anti-shame copy

### DIFF
--- a/convex/coach.test.ts
+++ b/convex/coach.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { coachReplyForTechnique } from "./coach";
+
+const KNOWN_TECHNIQUES = [
+  "pomodoro",
+  "body_double",
+  "eat_the_frog",
+  "time_blocking",
+  "two_minute",
+  "general",
+] as const;
+
+/** Hebrew block — the old replies were hardcoded Hebrew; English-first is the contract now. */
+const HEBREW_CODEPOINTS = /[\u0590-\u05FF]/;
+
+/** HARD_RULES §1 — copy must never imply failure or laziness. */
+const SHAME_WORDS = /\b(behind|failing|failure|lazy|laziness|streak broken|overdue)\b/i;
+
+describe("coachReplyForTechnique", () => {
+  test.each([...KNOWN_TECHNIQUES])("returns a non-empty English reply for %s", (technique) => {
+    const reply = coachReplyForTechnique(technique);
+    expect(reply.trim().length).toBeGreaterThan(0);
+    expect(reply).not.toMatch(HEBREW_CODEPOINTS);
+  });
+
+  test("each known technique has its own distinct reply", () => {
+    const replies = KNOWN_TECHNIQUES.map((technique) => coachReplyForTechnique(technique));
+    expect(new Set(replies).size).toBe(KNOWN_TECHNIQUES.length);
+  });
+
+  test("falls back to the general reply for an unknown technique", () => {
+    expect(coachReplyForTechnique("swiss_cheese")).toBe(coachReplyForTechnique("general"));
+  });
+
+  test("falls back to the general reply when technique is undefined", () => {
+    expect(coachReplyForTechnique(undefined)).toBe(coachReplyForTechnique("general"));
+  });
+
+  test("does not resolve replies from Object.prototype keys", () => {
+    expect(coachReplyForTechnique("toString")).toBe(coachReplyForTechnique("general"));
+    expect(coachReplyForTechnique("constructor")).toBe(coachReplyForTechnique("general"));
+  });
+
+  test.each([...KNOWN_TECHNIQUES])("reply for %s carries no shame language", (technique) => {
+    expect(coachReplyForTechnique(technique)).not.toMatch(SHAME_WORDS);
+  });
+});

--- a/convex/coach.ts
+++ b/convex/coach.ts
@@ -2,20 +2,39 @@ import { v } from "convex/values";
 import { mutation } from "./_generated/server";
 import { requireUser } from "./lib/requireUser";
 
-const REPLIES: Record<string, string> = {
+/**
+ * English-first, anti-shame coach replies per technique (HARD_RULES §1).
+ * Copy never implies the user is behind, failing, or lazy — it always offers
+ * one small, optional next step.
+ *
+ * Keyed by `conversations.technique`; unknown or missing techniques fall back
+ * to `general`.
+ */
+const COACH_REPLIES: Record<string, string> = {
   pomodoro:
-    "נסה מקטע של 25 דקות עם טיימר אחד בלבד. אחרי הפסקה של 5 דקות, החלט אם להמשיך עוד מקטע או לעבור למשימה הבאה.",
+    "Try one 25-minute stretch with a single timer. After a 5-minute break, you get to choose: another stretch, or move on. Either answer is a win.",
   body_double:
-    "עבוד לצד מישהו (או בשיחת וידאו שקטה) בלי לדבר על המשימה — הנוכחות לבד מורידה הסחות דעת.",
+    "Work alongside someone — in person or on a quiet video call — without talking about the task. Just having company nearby makes it easier to stay with it.",
   eat_the_frog:
-    "בחר את המשימה הכי כבדה היום והתחל ממנה לפני כל השאר. רק צעד ראשון קטן עכשיו.",
+    "Pick the task that feels heaviest today and start there, before anything else. Only the first small step counts right now — nothing more.",
   time_blocking:
-    "חסום ביומן חלון קצר לכל משימה והגדר התראה אחת לסוף החלון — לא לשינוי תוכנית באמצע.",
+    "Block a short window on your calendar for one task, and set a single reminder for the end of the window. No mid-plan changes — the window does the deciding for you.",
   two_minute:
-    "אם זה באמת מתחת לשתי דקות — עשה עכשיו. אם לא, הפוך את זה לצעד קטן שמתחיל בשנייה אחת.",
+    "If it truly takes under two minutes, do it now. If not, shrink it into a step so small it starts in one second.",
   general:
-    "מה הצעד הקטן ביותר שאפשר לעשות בלי התנגדות? התחל משם בלבד.",
+    "What's the smallest step you could take without any resistance? Start there — that's the whole assignment.",
 };
+
+/**
+ * Resolve the coach reply for a conversation technique.
+ * Pure helper so the copy is unit-testable (see coach.test.ts).
+ */
+export function coachReplyForTechnique(technique: string | undefined): string {
+  if (technique !== undefined && Object.prototype.hasOwnProperty.call(COACH_REPLIES, technique)) {
+    return COACH_REPLIES[technique] as string;
+  }
+  return COACH_REPLIES.general as string;
+}
 
 /**
  * Append a user message and a coach reply (template by conversation technique).
@@ -26,6 +45,7 @@ export const sendMessage = mutation({
     conversationId: v.id("conversations"),
     content: v.string(),
   },
+  returns: v.object({ success: v.literal(true) }),
   handler: async (ctx, args) => {
     const user = await requireUser(ctx);
     const conv = await ctx.db.get(args.conversationId);
@@ -45,9 +65,7 @@ export const sendMessage = mutation({
       createdAt: now,
     });
 
-    const technique = conv.technique ?? "general";
-    const assistantBody =
-      REPLIES[technique] ?? REPLIES.general;
+    const assistantBody = coachReplyForTechnique(conv.technique);
 
     await ctx.db.insert("messages", {
       conversationId: args.conversationId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
Tempo Flow PR template. Format mandated by docs/HARD_RULES.md §12.
Owner-tag discipline is enforced by §14.
-->

## Summary

The coach's canned technique replies were six hardcoded Hebrew strings, so every non-Hebrew user got responses in a language they may not read; the Linear ticket "Coach ships six hardcoded Hebrew strings — replace with English-first, any-language" tracks this. This PR makes the copy English-first with HARD_RULES §1 anti-shame tone, extracts the lookup into a pure `coachReplyForTechnique()` helper so the copy is unit-testable, and adds the previously missing `returns` validator to `coach.sendMessage`.

## Linked task(s)

Task: Linear — "Coach ships six hardcoded Hebrew strings — replace with English-first, any-language" (no `T-XXXX` ID exists for this ticket; `docs/brain/TASKS.md` is a private submodule not readable by cloud agents, per AGENTS.md appendix)

## Screenshots / screen recording

N/A — no user-visible surface change beyond string content (coach chat replies switch from Hebrew to English).

## Test plan

- [x] Local `bun run typecheck` passes (plus a direct `tsc --noEmit -p convex/tsconfig.json`)
- [x] Local `bun run lint` passes
- [x] Relevant unit / integration tests added or updated — new `convex/coach.test.ts` (10 tests): every technique returns non-empty English copy, distinct replies per technique, unknown/`undefined` technique falls back to `general`, prototype-key lookups (`toString`, `constructor`) fall back safely, and a no-shame-language scan over all replies
- [x] Manual QA steps performed: ran `bun run test` (60 pass / 0 fail), `bun run scan:forbidden-tech`, `scan:ram-only-audit`, `scan:design-tokens`, `check:notices` — all green locally on top of `integration` @ 1c2a654
- [x] Reproduces the acceptance criteria below

## Acceptance criteria

From the Linear ticket title (no fuller criteria visible to cloud agents):

- The six hardcoded Hebrew coach replies are replaced with English-first copy.
- Copy carries the anti-shame tone required by HARD_RULES §1 (verified by test).

Additional hygiene in the same file (same logical unit, per validator guidance for this run):

- `coach.sendMessage` now declares `returns: v.object({ success: v.literal(true) })`, matching its actual `{ success: true as const }` return value. No table rows are returned by this mutation, so no stored-field omission risk.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). — N/A: this mutation only appends chat rows; it never mutates tasks/notes (unchanged behavior).
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). — No schema changes; `convex/schema.ts` untouched (frozen per PR #315).
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7). — No styling changes.
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8). — No UI changes.
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13). — No env changes.
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9). — Enforced by a dedicated test.

## Owner tag (§14)

- [ ] `cursor-ide`
- [ ] `cursor-cloud-1`
- [x] `cursor-cloud-2`
- [ ] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

## Reviewer

Amit (`human-amit`). Cloud agent stops at PR-open; no self-merge.

## Notes for the reviewer

- Head branch is `cursor/*`-named instead of the `fix/<id>-<kebab>` convention: this cloud environment can only push `cursor/*`-prefixed branches (403 otherwise). Intended conventional name: `fix/coach-english-replies`.
- `docs/brain/TASKS.md` reference in the repo rules is broken for cloud agents (private submodule) — used Linear as the task source per AGENTS.md.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-188c9fa8-cead-4afe-aca2-4f3d6e451605?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-188c9fa8-cead-4afe-aca2-4f3d6e451605&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

