### PR TITLE
fix(analytics): add the missing returns validator to analytics.overview

### DIFF
--- a/convex/analytics.test.ts
+++ b/convex/analytics.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { computeOverview, type OverviewTaskRow } from "./analytics";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const todayStartMs = 10 * DAY_MS;
+const todayEndMs = 11 * DAY_MS;
+
+function overview(input: Partial<Parameters<typeof computeOverview>[0]> = {}) {
+  return computeOverview({
+    tasks: [],
+    notes: [],
+    habitsCount: 0,
+    goals: [],
+    memoriesCount: 0,
+    conversationsCount: 0,
+    ...input,
+  });
+}
+
+describe("computeOverview", () => {
+  test("empty inputs produce all-zero counts", () => {
+    expect(overview()).toEqual({
+      tasksTotal: 0,
+      taskTodo: 0,
+      taskDone: 0,
+      tasksDueToday: 0,
+      notesTotal: 0,
+      notesPinned: 0,
+      habitsTotal: 0,
+      goalsActive: 0,
+      goalsTotal: 0,
+      memoriesTotal: 0,
+      coachSessionsTotal: 0,
+    });
+  });
+
+  test("task status buckets: todo+in_progress count as open, done separately", () => {
+    const tasks: OverviewTaskRow[] = [
+      { status: "todo" },
+      { status: "in_progress" },
+      { status: "done" },
+      { status: "cancelled" },
+    ];
+    const counts = overview({ tasks });
+    expect(counts.tasksTotal).toBe(4);
+    expect(counts.taskTodo).toBe(2);
+    expect(counts.taskDone).toBe(1);
+  });
+
+  test("tasksDueToday is 0 when the window is omitted", () => {
+    const tasks: OverviewTaskRow[] = [{ status: "todo", dueAt: todayStartMs }];
+    expect(overview({ tasks }).tasksDueToday).toBe(0);
+    expect(overview({ tasks, todayStartMs }).tasksDueToday).toBe(0); // half a window is no window
+  });
+
+  test("tasksDueToday respects exact window boundaries and skips done/cancelled", () => {
+    const tasks: OverviewTaskRow[] = [
+      { status: "todo", dueAt: todayStartMs }, // counts (inclusive start)
+      { status: "in_progress", dueAt: todayEndMs - 1 }, // counts
+      { status: "todo", dueAt: todayEndMs }, // exclusive end
+      { status: "todo", dueAt: todayStartMs - 1 }, // before window
+      { status: "done", dueAt: todayStartMs }, // done excluded
+      { status: "cancelled", dueAt: todayStartMs }, // cancelled excluded
+      { status: "todo" }, // no dueAt
+    ];
+    expect(overview({ tasks, todayStartMs, todayEndMs }).tasksDueToday).toBe(2);
+  });
+
+  test("notes, goals, and passthrough counts", () => {
+    const counts = overview({
+      notes: [{ pinned: true }, { pinned: false }, { pinned: true }],
+      goals: [{ status: "active" }, { status: "completed" }, { status: "archived" }],
+      habitsCount: 4,
+      memoriesCount: 7,
+      conversationsCount: 2,
+    });
+    expect(counts.notesTotal).toBe(3);
+    expect(counts.notesPinned).toBe(2);
+    expect(counts.goalsTotal).toBe(3);
+    expect(counts.goalsActive).toBe(1);
+    expect(counts.habitsTotal).toBe(4);
+    expect(counts.memoriesTotal).toBe(7);
+    expect(counts.coachSessionsTotal).toBe(2);
+  });
+});

--- a/convex/analytics.ts
+++ b/convex/analytics.ts
@@ -2,6 +2,83 @@ import { v } from "convex/values";
 import { query } from "./_generated/server";
 import { requireUser } from "./lib/requireUser";
 
