### PR TITLE
feat(today): energy-aware task recommendations with accept/reject (T-007c)

### DIFF
--- a/apps/web/components/today/TodayEnergyRecommendations.tsx
+++ b/apps/web/components/today/TodayEnergyRecommendations.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useMutation, useQuery } from "convex/react";
+import { BatteryLow, BatteryMedium, Plus, Sparkles, X, Zap } from "lucide-react";
+import { useState } from "react";
+import type { Id } from "@/convex/_generated/dataModel";
+import { api } from "@/convex/_generated/api";
+import {
+  type EnergyLevel,
+  recommendTasksForEnergy,
+} from "@/lib/energyRecommendations";
+import { cn } from "@/lib/utils";
+
+/**
+ * T-007c — energy-aware suggestions with an explicit accept / reject step.
+ *
+ * Reads the user's open tasks and recommends up to three that fit the energy
+ * level they pick. Accepting ("Add to Today") calls the existing
+ * `tasks.update` mutation with today's dueAt; "Not now" dismisses locally.
+ * Nothing is ever applied without the user's click (HARD_RULES §1).
+ */
+
+type TodayEnergyRecommendationsProps = {
+  /** End-of-today dueAt to stamp on accepted tasks (bounds.endMs - 1). */
+  dueAt: number;
+  todayStartMs: number;
+  todayEndMs: number;
+};
+
+const ENERGY_OPTIONS: Array<{ level: EnergyLevel; label: string; icon: React.ReactNode }> = [
+  { level: "low", label: "Low", icon: <BatteryLow className="h-4 w-4" aria-hidden /> },
+  { level: "medium", label: "Medium", icon: <BatteryMedium className="h-4 w-4" aria-hidden /> },
+  { level: "high", label: "High", icon: <Zap className="h-4 w-4" aria-hidden /> },
+];
+
+export function TodayEnergyRecommendations({
+  dueAt,
+  todayStartMs,
+  todayEndMs,
+}: TodayEnergyRecommendationsProps) {
+  const [energy, setEnergy] = useState<EnergyLevel | null>(null);
+  const [dismissedIds, setDismissedIds] = useState<ReadonlySet<string>>(new Set());
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const updateTask = useMutation(api.tasks.update);
+
+  // Only subscribe once the user has opted in by picking an energy level.
+  const tasks = useQuery(api.tasks.list, energy !== null ? {} : "skip");
+
+  const recommendations =
+    energy !== null && tasks !== undefined
+      ? recommendTasksForEnergy(
+          tasks.map((t) => ({
+            id: t._id,
+            title: t.title,
+            status: t.status,
+            priority: t.priority,
+            energy: t.energy,
+            dueAt: t.dueAt,
+            updatedAt: t.updatedAt,
+          })),
+          { energy, todayStartMs, todayEndMs, dismissedIds },
+        )
+      : null;
+
+  const acceptTask = async (taskId: string) => {
+    setPendingId(taskId);
+    try {
+      await updateTask({ taskId: taskId as Id<"tasks">, dueAt });
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const dismissTask = (taskId: string) => {
+    setDismissedIds((prev) => {
+      const next = new Set(prev);
+      next.add(taskId);
+      return next;
+    });
+  };
+
+  return (
+    <section
+      className="rounded-3xl border border-border/80 bg-card/90 p-6 shadow-[0_10px_30px_rgba(26,25,23,0.08)]"
+      aria-labelledby="energy-recommendations-heading"
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <Sparkles className="h-5 w-5" aria-hidden />
+        </div>
+        <div>
+          <h2
+            id="energy-recommendations-heading"
+            className="font-heading text-2xl font-semibold text-foreground"
+          >
+            Match your energy
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            How's your energy right now? We'll suggest tasks that fit — you decide.
+          </p>
+        </div>
+      </div>
+
+      <fieldset className="mt-4 flex flex-wrap gap-2 border-0 p-0">
+        <legend className="sr-only">Pick your current energy level</legend>
+        {ENERGY_OPTIONS.map((option) => {
+          const isActive = energy === option.level;
+          return (
+            <button
+              key={option.level}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => setEnergy(isActive ? null : option.level)}
+              className={cn(
+                "flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+                isActive
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-background/70 text-foreground hover:border-primary hover:text-primary",
+              )}
+            >
+              {option.icon}
+              {option.label}
+            </button>
+          );
+        })}
+      </fieldset>
+
+      {energy === null ? null : recommendations === null ? (
+        <div className="mt-4 space-y-3" aria-hidden>
+          <div className="h-16 animate-pulse rounded-2xl bg-muted" />
+          <div className="h-16 animate-pulse rounded-2xl bg-muted" />
+        </div>
+      ) : recommendations.length === 0 ? (
+        <div className="mt-4 rounded-2xl border border-dashed border-border bg-muted/30 px-5 py-6 text-center">
+          <p className="text-base text-foreground">
+            Nothing outside today's plan fits that energy right now.
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            That's a fine answer — today's list already has you covered.
+          </p>
+        </div>
+      ) : (
+        <ul className="mt-4 space-y-3">
+          {recommendations.map(({ task, reason }) => (
+            <li
+              key={task.id}
+              className="rounded-2xl border border-border/80 bg-background/70 px-4 py-4"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium text-foreground">{task.title}</p>
+                  <p className="mt-0.5 text-sm text-muted-foreground">{reason}</p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    disabled={pendingId === task.id}
+                    onClick={() => {
+                      void acceptTask(task.id);
+                    }}
+                    className="flex items-center gap-1.5 rounded-full bg-primary px-3.5 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-60"
+                    aria-label={`Add ${task.title} to Today`}
+                  >
+                    <Plus className="h-4 w-4" aria-hidden />
+                    Add to Today
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => dismissTask(task.id)}
+                    className="flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-2 text-sm font-medium text-muted-foreground transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                    aria-label={`Not now: ${task.title}`}
+                  >
+                    <X className="h-4 w-4" aria-hidden />
+                    Not now
+                  </button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/today/TodayScreen.tsx
+++ b/apps/web/components/today/TodayScreen.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { api } from "@/convex/_generated/api";
 import { useLocalDayBounds } from "@/lib/useLocalDayBounds";
 import { TodayBrainDumpPanel } from "./TodayBrainDumpPanel";
+import { TodayEnergyRecommendations } from "./TodayEnergyRecommendations";
 import { TodayGreeting } from "./TodayGreeting";
 import { TodayQuickAdd } from "./TodayQuickAdd";
 import { TodayTaskList } from "./TodayTaskList";
@@ -76,6 +77,11 @@ export function TodayScreen() {
           <TodayQuickAdd dueAt={bounds.endMs - 1} />
           <TodayTaskList tasks={todayTasks} />
         </div>
+        <TodayEnergyRecommendations
+          dueAt={bounds.endMs - 1}
+          todayStartMs={bounds.startMs}
+          todayEndMs={bounds.endMs}
+        />
       </div>
     </div>
   );

--- a/apps/web/lib/energyRecommendations.test.ts
+++ b/apps/web/lib/energyRecommendations.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type RecommendableTask,
+  recommendTasksForEnergy,
+} from "./energyRecommendations";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const todayStartMs = 10 * DAY_MS;
+const todayEndMs = 11 * DAY_MS;
+
+let nextId = 0;
+
+function task(overrides: Partial<RecommendableTask> = {}): RecommendableTask {
+  nextId += 1;
+  return {
+    id: `t${nextId}`,
+    title: `Task ${nextId}`,
+    status: "todo",
+    priority: "medium",
+    updatedAt: todayStartMs - DAY_MS,
+    ...overrides,
+  };
+}
+
+function recommend(
+  tasks: RecommendableTask[],
+  overrides: Partial<Parameters<typeof recommendTasksForEnergy>[1]> = {},
+) {
+  return recommendTasksForEnergy(tasks, {
+    energy: "medium",
+    todayStartMs,
+    todayEndMs,
+    ...overrides,
+  });
+}
+
+describe("recommendTasksForEnergy", () => {
+  test("returns nothing for an empty task list", () => {
+    expect(recommend([])).toEqual([]);
+  });
+
+  test("only todo and in_progress tasks are candidates", () => {
+    const open = task({ energy: "medium" });
+    const inProgress = task({ energy: "medium", status: "in_progress" });
+    const picks = recommend([
+      open,
+      inProgress,
+      task({ energy: "medium", status: "done" }),
+      task({ energy: "medium", status: "cancelled" }),
+    ]);
+    expect(picks.map((p) => p.task.id).toSorted()).toEqual([open.id, inProgress.id].toSorted());
+  });
+
+  test("tasks already due today are excluded; other dueAt values are not", () => {
+    const dueToday = task({ energy: "medium", dueAt: todayStartMs });
+    const dueTodayEdge = task({ energy: "medium", dueAt: todayEndMs - 1 });
+    const dueTomorrow = task({ energy: "medium", dueAt: todayEndMs });
+    const overdue = task({ energy: "medium", dueAt: todayStartMs - 1 });
+    const picks = recommend([dueToday, dueTodayEdge, dueTomorrow, overdue]);
+    const ids = picks.map((p) => p.task.id);
+    expect(ids).not.toContain(dueToday.id);
+    expect(ids).not.toContain(dueTodayEdge.id);
+    expect(ids).toContain(dueTomorrow.id);
+    expect(ids).toContain(overdue.id);
+  });
+
+  test("exact energy matches come first and are flagged exactMatch", () => {
+    const low = task({ energy: "low" });
+    const medium = task({ energy: "medium" });
+    const picks = recommend([low, medium], { energy: "low" });
+    expect(picks[0]?.task.id).toBe(low.id);
+    expect(picks[0]?.exactMatch).toBe(true);
+    expect(picks[1]?.task.id).toBe(medium.id);
+    expect(picks[1]?.exactMatch).toBe(false);
+  });
+
+  test("a task without an energy level counts as medium", () => {
+    const unlabelled = task({ energy: undefined });
+    const picks = recommend([unlabelled], { energy: "medium" });
+    expect(picks[0]?.task.id).toBe(unlabelled.id);
+    expect(picks[0]?.exactMatch).toBe(true);
+  });
+
+  test("low-energy request never surfaces high-energy work", () => {
+    const high = task({ energy: "high" });
+    const picks = recommend([high], { energy: "low" });
+    expect(picks).toEqual([]);
+  });
+
+  test("high-energy request never surfaces low-energy work", () => {
+    const low = task({ energy: "low" });
+    const picks = recommend([low], { energy: "high" });
+    expect(picks).toEqual([]);
+  });
+
+  test("ranking: higher priority first, then longest-waiting task", () => {
+    const oldLowPriority = task({ energy: "medium", priority: "low", updatedAt: 1 });
+    const newHighPriority = task({ energy: "medium", priority: "high", updatedAt: 9 * DAY_MS });
+    const oldHighPriority = task({ energy: "medium", priority: "high", updatedAt: 1 });
+    const picks = recommend([oldLowPriority, newHighPriority, oldHighPriority]);
+    expect(picks.map((p) => p.task.id)).toEqual([
+      oldHighPriority.id,
+      newHighPriority.id,
+      oldLowPriority.id,
+    ]);
+  });
+
+  test("limit caps results (default 3)", () => {
+    const tasks = [task(), task(), task(), task(), task()].map((t) => ({
+      ...t,
+      energy: "medium" as const,
+    }));
+    expect(recommend(tasks)).toHaveLength(3);
+    expect(recommend(tasks, { limit: 2 })).toHaveLength(2);
+    expect(recommend(tasks, { limit: 0 })).toEqual([]);
+  });
+
+  test("dismissed tasks are never re-suggested", () => {
+    const a = task({ energy: "medium" });
+    const b = task({ energy: "medium" });
+    const picks = recommend([a, b], { dismissedIds: new Set([a.id]) });
+    expect(picks.map((p) => p.task.id)).toEqual([b.id]);
+  });
+
+  test("fallback fills remaining slots after exact matches, in preference order", () => {
+    const exact = task({ energy: "medium" });
+    const low = task({ energy: "low" });
+    const high = task({ energy: "high" });
+    const picks = recommend([high, low, exact], { energy: "medium" });
+    expect(picks.map((p) => p.task.id)).toEqual([exact.id, low.id, high.id]);
+    expect(picks.map((p) => p.exactMatch)).toEqual([true, false, false]);
+  });
+
+  test("every reason string is shame-free", () => {
+    const picks = recommend(
+      [task({ energy: "medium" }), task({ energy: "low" }), task({ energy: "high" })],
+      { energy: "medium" },
+    );
+    for (const pick of picks) {
+      expect(pick.reason).not.toMatch(/\b(behind|failing|failure|lazy|overdue|late)\b/i);
+    }
+  });
+
+  test("does not mutate the input array", () => {
+    const tasks = [
+      task({ energy: "medium", priority: "low" }),
+      task({ energy: "medium", priority: "high" }),
+    ];
+    const order = tasks.map((t) => t.id);
+    recommend(tasks);
+    expect(tasks.map((t) => t.id)).toEqual(order);
+  });
+});

--- a/apps/web/lib/energyRecommendations.ts
+++ b/apps/web/lib/energyRecommendations.ts
@@ -1,0 +1,138 @@
+/**
+ * T-007c — energy-aware task recommendations (pure logic, unit-tested).
+ *
+ * Given the user's current energy level and their open tasks, pick a small,
+ * non-overwhelming set of tasks that fit how they feel right now. This module
+ * only READS and RECOMMENDS — accepting a recommendation is an explicit user
+ * action handled by the UI via the existing `tasks.update` mutation
+ * (HARD_RULES §1: nothing is ever applied silently).
+ */
+
+export type EnergyLevel = "low" | "medium" | "high";
+
+export type RecommendableTask = {
+  id: string;
+  title: string;
+  status: "todo" | "in_progress" | "done" | "cancelled";
+  priority: "low" | "medium" | "high";
+  energy?: EnergyLevel;
+  dueAt?: number;
+  updatedAt: number;
+};
+
+export type EnergyRecommendation = {
+  task: RecommendableTask;
+  /** True when the task's energy is exactly the requested level (vs. a nearby fallback). */
+  exactMatch: boolean;
+  /** Shame-free, one-line explanation for why this task is suggested. */
+  reason: string;
+};
+
+const PRIORITY_RANK: Record<RecommendableTask["priority"], number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+/** Neighbouring energy levels to fall back to, in preference order. */
+const ENERGY_FALLBACK: Record<EnergyLevel, EnergyLevel[]> = {
+  low: ["medium"],
+  medium: ["low", "high"],
+  high: ["medium"],
+};
+
+const EXACT_REASON: Record<EnergyLevel, string> = {
+  low: "A gentle fit for low energy — small effort, real progress.",
+  medium: "A steady fit for how you're feeling right now.",
+  high: "You've got momentum — this one is sized for it.",
+};
+
+const FALLBACK_REASON: Record<EnergyLevel, string> = {
+  low: "Close to your current energy — only if it feels right.",
+  medium: "Slightly off your current energy, but very doable.",
+  high: "Not quite max-energy work, but momentum makes it easy.",
+};
+
+function taskEnergy(task: RecommendableTask): EnergyLevel {
+  return task.energy ?? "medium";
+}
+
+/**
+ * Ranking inside an energy bucket: higher priority first, then the task that
+ * has waited longest (oldest updatedAt) — quietly resurfacing stale work
+ * without ever calling it "overdue".
+ */
+function rankCandidates(a: RecommendableTask, b: RecommendableTask): number {
+  const byPriority = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
+  if (byPriority !== 0) {
+    return byPriority;
+  }
+  return a.updatedAt - b.updatedAt;
+}
+
+export function recommendTasksForEnergy(
+  tasks: RecommendableTask[],
+  options: {
+    energy: EnergyLevel;
+    /** Local-day window — tasks already due today are excluded (they're on the plan). */
+    todayStartMs: number;
+    todayEndMs: number;
+    /** Maximum number of recommendations (default 3). */
+    limit?: number;
+    /** Task ids the user dismissed this session ("Not now"); never re-suggested. */
+    dismissedIds?: ReadonlySet<string>;
+  },
+): EnergyRecommendation[] {
+  const limit = options.limit ?? 3;
+  if (limit <= 0) {
+    return [];
+  }
+  const dismissed = options.dismissedIds ?? new Set<string>();
+
+  const candidates = tasks.filter((task) => {
+    if (task.status !== "todo" && task.status !== "in_progress") {
+      return false;
+    }
+    if (dismissed.has(task.id)) {
+      return false;
+    }
+    // Already due today → it is on today's plan; don't recommend it again.
+    if (
+      task.dueAt !== undefined &&
+      task.dueAt >= options.todayStartMs &&
+      task.dueAt < options.todayEndMs
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  const exact = candidates
+    .filter((task) => taskEnergy(task) === options.energy)
+    .toSorted(rankCandidates);
+
+  const picks: EnergyRecommendation[] = exact.slice(0, limit).map((task) => ({
+    task,
+    exactMatch: true,
+    reason: EXACT_REASON[options.energy],
+  }));
+
+  if (picks.length < limit) {
+    for (const fallbackLevel of ENERGY_FALLBACK[options.energy]) {
+      if (picks.length >= limit) {
+        break;
+      }
+      const fallback = candidates
+        .filter((task) => taskEnergy(task) === fallbackLevel)
+        .toSorted(rankCandidates);
+      for (const task of fallback) {
+        if (picks.length >= limit) {
+          break;
+        }
+        picks.push({ task, exactMatch: false, reason: FALLBACK_REASON[options.energy] });
+      }
+    }
+  }
+
+  return picks;
+}


### PR DESCRIPTION
## Summary

Implements the task-side half of Linear ticket **T-007c — "Energy-aware suggestions (accept/reject) + shame-free copy scan"**. The authenticated Today screen gains an opt-in "Match your energy" panel: the user picks how their energy feels right now, and up to three open tasks that fit are suggested — each with an explicit **Add to Today** (accept) and **Not now** (reject) action. This reads and recommends only; nothing is ever applied without the user's click (HARD_RULES §1 accept-reject law).

## Linked task(s)

Task: Linear — T-007c — Energy-aware suggestions (accept/reject) + shame-free copy scan. (`docs/brain/TASKS.md` is a private submodule cloud agents cannot read, per AGENTS.md appendix.)

## How it works

- **Pure logic** in `apps/web/lib/energyRecommendations.ts` (`recommendTasksForEnergy`): candidates are open (`todo`/`in_progress`) tasks **not already due today**; exact energy matches first (a task without an energy label counts as `medium`, matching `tasks.list` semantics); neighbouring-energy fallback fills remaining slots (low→medium, medium→low,high, high→medium — low-energy users are never handed high-energy work and vice versa); ranked by priority, then longest-waiting (quietly resurfacing stale tasks without calling them "overdue").
- **Accept** = existing `api.tasks.update` mutation with `dueAt = bounds.endMs - 1` (same convention as TodayQuickAdd) — the task joins today's plan and reactively disappears from the suggestions (it is now due today).
- **Reject** ("Not now") = session-local dismissal; never re-suggested this session; no data is written.
- The `tasks.list` subscription only starts after the user opts in by picking an energy level.
- **No new Convex functions** — uses existing `tasks.list` + `tasks.update` only. No validators written; `convex/` untouched.

## Test plan

- [x] Local `bun run typecheck` passes
- [x] Local `bun run lint` passes (fixed a `useSemanticElements` a11y finding by using `fieldset`/`legend` for the energy picker)
- [x] New `apps/web/lib/energyRecommendations.test.ts` — 13 tests: empty input, candidacy (done/cancelled excluded), exact today-window exclusion boundaries (`todayStartMs` inclusive, `todayEndMs` exclusive), exact-match-first with `exactMatch` flags, medium default for unlabelled tasks, low↔high never crossing, priority-then-staleness ranking, limit cap (default 3, 0 → none), dismissal, fallback preference order, shame-free reason copy, input-array immutability
- [x] `bun run test` → 57 pass / 0 fail; all four scans + notices check green locally on top of `integration` @ 1c2a654

## Screenshots / screen recording

Could not run the web app against a real Convex deployment in this cloud environment (no deployment credentials), so no screenshot — the panel follows the exact card/list styling of the adjacent `TodayTaskList` and all recommendation logic is unit-tested.

## Acceptance criteria (from the ticket title)

- Energy-aware suggestions: ✓ (energy picker → up to 3 fitting open tasks)
- Accept/reject: ✓ (explicit Add to Today / Not now per suggestion; nothing silent)
- Shame-free copy scan: ✓ (reason strings unit-tested against shame vocabulary; empty state is kind)

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2) — React local state only; Convex reactive queries remain the state.
- [x] Accept / reject surfaced for every suggested change (§1, §6) — core of the feature.
- [x] No schema changes (§5) — `convex/` untouched; schema frozen per #315.
- [x] Styling uses semantic tokens (§7) — design-token scan unchanged at 18/2 baseline.
- [x] Accessibility (§8) — `fieldset`+`legend` picker, `aria-pressed` pills, per-task `aria-label`s on accept/dismiss buttons, `focus-visible` rings.
- [x] No secrets; no new env vars (§13).
- [x] Anti-shame copy (§1, §9) — unit-tested.

## Owner tag (§14)

- [x] `cursor-cloud-2`

## Reviewer

Amit (`human-amit`). Cloud agent stops at PR-open; no self-merge.

## Notes for the reviewer

- Head branch is `cursor/energy-recommendations-3a0b` (this cloud environment can only push `cursor/*` branches; intended conventional name: `feat/T-007c-energy-recommendations`).
- Possible sibling work: stale **master-based** PRs #171/#227 add habit-side energy suggestions. Per run instructions the open-PR queue was not touched or inspected in depth; this PR is the task-side Today surface and shares no files with them as far as the integration baseline is concerned.
- No file overlap with #321 / #322 (same unattended run, disjoint file sets).