### PR TITLE
feat(insights): read-only insights.summary query + live Insights screen

### DIFF
--- a/apps/web/app/(tempo)/insights/page.tsx
+++ b/apps/web/app/(tempo)/insights/page.tsx
@@ -1,23 +1,14 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: analytics
  * @category: You
  * @source: docs/design/claude-export/design-system/screens-5.jsx
- * @summary: Personal analytics & trends.
+ * @summary: Personal analytics & trends — read-only insights over tasks, habits, and goals.
  * @queries: insights.summary
  * @mutations: (none)
- * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @auth: required (gentle sign-in card otherwise)
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { InsightsScreen } from "@/components/insights/InsightsScreen";
 
 export default function Page() {
-  return (
-    <ScaffoldScreen
-      title="Insights"
-      category="You"
-      source="screens-5.jsx"
-      summary="Personal analytics & trends."
-    />
-  );
+  return <InsightsScreen />;
 }

--- a/apps/web/components/insights/InsightsScreen.tsx
+++ b/apps/web/components/insights/InsightsScreen.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useConvexAuth, useQuery } from "convex/react";
+import { BarChart3, CheckCircle2, Compass, Flame } from "lucide-react";
+import Link from "next/link";
+import { SoftCard } from "@/components/soft-editorial/SoftCard";
+import { Button } from "@/components/ui/button";
+import { api } from "@/convex/_generated/api";
+import { startOfLocalWeekMondayMs } from "@/lib/localDay";
+import { useLocalDayBounds } from "@/lib/useLocalDayBounds";
+
+/**
+ * Read-only insights surface (reads `insights.summary`; mutates nothing).
+ * Copy follows HARD_RULES §1 — numbers are framed as information, never as
+ * a judgment. Overdue work is "waiting", not "late".
+ */
+
+type EnergyOrPriorityBuckets = { low: number; medium: number; high: number };
+
+function StatCard({
+  icon,
+  label,
+  value,
+  detail,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  detail: string;
+}) {
+  return (
+    <SoftCard className="p-6">
+      <div className="flex items-center gap-3">
+        <div
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary"
+          aria-hidden
+        >
+          {icon}
+        </div>
+        <div className="min-w-0">
+          <p className="text-sm text-muted-foreground">{label}</p>
+          <p className="font-heading text-3xl font-semibold text-foreground">{value}</p>
+        </div>
+      </div>
+      <p className="mt-3 text-sm text-muted-foreground">{detail}</p>
+    </SoftCard>
+  );
+}
+
+function BucketBars({
+  title,
+  buckets,
+  labels,
+}: {
+  title: string;
+  buckets: EnergyOrPriorityBuckets;
+  labels: { low: string; medium: string; high: string };
+}) {
+  const total = buckets.low + buckets.medium + buckets.high;
+  const rows: Array<{ key: keyof EnergyOrPriorityBuckets; label: string; count: number }> = [
+    { key: "high", label: labels.high, count: buckets.high },
+    { key: "medium", label: labels.medium, count: buckets.medium },
+    { key: "low", label: labels.low, count: buckets.low },
+  ];
+
+  return (
+    <SoftCard className="p-6">
+      <h3 className="font-heading text-lg font-semibold text-foreground">{title}</h3>
+      {total === 0 ? (
+        <p className="mt-3 text-sm text-muted-foreground">
+          Nothing open here right now — a quiet list is a fine list.
+        </p>
+      ) : (
+        <ul className="mt-4 space-y-3">
+          {rows.map((row) => {
+            const percent = total === 0 ? 0 : Math.round((row.count / total) * 100);
+            return (
+              <li key={row.key}>
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-foreground">{row.label}</span>
+                  <span className="font-medium text-muted-foreground">
+                    {row.count} ({percent}%)
+                  </span>
+                </div>
+                <div
+                  className="mt-1 h-2 overflow-hidden rounded-full bg-muted"
+                  role="progressbar"
+                  aria-label={`${row.label}: ${row.count} of ${total} open tasks`}
+                  aria-valuenow={row.count}
+                  aria-valuemin={0}
+                  aria-valuemax={total}
+                >
+                  <div className="h-full rounded-full bg-primary/70" style={{ width: `${percent}%` }} />
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </SoftCard>
+  );
+}
+
+export function InsightsScreen() {
+  const bounds = useLocalDayBounds();
+  const weekStartMs = startOfLocalWeekMondayMs(new Date(bounds.startMs));
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const profile = useQuery(api.users.getProfile, isAuthenticated ? {} : "skip");
+  const hasConvexUser = profile != null;
+  const summary = useQuery(
+    api.insights.summary,
+    isAuthenticated && hasConvexUser
+      ? { todayStartMs: bounds.startMs, todayEndMs: bounds.endMs, weekStartMs }
+      : "skip",
+  );
+
+  const isLoading =
+    isAuthLoading ||
+    (isAuthenticated && (profile === undefined || (hasConvexUser && summary === undefined)));
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto max-w-5xl px-6 py-12">
+        <div className="space-y-6">
+          <div className="h-12 w-64 animate-pulse rounded-xl bg-muted" />
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+            <div className="h-36 animate-pulse rounded-2xl bg-muted" />
+            <div className="h-36 animate-pulse rounded-2xl bg-muted" />
+            <div className="h-36 animate-pulse rounded-2xl bg-muted" />
+            <div className="h-36 animate-pulse rounded-2xl bg-muted" />
+          </div>
+          <div className="grid gap-6 md:grid-cols-2">
+            <div className="h-56 animate-pulse rounded-2xl bg-muted" />
+            <div className="h-56 animate-pulse rounded-2xl bg-muted" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated || !profile || !summary) {
+    return (
+      <div className="container mx-auto max-w-5xl px-6 py-16 text-center">
+        <SoftCard className="mx-auto max-w-xl">
+          <h1 className="font-heading text-2xl font-semibold text-foreground">Insights</h1>
+          <p className="mt-3 text-muted-foreground">
+            Sign in to see a calm overview of your tasks, habits, and goals.
+          </p>
+          <Button asChild className="mt-6">
+            <Link href="/sign-in">Sign in</Link>
+          </Button>
+        </SoftCard>
+      </div>
+    );
+  }
+
+  const nothingTrackedYet =
+    summary.tasksOpen === 0 &&
+    summary.tasksCompletedThisWeek === 0 &&
+    summary.habitsTotal === 0 &&
+    summary.goalsActive === 0;
+
+  return (
+    <div className="container mx-auto max-w-5xl px-6 py-12">
+      <div className="space-y-8">
+        <header>
+          <h1 className="font-heading text-3xl font-semibold text-foreground">Insights</h1>
+          <p className="mt-2 text-muted-foreground">
+            A calm snapshot of where things stand. Numbers are information, not judgment.
+          </p>
+        </header>
+
+        {nothingTrackedYet ? (
+          <SoftCard className="text-center">
+            <h2 className="font-heading text-xl font-semibold text-foreground">
+              Nothing tracked yet — and that's okay
+            </h2>
+            <p className="mt-3 text-muted-foreground">
+              As you add tasks, habits, and goals, this page fills in with a gentle overview.
+            </p>
+            <Button asChild className="mt-6">
+              <Link href="/today">Start with Today</Link>
+            </Button>
+          </SoftCard>
+        ) : (
+          <>
+            <section
+              className="grid gap-6 md:grid-cols-2 xl:grid-cols-4"
+              aria-label="Task overview"
+            >
+              <StatCard
+                icon={<CheckCircle2 className="h-5 w-5" aria-hidden />}
+                label="Done this week"
+                value={summary.tasksCompletedThisWeek}
+                detail={
+                  summary.tasksCompletedThisWeek === 0
+                    ? "The week is still open — anything you finish counts."
+                    : "Finished since Monday. Every one of these took real effort."
+                }
+              />
+              <StatCard
+                icon={<Compass className="h-5 w-5" aria-hidden />}
+                label="Due today"
+                value={summary.tasksDueToday}
+                detail={
+                  summary.tasksDueToday === 0
+                    ? "Nothing is asking for attention today."
+                    : "On today's plate. Small steps are enough."
+                }
+              />
+              <StatCard
+                icon={<BarChart3 className="h-5 w-5" aria-hidden />}
+                label="Open tasks"
+                value={summary.tasksOpen}
+                detail={
+                  summary.tasksOverdue === 0
+                    ? "Everything open is either scheduled or flexible."
+                    : `${summary.tasksOverdue} of these have been waiting patiently — pick them up whenever you're ready.`
+                }
+              />
+              <StatCard
+                icon={<Flame className="h-5 w-5" aria-hidden />}
+                label="Active streaks"
+                value={summary.habitsWithActiveStreak}
+                detail={
+                  summary.habitsTotal === 0
+                    ? "No habits tracked yet."
+                    : summary.bestStreak > 0
+                      ? `Across ${summary.habitsTotal} habit${summary.habitsTotal === 1 ? "" : "s"} — best run so far: ${summary.bestStreak} day${summary.bestStreak === 1 ? "" : "s"}.`
+                      : `Across ${summary.habitsTotal} habit${summary.habitsTotal === 1 ? "" : "s"} — fresh starts welcome any day.`
+                }
+              />
+            </section>
+
+            <section className="grid gap-6 md:grid-cols-2" aria-label="Open task breakdowns">
+              <BucketBars
+                title="Open tasks by energy"
+                buckets={summary.openByEnergy}
+                labels={{ low: "Low energy", medium: "Medium energy", high: "High energy" }}
+              />
+              <BucketBars
+                title="Open tasks by priority"
+                buckets={summary.openByPriority}
+                labels={{ low: "Low priority", medium: "Medium priority", high: "High priority" }}
+              />
+            </section>
+
+            <section aria-label="Goals overview">
+              <SoftCard className="p-6">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <h3 className="font-heading text-lg font-semibold text-foreground">Goals</h3>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {summary.goalsActive === 0
+                        ? "No active goals right now — direction can wait until you want it."
+                        : `${summary.goalsActive} active goal${summary.goalsActive === 1 ? "" : "s"}, ${summary.goalsAverageProgressPercent}% along on average.`}
+                    </p>
+                  </div>
+                  <Button asChild variant="outline">
+                    <Link href="/goals">Open goals</Link>
+                  </Button>
+                </div>
+                {summary.goalsActive > 0 ? (
+                  <div
+                    className="mt-4 h-2 overflow-hidden rounded-full bg-muted"
+                    role="progressbar"
+                    aria-label={`Average goal progress: ${summary.goalsAverageProgressPercent}%`}
+                    aria-valuenow={summary.goalsAverageProgressPercent}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                  >
+                    <div
+                      className="h-full rounded-full bg-primary/70"
+                      style={{ width: `${Math.min(Math.max(summary.goalsAverageProgressPercent, 0), 100)}%` }}
+                    />
+                  </div>
+                ) : null}
+              </SoftCard>
+            </section>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as conversations from "../conversations.js";
 import type * as goals from "../goals.js";
 import type * as habits from "../habits.js";
 import type * as http from "../http.js";
+import type * as insights from "../insights.js";
 import type * as lib_ai_errors from "../lib/ai_errors.js";
 import type * as lib_ai_router from "../lib/ai_router.js";
 import type * as lib_requireUser from "../lib/requireUser.js";
@@ -46,6 +47,7 @@ declare const fullApi: ApiFromModules<{
   goals: typeof goals;
   habits: typeof habits;
   http: typeof http;
+  insights: typeof insights;
   "lib/ai_errors": typeof lib_ai_errors;
   "lib/ai_router": typeof lib_ai_router;
   "lib/requireUser": typeof lib_requireUser;

--- a/convex/insights.test.ts
+++ b/convex/insights.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "bun:test";
+import {
+  computeInsightsSummary,
+  type InsightsGoalRow,
+  type InsightsHabitRow,
+  type InsightsTaskRow,
+} from "./insights";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Fixed, timezone-independent windows: "today" is [10 days, 11 days), week starts 4 days before today. */
+const todayStartMs = 10 * DAY_MS;
+const todayEndMs = 11 * DAY_MS;
+const weekStartMs = 6 * DAY_MS;
+
+const windows = { todayStartMs, todayEndMs, weekStartMs };
+
+function task(overrides: Partial<InsightsTaskRow> = {}): InsightsTaskRow {
+  return {
+    status: "todo",
+    priority: "medium",
+    updatedAt: todayStartMs,
+    ...overrides,
+  };
+}
+
+function habit(overrides: Partial<InsightsHabitRow> = {}): InsightsHabitRow {
+  return { currentStreak: 0, longestStreak: 0, ...overrides };
+}
+
+function goal(overrides: Partial<InsightsGoalRow> = {}): InsightsGoalRow {
+  return { status: "active", progressPercent: 0, ...overrides };
+}
+
+function summarize(input: {
+  tasks?: InsightsTaskRow[];
+  habits?: InsightsHabitRow[];
+  goals?: InsightsGoalRow[];
+}) {
+  return computeInsightsSummary({
+    tasks: input.tasks ?? [],
+    habits: input.habits ?? [],
+    goals: input.goals ?? [],
+    ...windows,
+  });
+}
+
+describe("computeInsightsSummary", () => {
+  test("empty inputs produce an all-zero summary", () => {
+    const s = summarize({});
+    expect(s).toEqual({
+      tasksOpen: 0,
+      tasksDueToday: 0,
+      tasksOverdue: 0,
+      tasksCompletedThisWeek: 0,
+      openByEnergy: { low: 0, medium: 0, high: 0 },
+      openByPriority: { low: 0, medium: 0, high: 0 },
+      habitsTotal: 0,
+      habitsWithActiveStreak: 0,
+      bestStreak: 0,
+      goalsActive: 0,
+      goalsAverageProgressPercent: 0,
+    });
+  });
+
+  test("soft-deleted rows are excluded everywhere", () => {
+    const s = summarize({
+      tasks: [task({ deletedAt: 1, dueAt: todayStartMs })],
+      habits: [habit({ deletedAt: 1, currentStreak: 5, longestStreak: 9 })],
+      goals: [goal({ deletedAt: 1, progressPercent: 80 })],
+    });
+    expect(s.tasksOpen).toBe(0);
+    expect(s.tasksDueToday).toBe(0);
+    expect(s.habitsTotal).toBe(0);
+    expect(s.bestStreak).toBe(0);
+    expect(s.goalsActive).toBe(0);
+  });
+
+  test("done and cancelled tasks are not open, due today, or overdue", () => {
+    const s = summarize({
+      tasks: [
+        task({ status: "done", dueAt: todayStartMs - 1 }),
+        task({ status: "cancelled", dueAt: todayStartMs + 1 }),
+      ],
+    });
+    expect(s.tasksOpen).toBe(0);
+    expect(s.tasksDueToday).toBe(0);
+    expect(s.tasksOverdue).toBe(0);
+  });
+
+  test("due-today vs overdue boundaries are exact at todayStartMs / todayEndMs", () => {
+    const s = summarize({
+      tasks: [
+        task({ dueAt: todayStartMs - 1 }), // overdue
+        task({ dueAt: todayStartMs }), // due today (inclusive start)
+        task({ dueAt: todayEndMs - 1 }), // due today
+        task({ dueAt: todayEndMs }), // future — neither bucket
+        task({}), // no dueAt — open only
+      ],
+    });
+    expect(s.tasksOpen).toBe(5);
+    expect(s.tasksDueToday).toBe(2);
+    expect(s.tasksOverdue).toBe(1);
+  });
+
+  test("in_progress counts as open", () => {
+    const s = summarize({ tasks: [task({ status: "in_progress" })] });
+    expect(s.tasksOpen).toBe(1);
+  });
+
+  test("completed-this-week uses updatedAt >= weekStartMs on done tasks only", () => {
+    const s = summarize({
+      tasks: [
+        task({ status: "done", updatedAt: weekStartMs }), // counts (inclusive)
+        task({ status: "done", updatedAt: weekStartMs - 1 }), // too old
+        task({ status: "todo", updatedAt: weekStartMs + 1 }), // not done
+      ],
+    });
+    expect(s.tasksCompletedThisWeek).toBe(1);
+  });
+
+  test("missing energy counts as medium; priority buckets are exact", () => {
+    const s = summarize({
+      tasks: [
+        task({ energy: "low", priority: "high" }),
+        task({ energy: undefined, priority: "low" }),
+        task({ energy: "high", priority: "medium" }),
+        task({ energy: "medium", priority: "medium" }),
+      ],
+    });
+    expect(s.openByEnergy).toEqual({ low: 1, medium: 2, high: 1 });
+    expect(s.openByPriority).toEqual({ low: 1, medium: 2, high: 1 });
+  });
+
+  test("closed tasks do not contribute to energy/priority buckets", () => {
+    const s = summarize({
+      tasks: [task({ status: "done", energy: "high", priority: "high" })],
+    });
+    expect(s.openByEnergy).toEqual({ low: 0, medium: 0, high: 0 });
+    expect(s.openByPriority).toEqual({ low: 0, medium: 0, high: 0 });
+  });
+
+  test("habit streak aggregates: active streaks and best-ever streak", () => {
+    const s = summarize({
+      habits: [
+        habit({ currentStreak: 3, longestStreak: 7 }),
+        habit({ currentStreak: 0, longestStreak: 12 }),
+        habit({ currentStreak: 1, longestStreak: 1 }),
+      ],
+    });
+    expect(s.habitsTotal).toBe(3);
+    expect(s.habitsWithActiveStreak).toBe(2);
+    expect(s.bestStreak).toBe(12);
+  });
+
+  test("goal aggregates average only active goals and round the result", () => {
+    const s = summarize({
+      goals: [
+        goal({ progressPercent: 10 }),
+        goal({ progressPercent: 25 }),
+        goal({ status: "completed", progressPercent: 100 }),
+        goal({ status: "archived", progressPercent: 0 }),
+      ],
+    });
+    expect(s.goalsActive).toBe(2);
+    expect(s.goalsAverageProgressPercent).toBe(18); // round(17.5)
+  });
+});

--- a/convex/insights.ts
+++ b/convex/insights.ts
@@ -1,0 +1,194 @@
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+import { requireUser } from "./lib/requireUser";
+
+/**
+ * Read-only insights for the /insights screen.
+ *
+ * HARD_RULES §10 / Convex rule `no-date-now-in-queries`: the caller passes the
+ * local-day and local-week windows (derived client-side from the user's clock);
+ * the query body never touches wall-clock time, so results stay cacheable and
+ * reactive.
+ *
+ * The query returns computed scalars only — never raw table rows — so the
+ * `returns` validator cannot drift from `convex/schema.ts` field lists.
+ */
+
+/** Guard against absurd client windows (DST-tolerant day, one-week lookback). */
+const maxDayWindowMs = 48 * 60 * 60 * 1000;
+const maxWeekLookbackMs = 9 * 24 * 60 * 60 * 1000;
+
+export type InsightsTaskRow = {
+  status: "todo" | "in_progress" | "done" | "cancelled";
+  priority: "low" | "medium" | "high";
+  energy?: "low" | "medium" | "high";
+  dueAt?: number;
+  updatedAt: number;
+  deletedAt?: number;
+};
+
+export type InsightsHabitRow = {
+  currentStreak: number;
+  longestStreak: number;
+  deletedAt?: number;
+};
+
+export type InsightsGoalRow = {
+  status: "active" | "completed" | "archived";
+  progressPercent: number;
+  deletedAt?: number;
+};
+
+export type InsightsSummary = {
+  tasksOpen: number;
+  tasksDueToday: number;
+  tasksOverdue: number;
+  tasksCompletedThisWeek: number;
+  openByEnergy: { low: number; medium: number; high: number };
+  openByPriority: { low: number; medium: number; high: number };
+  habitsTotal: number;
+  habitsWithActiveStreak: number;
+  bestStreak: number;
+  goalsActive: number;
+  goalsAverageProgressPercent: number;
+};
+
+/**
+ * Pure aggregation over already-fetched rows. Exported for unit tests
+ * (convex/insights.test.ts) — the query handler is a thin wrapper around this.
+ *
+ * Conventions:
+ * - "open" task = status todo/in_progress and not soft-deleted.
+ * - overdue = open with a dueAt strictly before todayStartMs.
+ * - completed this week = done with updatedAt >= weekStartMs (updatedAt is set
+ *   on every mutation, so it marks the completion moment for done tasks).
+ * - a task without an energy level counts as "medium" (matches tasks.list).
+ */
+export function computeInsightsSummary(input: {
+  tasks: InsightsTaskRow[];
+  habits: InsightsHabitRow[];
+  goals: InsightsGoalRow[];
+  todayStartMs: number;
+  todayEndMs: number;
+  weekStartMs: number;
+}): InsightsSummary {
+  const liveTasks = input.tasks.filter((t) => t.deletedAt === undefined);
+  const openTasks = liveTasks.filter((t) => t.status === "todo" || t.status === "in_progress");
+
+  const openByEnergy = { low: 0, medium: 0, high: 0 };
+  const openByPriority = { low: 0, medium: 0, high: 0 };
+  let tasksDueToday = 0;
+  let tasksOverdue = 0;
+
+  for (const task of openTasks) {
+    openByEnergy[task.energy ?? "medium"] += 1;
+    openByPriority[task.priority] += 1;
+    if (task.dueAt !== undefined) {
+      if (task.dueAt >= input.todayStartMs && task.dueAt < input.todayEndMs) {
+        tasksDueToday += 1;
+      } else if (task.dueAt < input.todayStartMs) {
+        tasksOverdue += 1;
+      }
+    }
+  }
+
+  const tasksCompletedThisWeek = liveTasks.filter(
+    (t) => t.status === "done" && t.updatedAt >= input.weekStartMs,
+  ).length;
+
+  const liveHabits = input.habits.filter((h) => h.deletedAt === undefined);
+  const habitsWithActiveStreak = liveHabits.filter((h) => h.currentStreak > 0).length;
+  let bestStreak = 0;
+  for (const habit of liveHabits) {
+    if (habit.longestStreak > bestStreak) {
+      bestStreak = habit.longestStreak;
+    }
+  }
+
+  const liveGoals = input.goals.filter((g) => g.deletedAt === undefined);
+  const activeGoals = liveGoals.filter((g) => g.status === "active");
+  const goalsAverageProgressPercent =
+    activeGoals.length === 0
+      ? 0
+      : Math.round(
+          activeGoals.reduce((sum, goal) => sum + goal.progressPercent, 0) / activeGoals.length,
+        );
+
+  return {
+    tasksOpen: openTasks.length,
+    tasksDueToday,
+    tasksOverdue,
+    tasksCompletedThisWeek,
+    openByEnergy,
+    openByPriority,
+    habitsTotal: liveHabits.length,
+    habitsWithActiveStreak,
+    bestStreak,
+    goalsActive: activeGoals.length,
+    goalsAverageProgressPercent,
+  };
+}
+
+export const summary = query({
+  args: {
+    /** Epoch ms at the start of the user's local "today". */
+    todayStartMs: v.number(),
+    /** Epoch ms at the end of the user's local "today" (exclusive). */
+    todayEndMs: v.number(),
+    /** Epoch ms at the start of the user's local week (Monday 00:00). */
+    weekStartMs: v.number(),
+  },
+  returns: v.object({
+    tasksOpen: v.number(),
+    tasksDueToday: v.number(),
+    tasksOverdue: v.number(),
+    tasksCompletedThisWeek: v.number(),
+    openByEnergy: v.object({ low: v.number(), medium: v.number(), high: v.number() }),
+    openByPriority: v.object({ low: v.number(), medium: v.number(), high: v.number() }),
+    habitsTotal: v.number(),
+    habitsWithActiveStreak: v.number(),
+    bestStreak: v.number(),
+    goalsActive: v.number(),
+    goalsAverageProgressPercent: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    if (args.todayEndMs <= args.todayStartMs) {
+      throw new Error("Today window must end after it starts.");
+    }
+    if (args.todayEndMs - args.todayStartMs > maxDayWindowMs) {
+      throw new Error("Today window is too large.");
+    }
+    if (args.weekStartMs > args.todayStartMs) {
+      throw new Error("Week must start on or before today.");
+    }
+    if (args.todayStartMs - args.weekStartMs > maxWeekLookbackMs) {
+      throw new Error("Week window is too large.");
+    }
+
+    const user = await requireUser(ctx);
+
+    const [tasks, habits, goals] = await Promise.all([
+      ctx.db
+        .query("tasks")
+        .withIndex("by_userId", (q) => q.eq("userId", user._id))
+        .collect(),
+      ctx.db
+        .query("habits")
+        .withIndex("by_userId", (q) => q.eq("userId", user._id))
+        .collect(),
+      ctx.db
+        .query("goals")
+        .withIndex("by_userId", (q) => q.eq("userId", user._id))
+        .collect(),
+    ]);
+
+    return computeInsightsSummary({
+      tasks,
+      habits,
+      goals,
+      todayStartMs: args.todayStartMs,
+      todayEndMs: args.todayEndMs,
+      weekStartMs: args.weekStartMs,
+    });
+  },
+});


### PR DESCRIPTION
## Summary

The `/insights` route was a ScaffoldScreen placeholder whose header already declared its contract (`@queries: insights.summary`). This PR makes that contract real: a read-only Convex `insights.summary` query aggregating tasks, habits, and goals, and a live Insights screen that presents the numbers as information, never judgment (HARD_RULES §1). Pure "reads and recommends" surface — the screen mutates nothing.

## Linked task(s)

Task: scaffold contract in `apps/web/app/(tempo)/insights/page.tsx` (T-F004 scaffold → this is the follow-up port; no readable `T-XXXX` row — `docs/brain/TASKS.md` is a private submodule cloud agents cannot read, per AGENTS.md appendix).

## Test plan

- [x] Local `bun run typecheck` passes (plus direct `tsc --noEmit -p convex/tsconfig.json`)
- [x] Local `bun run lint` passes
- [x] New `convex/insights.test.ts` (10 tests): all-zero empty summary, soft-delete exclusion everywhere, done/cancelled exclusion, exact due-today/overdue boundaries at `todayStartMs`/`todayEndMs`, in_progress-as-open, completed-this-week via `updatedAt >= weekStartMs`, energy default to medium, closed-task bucket exclusion, streak aggregates, active-goal-only averaging with rounding
- [x] `bun run test` → 54 pass / 0 fail; all four scans + notices check green locally on top of `integration` @ 1c2a654
- [x] Reproduces the acceptance criteria below

## Screenshots / screen recording

Could not run the web app in this cloud environment against a real Convex deployment (no deployment credentials available to the agent), so no screenshot — the screen follows the exact auth-gating and layout patterns of the existing `TodayScreen` (skeleton → sign-in card → content) and the aggregation logic is fully unit-tested.

## Acceptance criteria

- `insights.summary` exists, is auth-checked (`requireUser`), reads only via `by_userId` indexes, and filters soft-deleted rows.
- The query never calls `Date.now()` — local-day and local-week windows are passed from the client (existing `useLocalDayBounds` + `startOfLocalWeekMondayMs`) and sanity-validated (ordering + max range).
- `/insights` renders live per-user aggregates: done this week, due today, open (overdue framed gently), active habit streaks, energy/priority breakdowns of open tasks, and average active-goal progress.
- Loading skeleton, signed-out card, and a kind empty state are all present.

## Convex validator note (per today's validator bugs)

`summary` returns **computed scalars only — no table rows** — so the `returns:` validator cannot omit stored fields by construction. Validator: `tasksOpen, tasksDueToday, tasksOverdue, tasksCompletedThisWeek, openByEnergy{low,medium,high}, openByPriority{low,medium,high}, habitsTotal, habitsWithActiveStreak, bestStreak, goalsActive, goalsAverageProgressPercent` — all `v.number()`. Schema fields consumed and checked against `convex/schema.ts`: tasks(`status, priority, energy, dueAt, updatedAt, deletedAt`), habits(`currentStreak, longestStreak, deletedAt`), goals(`status, progressPercent, deletedAt`). `convex/schema.ts` untouched (frozen per #315).

`convex/_generated/api.d.ts` was regenerated with the real convex CLI (`CONVEX_AGENT_MODE=anonymous bun x convex dev --once` against the cached local backend) — the diff is the expected mechanical two-line `insights` registration.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2).
- [x] AI-originated state changes surface an accept / edit / reject card (§1, §6) — N/A: no AI, no mutations at all.
- [x] Schema changes respect §5 — no schema changes.
- [x] Styling uses design tokens (§7) — semantic Tailwind utilities only; design-token scan unchanged at 18/2 baseline.
- [x] Accessibility (§8): stat bars use `role="progressbar"` with labels/min/max, sections have `aria-label`s, icons are `aria-hidden`.
- [x] No secrets committed; no new env vars (§13).
- [x] Anti-shame copy (§1): overdue = "waiting patiently — pick them up whenever you're ready"; empty state = "Nothing tracked yet — and that's okay".

## Owner tag (§14)

- [x] `cursor-cloud-2`

## Reviewer

Amit (`human-amit`). Cloud agent stops at PR-open; no self-merge.

## Notes for the reviewer

- Head branch is `cursor/insights-summary-3a0b` (this cloud environment can only push `cursor/*` branches; intended conventional name: `feat/insights-summary-read-surface`).
- No file overlap with #321 (same unattended run, disjoint file sets).