+export type OverviewTaskRow = {
+  status: "todo" | "in_progress" | "done" | "cancelled";
+  dueAt?: number;
+};
+
+export type OverviewNoteRow = {
+  pinned: boolean;
+};
+
+export type OverviewGoalRow = {
+  status: "active" | "completed" | "archived";
+};
+
+export type OverviewCounts = {
+  tasksTotal: number;
+  taskTodo: number;
+  taskDone: number;
+  tasksDueToday: number;
+  notesTotal: number;
+  notesPinned: number;
+  habitsTotal: number;
+  goalsActive: number;
+  goalsTotal: number;
+  memoriesTotal: number;
+  coachSessionsTotal: number;
+};
+
+/**
+ * Pure aggregation over already-fetched rows — exported for unit tests
+ * (analytics.test.ts); the query handler is a thin wrapper around this.
+ */
+export function computeOverview(input: {
+  tasks: OverviewTaskRow[];
+  notes: OverviewNoteRow[];
+  habitsCount: number;
+  goals: OverviewGoalRow[];
+  memoriesCount: number;
+  conversationsCount: number;
+  todayStartMs?: number;
+  todayEndMs?: number;
+}): OverviewCounts {
+  const taskTodo = input.tasks.filter(
+    (t) => t.status === "todo" || t.status === "in_progress",
+  ).length;
+  const taskDone = input.tasks.filter((t) => t.status === "done").length;
+  const notesPinned = input.notes.filter((n) => n.pinned).length;
+  const goalsActive = input.goals.filter((g) => g.status === "active").length;
+
+  let tasksDueToday = 0;
+  if (input.todayStartMs !== undefined && input.todayEndMs !== undefined) {
+    const startMs = input.todayStartMs;
+    const endMs = input.todayEndMs;
+    tasksDueToday = input.tasks.filter(
+      (t) =>
+        t.dueAt !== undefined &&
+        t.dueAt >= startMs &&
+        t.dueAt < endMs &&
+        t.status !== "done" &&
+        t.status !== "cancelled",
+    ).length;
+  }
+
+  return {
+    tasksTotal: input.tasks.length,
+    taskTodo,
+    taskDone,
+    tasksDueToday,
+    notesTotal: input.notes.length,
+    notesPinned,
+    habitsTotal: input.habitsCount,
+    goalsActive,
+    goalsTotal: input.goals.length,
+    memoriesTotal: input.memoriesCount,
+    coachSessionsTotal: input.conversationsCount,
+  };
+}
+
 /**
  * Aggregated counts for dashboard and analytics screens.
  *
@@ -22,6 +99,19 @@ export const overview = query({
     /** Epoch ms at the end of the user's local "today" (exclusive). Pair with `todayStartMs`. */
     todayEndMs: v.optional(v.number()),
   },
+  returns: v.object({
+    tasksTotal: v.number(),
+    taskTodo: v.number(),
+    taskDone: v.number(),
+    tasksDueToday: v.number(),
+    notesTotal: v.number(),
+    notesPinned: v.number(),
+    habitsTotal: v.number(),
+    goalsActive: v.number(),
+    goalsTotal: v.number(),
+    memoriesTotal: v.number(),
+    coachSessionsTotal: v.number(),
+  }),
   handler: async (ctx, args) => {
     const user = await requireUser(ctx);
 
@@ -52,37 +142,15 @@ export const overview = query({
         .collect(),
     ]);
 
-    const taskTodo = tasks.filter((t) => t.status === "todo" || t.status === "in_progress").length;
-    const taskDone = tasks.filter((t) => t.status === "done").length;
-    const notesPinned = notes.filter((n) => n.pinned).length;
-    const goalsActive = goals.filter((g) => g.status === "active").length;
-
-    let tasksDueToday = 0;
-    if (args.todayStartMs !== undefined && args.todayEndMs !== undefined) {
-      const startMs = args.todayStartMs;
-      const endMs = args.todayEndMs;
-      tasksDueToday = tasks.filter(
-        (t) =>
-          t.dueAt !== undefined &&
-          t.dueAt >= startMs &&
-          t.dueAt < endMs &&
-          t.status !== "done" &&
-          t.status !== "cancelled",
-      ).length;
-    }
-
-    return {
-      tasksTotal: tasks.length,
-      taskTodo,
-      taskDone,
-      tasksDueToday,
-      notesTotal: notes.length,
-      notesPinned,
-      habitsTotal: habits.length,
-      goalsActive,
-      goalsTotal: goals.length,
-      memoriesTotal: memories.length,
-      coachSessionsTotal: conversations.length,
-    };
+    return computeOverview({
+      tasks,
+      notes,
+      habitsCount: habits.length,
+      goals,
+      memoriesCount: memories.length,
+      conversationsCount: conversations.length,
+      todayStartMs: args.todayStartMs,
+      todayEndMs: args.todayEndMs,
+    });
   },
 });


### PR DESCRIPTION
## Summary

`analytics.overview` was the last public Convex query in the repo with **no `returns:` validator** — the exact failure class behind the two validator bugs fixed on `integration` today (one omitting `userId`/`deletedAt`, one omitting `timeEstimate`/`timeSpentOnDay`/`repeatCfgId`/`parentTaskId`). This adds a complete validator and extracts the aggregation into a pure, unit-tested `computeOverview()` helper. **Behavior-preserving**: identical output shape and semantics, including the documented "window omitted ⇒ `tasksDueToday: 0`" contract.

## Linked task(s)

Task: validator-hardening follow-up to today's integration fixes (no readable `T-XXXX` row — `docs/brain/TASKS.md` is a private submodule cloud agents cannot read, per AGENTS.md appendix).

## Test plan

- [x] Local `bun run typecheck` passes (plus direct `tsc --noEmit -p convex/tsconfig.json`)
- [x] Local `bun run lint` passes
- [x] New `convex/analytics.test.ts` — 5 tests: all-zero empty case; todo+in_progress vs done buckets; `tasksDueToday` = 0 when the window (or half of it) is omitted; exact window boundaries (`todayStartMs` inclusive, `todayEndMs` exclusive) with done/cancelled exclusion; notes/goals/passthrough counts
- [x] `bun run test` → 49 pass / 0 fail; all four scans + notices check green locally on top of `integration` @ 1c2a654

## Screenshots / screen recording

N/A — no user-visible surface; validator + refactor only. Consumers of `analytics.overview` receive the identical payload.

## Acceptance criteria

- `analytics.overview` declares a full `returns:` validator.
- Query behavior is unchanged (verified by unit tests over the extracted pure helper).

## Convex validator note (per today's validator bugs)

The query returns **computed scalars only — no table rows** — so the validator cannot omit stored schema fields by construction. Validator fields (all `v.number()`): `tasksTotal, taskTodo, taskDone, tasksDueToday, notesTotal, notesPinned, habitsTotal, goalsActive, goalsTotal, memoriesTotal, coachSessionsTotal` — checked 1:1 against the handler's return object. Schema fields consumed (checked against `convex/schema.ts`): tasks(`status, dueAt`), notes(`pinned`), goals(`status`). `convex/schema.ts` untouched (frozen per #315).

Pre-existing behavior deliberately **not** changed in this PR: `overview` counts soft-deleted rows (no `deletedAt` filter), as before. Changing that would alter dashboard numbers and belongs in its own reviewed change if desired.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2).
- [x] AI accept/reject (§1, §6) — N/A: read-only query.
- [x] Schema (§5) — untouched.
- [x] Styling (§7) — N/A.
- [x] Accessibility (§8) — N/A.
- [x] No secrets; no env changes (§13).
- [x] Anti-shame copy (§1, §9) — N/A (no user-facing strings).

## Owner tag (§14)

- [x] `cursor-cloud-2`

## Reviewer

Amit (`human-amit`). Cloud agent stops at PR-open; no self-merge.

## Notes for the reviewer

- Head branch is `cursor/analytics-returns-3a0b` (this cloud environment can only push `cursor/*` branches; intended conventional name: `fix/analytics-overview-returns`).
- No file overlap with #321 / #322 / #323 (same unattended run, disjoint file sets).