### PR TITLE
feat(ai): slot env routing, AES-GCM spike, gated Deepgram builder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,14 +39,45 @@ CONVEX_SITE_URL=https://your-project-name.convex.site
 CONVEX_DEPLOY_KEY=
 
 # ----------------------------------------------------------------------------
-# Mistral (required for AI features)
-# scope: [convex dashboard] (+ [vercel production] for RSC calls)
+# AI router (Convex dashboard). Native fetch only — no vendor SDKs.
+# scope: [convex dashboard]
 # ----------------------------------------------------------------------------
-# HARD_RULES §6 forbids direct OpenAI / Anthropic / Google AI SDKs and vendor
-# AI SDKs. All LLM traffic flows through the Mistral API via native fetch
-# (https://api.mistral.ai/v1/chat/completions). Set in Convex dashboard env
-# vars for convex/ actions; set in Vercel env vars for any RSC-side calls.
+# Slot-specific vars win. Legacy fallbacks still work:
+#   chat        → AI_CHAT_API_KEY → MISTRAL_API_KEY → AI_API_KEY
+#   stt         → AI_STT_API_KEY → DEEPGRAM_API_KEY → AI_API_KEY
+#   tts         → AI_TTS_API_KEY → AI_API_KEY
+#   embeddings  → AI_EMBEDDINGS_API_KEY → MISTRAL_API_KEY → AI_API_KEY
+#
+# Thinking Machines Inkling (or any OpenAI-compatible host) uses the generic
+# pair — do not add a new Inkling-specific variable:
+#   AI_PROVIDER=inkling
+#   AI_MODEL=<inkling-model-id>
+#   AI_CHAT_BASE_URL=https://<inkling-host>/v1
+#   AI_CHAT_API_KEY=<key>
+#
+# `__DUMMY_PASTE_ME__` is treated as unset by requireEnv / readEnv.
+AI_PROVIDER=
+AI_MODEL=
+AI_CHAT_API_KEY=
+AI_CHAT_BASE_URL=
+AI_CHAT_MODEL=
+AI_STT_API_KEY=
+AI_STT_BASE_URL=
+AI_STT_MODEL=
+AI_TTS_API_KEY=
+AI_TTS_BASE_URL=
+AI_TTS_MODEL=
+AI_EMBEDDINGS_API_KEY=
+AI_EMBEDDINGS_BASE_URL=
+AI_EMBEDDINGS_MODEL=
+# Legacy chat key. Prefer AI_CHAT_API_KEY.
 MISTRAL_API_KEY=
+# Legacy generic key used by memories.ts extraction.
+AI_API_KEY=
+# STT half-spike (option C). UNVERIFIED until Amit confirms. Never paste in chat.
+DEEPGRAM_API_KEY=
+# Set to "true" only after Amit confirms the Deepgram key. Gates the live POST.
+DEEPGRAM_SPIKE_CONFIRMED=
 
 # ----------------------------------------------------------------------------
 # PostHog (opt-in analytics)

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
     "@types/react": "~19.1.17",
-    "chalk": "^5.3.0",
+    "chalk": "4.1.2",
     "react-test-renderer": "19.1.0",
     "tailwindcss": "^3.4.19",
     "typescript": "~5.9.3",

--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
         "@types/react": "~19.1.17",
-        "chalk": "^5.3.0",
+        "chalk": "4.1.2",
         "react-test-renderer": "19.1.0",
         "tailwindcss": "^3.4.19",
         "typescript": "~5.9.3",
@@ -134,6 +134,9 @@
         "typescript": "^5.9.3",
       },
     },
+  },
+  "overrides": {
+    "chalk": "4.1.2",
   },
   "packages": {
     "@0no-co/graphql.web": ["@0no-co/graphql.web@1.2.0", "", { "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0" }, "optionalPeers": ["graphql"] }, "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw=="],
@@ -880,7 +883,7 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001777", "", {}, "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ=="],
 
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -1800,8 +1803,6 @@
 
     "@babel/helper-create-regexp-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@babel/highlight/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
-
     "@babel/plugin-transform-runtime/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/template/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -1810,19 +1811,7 @@
 
     "@babel/traverse--for-generate-function-map/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
-    "@expo/cli/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "@expo/config-plugins/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
     "@expo/devcert/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
-
-    "@expo/devtools/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "@expo/env/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "@expo/fingerprint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "@expo/image-utils/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@expo/json-file/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -1832,23 +1821,13 @@
 
     "@expo/metro-config/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
-    "@expo/metro-config/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
     "@expo/metro-config/postcss": ["postcss@8.4.49", "", { "dependencies": { "nanoid": "^3.3.7", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA=="],
 
-    "@expo/package-manager/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
     "@expo/xcpretty/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
-
-    "@expo/xcpretty/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@istanbuljs/load-nyc-config/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
-
-    "@jest/transform/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "@jest/types/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -1894,8 +1873,6 @@
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "babel-jest/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
@@ -1910,8 +1887,6 @@
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "expo-modules-autolinking/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
     "expo-modules-autolinking/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
     "expo-router/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w=="],
@@ -1919,8 +1894,6 @@
     "expo-router/semver": ["semver@7.6.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
 
     "expo-updates/arg": ["arg@4.1.0", "", {}, "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="],
-
-    "expo-updates/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -1944,23 +1917,13 @@
 
     "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
-    "jest-message-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "jest-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
     "jest-util/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "lighthouse-logger/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
-    "log-symbols/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
-
     "metro/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
-
-    "metro/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
@@ -1995,8 +1958,6 @@
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "next/styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
-
-    "ora/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
@@ -2066,12 +2027,6 @@
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "@babel/highlight/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
-
-    "@babel/highlight/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
-    "@babel/highlight/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
-
     "@expo/metro/metro-source-map/ob1": ["ob1@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA=="],
 
     "@expo/metro/metro-source-map/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
@@ -2083,8 +2038,6 @@
     "@react-native/community-cli-plugin/metro/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@react-native/community-cli-plugin/metro/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
-    "@react-native/community-cli-plugin/metro/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "@react-native/community-cli-plugin/metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
@@ -2126,12 +2079,6 @@
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
-    "log-symbols/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
-
-    "log-symbols/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
-    "log-symbols/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
-
     "metro-babel-transformer/hermes-parser/hermes-estree": ["hermes-estree@0.32.0", "", {}, "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ=="],
 
     "metro-symbolicate/metro-source-map/ob1": ["ob1@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA=="],
@@ -2143,12 +2090,6 @@
     "metro/hermes-parser/hermes-estree": ["hermes-estree@0.32.0", "", {}, "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ=="],
 
     "metro/metro-source-map/ob1": ["ob1@0.83.3", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA=="],
-
-    "ora/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
-
-    "ora/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
-
-    "ora/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
     "react-native-css-interop/lightningcss/detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
 
@@ -2182,10 +2123,6 @@
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
-    "@babel/highlight/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
-
-    "@babel/highlight/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
-
     "@react-native/codegen/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "@react-native/community-cli-plugin/metro/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
@@ -2196,22 +2133,8 @@
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "log-symbols/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
-
-    "log-symbols/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
-
-    "ora/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
-
-    "ora/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
-
     "react-native/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
-
-    "@babel/highlight/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
-
-    "log-symbols/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
-
-    "ora/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
   }
 }

--- a/convex/lib/aes_gcm.test.ts
+++ b/convex/lib/aes_gcm.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import {
+  bytesEqual,
+  decryptBytes,
+  encryptBytes,
+  exportRawKey,
+  generateAesGcmKey,
+  importRawKey,
+} from "./aes_gcm";
+
+describe("AES-256-GCM spike", () => {
+  test("round-trips a small audio-like payload", async () => {
+    const key = await generateAesGcmKey();
+    const plaintext = new Uint8Array(2048);
+    for (let i = 0; i < plaintext.length; i++) {
+      plaintext[i] = i % 256;
+    }
+
+    const box = await encryptBytes(key, plaintext);
+    expect(box.iv.byteLength).toBe(12);
+    expect(box.ciphertext.byteLength).toBeGreaterThan(plaintext.byteLength);
+    expect(bytesEqual(box.ciphertext, plaintext)).toBe(false);
+
+    const recovered = await decryptBytes(key, box);
+    expect(bytesEqual(recovered, plaintext)).toBe(true);
+  });
+
+  test("exported raw key can decrypt on a fresh import", async () => {
+    const key = await generateAesGcmKey();
+    const raw = await exportRawKey(key);
+    expect(raw.byteLength).toBe(32);
+
+    const plaintext = new TextEncoder().encode("walkie-talkie spike");
+    const box = await encryptBytes(key, plaintext);
+    const imported = await importRawKey(raw);
+    const recovered = await decryptBytes(imported, box);
+    expect(new TextDecoder().decode(recovered)).toBe("walkie-talkie spike");
+  });
+
+  test("wrong key fails closed", async () => {
+    const keyA = await generateAesGcmKey();
+    const keyB = await generateAesGcmKey();
+    const box = await encryptBytes(keyA, new TextEncoder().encode("secret"));
+    await expect(decryptBytes(keyB, box)).rejects.toThrow();
+  });
+});

--- a/convex/lib/aes_gcm.ts
+++ b/convex/lib/aes_gcm.ts
@@ -1,0 +1,73 @@
+/**
+ * AES-256-GCM spike — encrypt / decrypt arbitrary bytes (voice payloads).
+ *
+ * Uses Web Crypto so the same helpers run in bun tests and Convex V8.
+ * IV is 96-bit (12 bytes). Tag is appended by SubtleCrypto (not stored separately).
+ *
+ * This is a transport spike only. No UI, no Convex table, no key-management
+ * product yet. Do not persist raw keys next to ciphertext.
+ */
+
+const IV_BYTES = 12;
+const KEY_BITS = 256;
+
+function getSubtle(): SubtleCrypto {
+  const cryptoApi = globalThis.crypto;
+  if (!cryptoApi?.subtle) {
+    throw new Error("Web Crypto SubtleCrypto is not available");
+  }
+  return cryptoApi.subtle;
+}
+
+export async function generateAesGcmKey(): Promise<CryptoKey> {
+  return getSubtle().generateKey({ name: "AES-GCM", length: KEY_BITS }, true, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+export async function exportRawKey(key: CryptoKey): Promise<Uint8Array> {
+  const raw = await getSubtle().exportKey("raw", key);
+  return new Uint8Array(raw);
+}
+
+export async function importRawKey(raw: Uint8Array): Promise<CryptoKey> {
+  return getSubtle().importKey("raw", raw, { name: "AES-GCM" }, true, [
+    "encrypt",
+    "decrypt",
+  ]);
+}
+
+export type AesGcmBox = {
+  iv: Uint8Array;
+  ciphertext: Uint8Array;
+};
+
+export async function encryptBytes(key: CryptoKey, plaintext: Uint8Array): Promise<AesGcmBox> {
+  const iv = globalThis.crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const cipherBuf = await getSubtle().encrypt({ name: "AES-GCM", iv }, key, plaintext);
+  return { iv, ciphertext: new Uint8Array(cipherBuf) };
+}
+
+export async function decryptBytes(
+  key: CryptoKey,
+  box: AesGcmBox,
+): Promise<Uint8Array> {
+  const plainBuf = await getSubtle().decrypt(
+    { name: "AES-GCM", iv: box.iv },
+    key,
+    box.ciphertext,
+  );
+  return new Uint8Array(plainBuf);
+}
+
+export function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.byteLength; i++) {
+    diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  }
+  return diff === 0;
+}

--- a/convex/lib/ai_env.test.ts
+++ b/convex/lib/ai_env.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { ENV_DUMMY_SENTINEL } from "./require_env";
+import { chatCompletionsUrl, resolveAiEnv } from "./ai_env";
+
+const TRACKED = [
+  "AI_PROVIDER",
+  "AI_MODEL",
+  "AI_API_KEY",
+  "AI_CHAT_API_KEY",
+  "AI_CHAT_BASE_URL",
+  "AI_CHAT_MODEL",
+  "AI_STT_API_KEY",
+  "AI_STT_BASE_URL",
+  "AI_STT_MODEL",
+  "AI_TTS_API_KEY",
+  "AI_TTS_MODEL",
+  "AI_EMBEDDINGS_API_KEY",
+  "AI_EMBEDDINGS_MODEL",
+  "MISTRAL_API_KEY",
+  "DEEPGRAM_API_KEY",
+] as const;
+
+afterEach(() => {
+  for (const name of TRACKED) {
+    delete process.env[name];
+  }
+});
+
+describe("resolveAiEnv chat", () => {
+  test("defaults to Mistral URL and tier model when only a legacy key is set", () => {
+    process.env.MISTRAL_API_KEY = "mistral-legacy";
+    const env = resolveAiEnv("chat", "balanced");
+    expect(env.apiKey).toBe("mistral-legacy");
+    expect(env.baseUrl).toBe("https://api.mistral.ai/v1");
+    expect(env.model).toBe("mistral-medium-latest");
+    expect(env.provider).toBe("mistral");
+  });
+
+  test("slot-specific chat vars beat legacy keys", () => {
+    process.env.MISTRAL_API_KEY = "legacy";
+    process.env.AI_CHAT_API_KEY = "chat-key";
+    process.env.AI_CHAT_BASE_URL = "https://api.inkling.example/v1";
+    process.env.AI_CHAT_MODEL = "inkling-chat";
+    process.env.AI_PROVIDER = "inkling";
+    const env = resolveAiEnv("chat", "fast");
+    expect(env.apiKey).toBe("chat-key");
+    expect(env.baseUrl).toBe("https://api.inkling.example/v1");
+    expect(env.model).toBe("inkling-chat");
+    expect(env.provider).toBe("inkling");
+  });
+
+  test("AI_PROVIDER + AI_MODEL configure Inkling with no new variable", () => {
+    process.env.AI_API_KEY = "generic";
+    process.env.AI_PROVIDER = "inkling";
+    process.env.AI_MODEL = "inkling-default";
+    const env = resolveAiEnv("chat", "deep");
+    expect(env.provider).toBe("inkling");
+    expect(env.model).toBe("inkling-default");
+    expect(env.apiKey).toBe("generic");
+  });
+
+  test("dummy sentinel on the preferred key falls through to legacy", () => {
+    process.env.AI_CHAT_API_KEY = ENV_DUMMY_SENTINEL;
+    process.env.MISTRAL_API_KEY = "real-legacy";
+    expect(resolveAiEnv("chat").apiKey).toBe("real-legacy");
+  });
+});
+
+describe("resolveAiEnv stt / tts / embeddings", () => {
+  test("STT prefers AI_STT_* then DEEPGRAM_API_KEY", () => {
+    process.env.DEEPGRAM_API_KEY = "dg";
+    expect(resolveAiEnv("stt").apiKey).toBe("dg");
+    process.env.AI_STT_API_KEY = "stt-slot";
+    expect(resolveAiEnv("stt").apiKey).toBe("stt-slot");
+    expect(resolveAiEnv("stt").model).toBe("nova-2");
+  });
+
+  test("dummy DEEPGRAM_API_KEY is treated as absent", () => {
+    process.env.DEEPGRAM_API_KEY = ENV_DUMMY_SENTINEL;
+    expect(resolveAiEnv("stt").apiKey).toBeUndefined();
+  });
+
+  test("TTS and embeddings use their slot keys with generic fallback", () => {
+    process.env.AI_API_KEY = "shared";
+    expect(resolveAiEnv("tts").apiKey).toBe("shared");
+    expect(resolveAiEnv("embeddings").apiKey).toBe("shared");
+    process.env.AI_TTS_API_KEY = "tts-only";
+    process.env.AI_EMBEDDINGS_API_KEY = "emb-only";
+    expect(resolveAiEnv("tts").apiKey).toBe("tts-only");
+    expect(resolveAiEnv("embeddings").apiKey).toBe("emb-only");
+  });
+});
+
+describe("chatCompletionsUrl", () => {
+  test("joins without a double slash", () => {
+    expect(chatCompletionsUrl("https://api.mistral.ai/v1/")).toBe(
+      "https://api.mistral.ai/v1/chat/completions",
+    );
+  });
+});

--- a/convex/lib/ai_env.ts
+++ b/convex/lib/ai_env.ts
@@ -1,0 +1,91 @@
+import { readEnv, readEnvFirst } from "./require_env";
+
+export type AiSlot = "chat" | "stt" | "tts" | "embeddings";
+export type AiEnvTier = "fast" | "balanced" | "deep";
+
+const TIER_FALLBACK_MODEL: Record<AiEnvTier, string> = {
+  fast: "mistral-small-latest",
+  balanced: "mistral-medium-latest",
+  deep: "mistral-large-latest",
+};
+
+export type ResolvedAiEnv = {
+  slot: AiSlot;
+  /** Provider hint only — Inkling is `AI_PROVIDER=inkling` + `AI_MODEL`, no new var. */
+  provider: string;
+  apiKey: string | undefined;
+  baseUrl: string;
+  model: string;
+};
+
+const DEFAULT_CHAT_BASE_URL = "https://api.mistral.ai/v1";
+const DEFAULT_STT_BASE_URL = "https://api.deepgram.com";
+const DEFAULT_TTS_BASE_URL = "https://api.mistral.ai/v1";
+const DEFAULT_EMBEDDINGS_BASE_URL = "https://api.mistral.ai/v1";
+const DEFAULT_STT_MODEL = "nova-2";
+const DEFAULT_TTS_MODEL = "mistral-small-latest";
+const DEFAULT_EMBEDDINGS_MODEL = "mistral-embed";
+
+function providerHint(): string {
+  return readEnv("AI_PROVIDER") ?? "mistral";
+}
+
+/**
+ * Resolve per-slot credentials.
+ *
+ * Slot-specific vars win. Legacy fallbacks:
+ *   chat        → AI_CHAT_* → MISTRAL_API_KEY → AI_API_KEY
+ *   stt         → AI_STT_* → DEEPGRAM_API_KEY → AI_API_KEY
+ *   tts         → AI_TTS_* → AI_API_KEY
+ *   embeddings  → AI_EMBEDDINGS_* → MISTRAL_API_KEY → AI_API_KEY
+ *
+ * `AI_PROVIDER` + `AI_MODEL` stay generic so Thinking Machines Inkling
+ * (or any OpenAI-compatible host) needs no new variable.
+ */
+export function resolveAiEnv(slot: AiSlot, tier: AiEnvTier = "fast"): ResolvedAiEnv {
+  const provider = providerHint();
+  const genericModel = readEnv("AI_MODEL");
+
+  switch (slot) {
+    case "chat":
+      return {
+        slot,
+        provider,
+        apiKey: readEnvFirst(["AI_CHAT_API_KEY", "MISTRAL_API_KEY", "AI_API_KEY"]),
+        baseUrl: readEnv("AI_CHAT_BASE_URL") ?? DEFAULT_CHAT_BASE_URL,
+        model: readEnv("AI_CHAT_MODEL") ?? genericModel ?? TIER_FALLBACK_MODEL[tier],
+      };
+    case "stt":
+      return {
+        slot,
+        provider,
+        apiKey: readEnvFirst(["AI_STT_API_KEY", "DEEPGRAM_API_KEY", "AI_API_KEY"]),
+        baseUrl: readEnv("AI_STT_BASE_URL") ?? DEFAULT_STT_BASE_URL,
+        model: readEnv("AI_STT_MODEL") ?? genericModel ?? DEFAULT_STT_MODEL,
+      };
+    case "tts":
+      return {
+        slot,
+        provider,
+        apiKey: readEnvFirst(["AI_TTS_API_KEY", "AI_API_KEY"]),
+        baseUrl: readEnv("AI_TTS_BASE_URL") ?? DEFAULT_TTS_BASE_URL,
+        model: readEnv("AI_TTS_MODEL") ?? genericModel ?? DEFAULT_TTS_MODEL,
+      };
+    case "embeddings":
+      return {
+        slot,
+        provider,
+        apiKey: readEnvFirst(["AI_EMBEDDINGS_API_KEY", "MISTRAL_API_KEY", "AI_API_KEY"]),
+        baseUrl: readEnv("AI_EMBEDDINGS_BASE_URL") ?? DEFAULT_EMBEDDINGS_BASE_URL,
+        model: readEnv("AI_EMBEDDINGS_MODEL") ?? genericModel ?? DEFAULT_EMBEDDINGS_MODEL,
+      };
+    default: {
+      const _exhaustive: never = slot;
+      throw new Error(`Unknown AI slot: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+export function chatCompletionsUrl(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, "")}/chat/completions`;
+}

--- a/convex/lib/ai_router.test.ts
+++ b/convex/lib/ai_router.test.ts
@@ -2,7 +2,13 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { AiAuthError } from "./ai_errors";
 import { callLLM } from "./ai_router";
 
-const TRACKED = ["AI_CHAT_API_KEY", "AI_CHAT_BASE_URL", "AI_CHAT_MODEL", "MISTRAL_API_KEY"] as const;
+const TRACKED = [
+  "AI_PROVIDER",
+  "AI_CHAT_API_KEY",
+  "AI_CHAT_BASE_URL",
+  "AI_CHAT_MODEL",
+  "MISTRAL_API_KEY",
+] as const;
 
 const originalFetch = globalThis.fetch;
 
@@ -24,6 +30,7 @@ describe("callLLM", () => {
   });
 
   test("POSTs to the resolved OpenAI-compatible chat URL", async () => {
+    process.env.AI_PROVIDER = "inkling";
     process.env.AI_CHAT_API_KEY = "chat-key";
     process.env.AI_CHAT_BASE_URL = "https://api.inkling.example/v1";
     process.env.AI_CHAT_MODEL = "inkling-chat";

--- a/convex/lib/ai_router.test.ts
+++ b/convex/lib/ai_router.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { AiAuthError } from "./ai_errors";
+import { callLLM } from "./ai_router";
+
+const TRACKED = ["AI_CHAT_API_KEY", "AI_CHAT_BASE_URL", "AI_CHAT_MODEL", "MISTRAL_API_KEY"] as const;
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const name of TRACKED) {
+    delete process.env[name];
+  }
+});
+
+describe("callLLM", () => {
+  test("throws AiAuthError when every chat key is absent", async () => {
+    await expect(
+      callLLM({
+        tier: "fast",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    ).rejects.toBeInstanceOf(AiAuthError);
+  });
+
+  test("POSTs to the resolved OpenAI-compatible chat URL", async () => {
+    process.env.AI_CHAT_API_KEY = "chat-key";
+    process.env.AI_CHAT_BASE_URL = "https://api.inkling.example/v1";
+    process.env.AI_CHAT_MODEL = "inkling-chat";
+
+    let capturedUrl = "";
+    let capturedAuth = "";
+    let capturedBody: { model?: string; safe_prompt?: boolean } = {};
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      capturedUrl = String(input);
+      capturedAuth = new Headers(init?.headers).get("Authorization") ?? "";
+      capturedBody = JSON.parse(String(init?.body ?? "{}")) as typeof capturedBody;
+      return new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "pong" } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const result = await callLLM({
+      tier: "fast",
+      messages: [{ role: "user", content: "ping" }],
+    });
+
+    expect(capturedUrl).toBe("https://api.inkling.example/v1/chat/completions");
+    expect(capturedAuth).toBe("Bearer chat-key");
+    expect(capturedBody.model).toBe("inkling-chat");
+    expect(capturedBody.safe_prompt).toBeUndefined();
+    expect(result.content).toBe("pong");
+    expect(result.model).toBe("inkling-chat");
+  });
+});

--- a/convex/lib/ai_router.ts
+++ b/convex/lib/ai_router.ts
@@ -1,3 +1,4 @@
+import { chatCompletionsUrl, resolveAiEnv } from "./ai_env";
 import {
   AiAuthError,
   AiContextTooLargeError,
@@ -51,7 +52,8 @@ async function attemptCall(
   opts: AiCallOptions,
   apiKey: string,
 ): Promise<AiResult & { requestedTier: AiTier }> {
-  const model = TIER_MODEL[tier];
+  const env = resolveAiEnv("chat", tier);
+  const model = env.model;
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 30_000);
 
@@ -62,13 +64,15 @@ async function attemptCall(
       messages: opts.messages,
       max_tokens: opts.maxTokens ?? 1024,
       temperature: opts.temperature ?? 0.3,
-      safe_prompt: false,
     };
+    if (env.provider === "mistral") {
+      body.safe_prompt = false;
+    }
     if (opts.responseFormat === "json_object") {
       body.response_format = { type: "json_object" };
     }
 
-    response = await fetch("https://api.mistral.ai/v1/chat/completions", {
+    response = await fetch(chatCompletionsUrl(env.baseUrl), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -92,18 +96,18 @@ async function attemptCall(
   if (!response.ok) {
     const text = await response.text().catch(() => "");
     if (response.status === 401) {
-      throw new AiAuthError(`Mistral auth failed: ${text.slice(0, 200)}`);
+      throw new AiAuthError(`Chat upstream auth failed: ${text.slice(0, 200)}`);
     }
     if (response.status === 429) {
       const retryAfterHeader = response.headers.get("Retry-After");
       const retryAfterMs = retryAfterHeader ? parseFloat(retryAfterHeader) * 1000 : undefined;
-      throw new AiRateLimitedError(`Rate limited by Mistral`, retryAfterMs);
+      throw new AiRateLimitedError(`Rate limited by chat upstream`, retryAfterMs);
     }
     if (response.status === 400 && isContextTooLarge(text)) {
       throw new AiContextTooLargeError(`Context too large for model ${model}`);
     }
     throw new AiUpstreamError(
-      `Mistral returned HTTP ${response.status}`,
+      `Chat upstream returned HTTP ${response.status}`,
       response.status,
       text.slice(0, 200),
     );
@@ -133,9 +137,10 @@ function sleep(ms: number): Promise<void> {
 }
 
 export async function callLLM(opts: AiCallOptions): Promise<AiResult> {
-  const apiKey = process.env.MISTRAL_API_KEY;
+  const env = resolveAiEnv("chat", opts.tier);
+  const apiKey = env.apiKey;
   if (!apiKey) {
-    throw new AiAuthError("MISTRAL_API_KEY not set in Convex env");
+    throw new AiAuthError("AI_CHAT_API_KEY / MISTRAL_API_KEY is not set in Convex env");
   }
 
   const chain = ESCALATION_CHAIN[opts.tier];

--- a/convex/lib/deepgram_stt.test.ts
+++ b/convex/lib/deepgram_stt.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { ENV_DUMMY_SENTINEL } from "./require_env";
+import {
+  buildDeepgramListenRequest,
+  deepgramGate,
+  isConvexStorageUrl,
+  postDeepgramListen,
+} from "./deepgram_stt";
+
+const TRACKED = ["AI_STT_API_KEY", "DEEPGRAM_API_KEY", "DEEPGRAM_SPIKE_CONFIRMED"] as const;
+
+afterEach(() => {
+  for (const name of TRACKED) {
+    delete process.env[name];
+  }
+});
+
+const SAMPLE_URL = "https://ceaseless-dog-617.convex.cloud/api/storage/abc123";
+
+describe("isConvexStorageUrl", () => {
+  test("accepts https Convex storage hosts", () => {
+    expect(isConvexStorageUrl(SAMPLE_URL)).toBe(true);
+    expect(isConvexStorageUrl("https://precious-wildcat-890.convex.site/api/storage/x")).toBe(
+      true,
+    );
+  });
+
+  test("rejects non-https and non-Convex hosts", () => {
+    expect(isConvexStorageUrl("http://ceaseless-dog-617.convex.cloud/api/storage/x")).toBe(false);
+    expect(isConvexStorageUrl("https://evil.example/steal")).toBe(false);
+    expect(isConvexStorageUrl("not-a-url")).toBe(false);
+  });
+});
+
+describe("deepgramGate", () => {
+  test("is not ready when the key is dummy or unset", () => {
+    expect(deepgramGate().ready).toBe(false);
+    process.env.DEEPGRAM_API_KEY = ENV_DUMMY_SENTINEL;
+    expect(deepgramGate().ready).toBe(false);
+  });
+
+  test("is ready when a real STT key is present", () => {
+    process.env.AI_STT_API_KEY = "dg-test";
+    const gate = deepgramGate();
+    expect(gate.ready).toBe(true);
+    if (gate.ready) {
+      expect(gate.apiKey).toBe("dg-test");
+    }
+  });
+});
+
+describe("buildDeepgramListenRequest", () => {
+  test("builds a JSON url-source listen request", () => {
+    process.env.DEEPGRAM_API_KEY = "dg-test";
+    const req = buildDeepgramListenRequest(SAMPLE_URL);
+    expect(req.url).toContain("/v1/listen");
+    expect(req.url).toContain("model=nova-2");
+    expect(req.headers.Authorization).toBe("Token dg-test");
+    expect(JSON.parse(req.body)).toEqual({ url: SAMPLE_URL });
+  });
+
+  test("refuses a non-Convex URL", () => {
+    process.env.DEEPGRAM_API_KEY = "dg-test";
+    expect(() => buildDeepgramListenRequest("https://example.com/a.wav")).toThrow(
+      /Convex storage URL/,
+    );
+  });
+});
+
+describe("postDeepgramListen gate", () => {
+  test("refuses to POST until the key is explicitly confirmed", async () => {
+    process.env.DEEPGRAM_API_KEY = "dg-test";
+    await expect(
+      postDeepgramListen({ signedAudioUrl: SAMPLE_URL, confirmed: false }),
+    ).rejects.toThrow(/gated/);
+    await expect(
+      postDeepgramListen({ signedAudioUrl: SAMPLE_URL, confirmed: true }),
+    ).rejects.toThrow(/DEEPGRAM_SPIKE_CONFIRMED/);
+  });
+});

--- a/convex/lib/deepgram_stt.ts
+++ b/convex/lib/deepgram_stt.ts
@@ -1,0 +1,117 @@
+import { resolveAiEnv } from "./ai_env";
+import { readEnv } from "./require_env";
+
+/**
+ * Deepgram listen request builder for the option-C half-spike.
+ *
+ * Live POST is gated: DEEPGRAM_API_KEY / AI_STT_API_KEY must be a real value
+ * (not `__DUMMY_PASTE_ME__`) and Amit must confirm the key. This module does
+ * not call the network by itself.
+ */
+
+export const DEEPGRAM_LISTEN_PATH = "/v1/listen";
+
+export type DeepgramListenRequest = {
+  url: string;
+  headers: { Authorization: string; "Content-Type": "application/json" };
+  body: string;
+};
+
+export type DeepgramGate =
+  | { ready: true; apiKey: string; baseUrl: string; model: string }
+  | { ready: false; reason: string };
+
+export function deepgramGate(): DeepgramGate {
+  const env = resolveAiEnv("stt");
+  if (!env.apiKey) {
+    return {
+      ready: false,
+      reason: "AI_STT_API_KEY / DEEPGRAM_API_KEY is unset or the dummy sentinel",
+    };
+  }
+  return {
+    ready: true,
+    apiKey: env.apiKey,
+    baseUrl: env.baseUrl,
+    model: env.model,
+  };
+}
+
+/** Convex storage signed URLs live on *.convex.cloud or *.convex.site. */
+export function isConvexStorageUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") {
+      return false;
+    }
+    const host = parsed.hostname.toLowerCase();
+    return host.endsWith(".convex.cloud") || host.endsWith(".convex.site");
+  } catch {
+    return false;
+  }
+}
+
+export function buildDeepgramListenRequest(
+  signedAudioUrl: string,
+  options?: { apiKey?: string; baseUrl?: string; model?: string },
+): DeepgramListenRequest {
+  if (!isConvexStorageUrl(signedAudioUrl)) {
+    throw new Error("signed audio URL is not a Convex storage URL");
+  }
+  const gate = deepgramGate();
+  const apiKey = options?.apiKey ?? (gate.ready ? gate.apiKey : undefined);
+  if (!apiKey) {
+    throw new Error("Deepgram key is not configured");
+  }
+  const baseUrl = (options?.baseUrl ?? (gate.ready ? gate.baseUrl : "https://api.deepgram.com")).replace(
+    /\/+$/,
+    "",
+  );
+  const model = options?.model ?? (gate.ready ? gate.model : "nova-2");
+  const listenUrl = new URL(`${baseUrl}${DEEPGRAM_LISTEN_PATH}`);
+  listenUrl.searchParams.set("model", model);
+  listenUrl.searchParams.set("smart_format", "true");
+
+  return {
+    url: listenUrl.toString(),
+    headers: {
+      Authorization: `Token ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ url: signedAudioUrl }),
+  };
+}
+
+/**
+ * Perform the Deepgram POST. Callers must pass `confirmed: true` after Amit
+ * explicitly verifies DEEPGRAM_API_KEY. Refuses otherwise.
+ */
+export async function postDeepgramListen(args: {
+  signedAudioUrl: string;
+  confirmed: boolean;
+}): Promise<{ transcript: string; requestUrlHost: string }> {
+  if (!args.confirmed) {
+    throw new Error("Deepgram POST is gated until DEEPGRAM_API_KEY is confirmed");
+  }
+  if (readEnv("DEEPGRAM_SPIKE_CONFIRMED") !== "true") {
+    throw new Error("Deepgram POST is gated until DEEPGRAM_SPIKE_CONFIRMED=true");
+  }
+  const request = buildDeepgramListenRequest(args.signedAudioUrl);
+  const response = await fetch(request.url, {
+    method: "POST",
+    headers: request.headers,
+    body: request.body,
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Deepgram listen failed: HTTP ${response.status} ${text.slice(0, 200)}`);
+  }
+  const json = (await response.json()) as {
+    results?: { channels?: Array<{ alternatives?: Array<{ transcript?: string }> }> };
+  };
+  const transcript = json.results?.channels?.[0]?.alternatives?.[0]?.transcript ?? "";
+  return {
+    transcript,
+    requestUrlHost: new URL(request.url).host,
+  };
+}

--- a/convex/lib/require_env.test.ts
+++ b/convex/lib/require_env.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { ENV_DUMMY_SENTINEL, readEnv, readEnvFirst, requireEnv } from "./require_env";
+
+const TRACKED = ["UNIT_TEST_ENV_A", "UNIT_TEST_ENV_B"] as const;
+
+afterEach(() => {
+  for (const name of TRACKED) {
+    delete process.env[name];
+  }
+});
+
+describe("readEnv", () => {
+  test("returns undefined when unset", () => {
+    expect(readEnv("UNIT_TEST_ENV_A")).toBeUndefined();
+  });
+
+  test("returns undefined for blank and whitespace", () => {
+    process.env.UNIT_TEST_ENV_A = "";
+    expect(readEnv("UNIT_TEST_ENV_A")).toBeUndefined();
+    process.env.UNIT_TEST_ENV_A = "   ";
+    expect(readEnv("UNIT_TEST_ENV_A")).toBeUndefined();
+  });
+
+  test("treats the dashboard dummy sentinel as absent", () => {
+    process.env.UNIT_TEST_ENV_A = ENV_DUMMY_SENTINEL;
+    expect(readEnv("UNIT_TEST_ENV_A")).toBeUndefined();
+    process.env.UNIT_TEST_ENV_A = `  ${ENV_DUMMY_SENTINEL}  `;
+    expect(readEnv("UNIT_TEST_ENV_A")).toBeUndefined();
+  });
+
+  test("returns a trimmed real value", () => {
+    process.env.UNIT_TEST_ENV_A = "  real-value  ";
+    expect(readEnv("UNIT_TEST_ENV_A")).toBe("real-value");
+  });
+});
+
+describe("readEnvFirst", () => {
+  test("skips dummy and blank names, then returns the first real value", () => {
+    process.env.UNIT_TEST_ENV_A = ENV_DUMMY_SENTINEL;
+    process.env.UNIT_TEST_ENV_B = "legacy";
+    expect(readEnvFirst(["UNIT_TEST_ENV_A", "UNIT_TEST_ENV_B"])).toBe("legacy");
+  });
+
+  test("returns undefined when every candidate is absent", () => {
+    expect(readEnvFirst(["UNIT_TEST_ENV_A", "UNIT_TEST_ENV_B"])).toBeUndefined();
+  });
+});
+
+describe("requireEnv", () => {
+  test("throws a named error for unset and dummy values", () => {
+    expect(() => requireEnv("UNIT_TEST_ENV_A")).toThrow("UNIT_TEST_ENV_A is not set");
+    process.env.UNIT_TEST_ENV_A = ENV_DUMMY_SENTINEL;
+    expect(() => requireEnv("UNIT_TEST_ENV_A")).toThrow("UNIT_TEST_ENV_A is not set");
+  });
+
+  test("returns a real value", () => {
+    process.env.UNIT_TEST_ENV_A = "ok";
+    expect(requireEnv("UNIT_TEST_ENV_A")).toBe("ok");
+  });
+});

--- a/convex/lib/require_env.ts
+++ b/convex/lib/require_env.ts
@@ -1,0 +1,46 @@
+/**
+ * Read Convex / process env vars with a fail-closed dummy sentinel.
+ *
+ * Dashboard cells were scaffolded with `__DUMMY_PASTE_ME__`. That string is
+ * not a secret — treat it as absent so requireEnv cannot "succeed" on a
+ * placeholder.
+ */
+
+export const ENV_DUMMY_SENTINEL = "__DUMMY_PASTE_ME__";
+
+function isAbsent(raw: string | undefined): boolean {
+  if (raw === undefined) {
+    return true;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length === 0 || trimmed === ENV_DUMMY_SENTINEL;
+}
+
+/** Returns a trimmed value, or undefined when unset / blank / dummy. */
+export function readEnv(name: string): string | undefined {
+  const raw = process.env[name];
+  if (isAbsent(raw)) {
+    return undefined;
+  }
+  return raw!.trim();
+}
+
+/** First defined non-dummy value in `names`, or undefined. */
+export function readEnvFirst(names: readonly string[]): string | undefined {
+  for (const name of names) {
+    const value = readEnv(name);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/** Throws when the named var is unset, blank, or the dummy sentinel. */
+export function requireEnv(name: string): string {
+  const value = readEnv(name);
+  if (value === undefined) {
+    throw new Error(`${name} is not set`);
+  }
+  return value;
+}

--- a/convex/memories.ts
+++ b/convex/memories.ts
@@ -1,6 +1,7 @@
 import { v } from 'convex/values';
 import { mutation, query, action } from './_generated/server';
 import { api } from './_generated/api';
+import { readEnv } from './lib/require_env';
 
 // Memory sector type
 export type MemorySector = 'semantic' | 'episodic' | 'procedural' | 'emotional' | 'general';
@@ -229,10 +230,11 @@ export const extractMemories = action({
       throw new Error('Not authenticated');
     }
 
-    // Get AI API key from environment (set in Convex dashboard)
-    const aiApiKey = process.env.AI_API_KEY;
-    const aiProvider = process.env.AI_PROVIDER || 'gemini';
-    const aiModel = process.env.AI_MODEL || 'gemini-2.5-flash';
+    // Get AI API key from environment (set in Convex dashboard).
+    // Dummy sentinel `__DUMMY_PASTE_ME__` is treated as absent.
+    const aiApiKey = readEnv('AI_API_KEY');
+    const aiProvider = readEnv('AI_PROVIDER') || 'gemini';
+    const aiModel = readEnv('AI_MODEL') || 'gemini-2.5-flash';
 
     if (!aiApiKey) {
       throw new Error('AI not configured. Please set AI_API_KEY in Convex dashboard.');

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -13,7 +13,11 @@
 
 ## Doing
 
-_(nothing in flight right now — waiting for tomorrow morning's 45-min + overnight test runs)_
+- **Voice / AI spikes (Tasks 1–3, no UI)** — branch `cursor/voice-ai-spikes-4458` off `integration`.
+  - Task 1 Deepgram signed-URL POST: **gated** until `DEEPGRAM_API_KEY` is confirmed and a DEV `storageId` is provided. No live POST in this PR.
+  - Task 2 AES-256-GCM encrypt/decrypt spike: in `convex/lib/aes_gcm.ts`.
+  - Task 3 `AI_CHAT_*` / `AI_STT_*` / `AI_TTS_*` / `AI_EMBEDDINGS_*` + `requireEnv` dummy sentinel + chalk 4.1.2 pin.
+  - Monthly voice ceiling **not implemented** — waiting for Amit to approve the numbers in the PR.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "@types/bun": "^1.3.13",
     "@types/node": "^20.19.0",
     "turbo": "^2.3.3"
+  },
+  "overrides": {
+    "chalk": "4.1.2"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Amit's local brief was stale; this checkout of `integration` is the source of truth. This PR lands Tasks 2 and 3, and scaffolds Task 1 without a live Deepgram POST. No web voice UI. EAS / `app.json` untouched. Expo SDK stays 54 — chalk is pinned to 4.1.2 (CJS) instead of an Expo 57 audio pin.

## Linked task(s)

No `T-XXXX` in the public board (`docs/brain/` is an empty private submodule). Tracked in `docs/TASKS.md` → Doing: Voice / AI spikes (Tasks 1–3).

## Screenshots / screen recording

N/A — no user-visible surface.

## Test plan

- [ ] `bun test convex/lib` passes
- [ ] `bun run scan:forbidden-tech` passes
- [ ] Relevant unit tests added for requireEnv, AI slot resolution, AES-GCM, Deepgram builder
- [ ] Manual QA: none for UI; Deepgram live POST is gated
- [ ] Reproduces the acceptance criteria below

## Acceptance criteria

- `requireEnv` / `readEnv` treat `__DUMMY_PASTE_ME__`, blank, and unset as absent.
- `AI_CHAT_*` / `AI_STT_*` / `AI_TTS_*` / `AI_EMBEDDINGS_*` resolve with legacy fallback (`MISTRAL_API_KEY`, `DEEPGRAM_API_KEY`, `AI_API_KEY`).
- Thinking Machines Inkling is `AI_PROVIDER` + `AI_MODEL` (+ optional `AI_CHAT_BASE_URL` / `AI_CHAT_API_KEY`). No new Inkling-specific variable.
- AES-256-GCM encrypt/decrypt round-trip is unit-tested. Wrong key fails closed.
- Deepgram listen request builder is unit-tested. Live POST refuses until Amit confirms the key (`confirmed: true` **and** `DEEPGRAM_SPIKE_CONFIRMED=true`).
- Chalk pinned to `4.1.2` for Expo 54 / Metro. Do not pin `expo-audio ~57.0.3`.
- No UI mount. No `app.json` / EAS edits. No `convex dev`. No production deploy.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). — N/A, no coach mutation in this PR.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). — no schema change.
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7). — N/A.
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8). — N/A.
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13).
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9).

## Owner tag (§14)

- [x] `cursor-cloud-2`

## Reviewer

Amit (`human-amit`). Code agents do not merge this PR.

## Conflicts flagged (brief was wrong; checkout wins)

- `ai_router.ts` is at `convex/lib/ai_router.ts` (confirmed).
- Expo SDK is 54, not 57. Chalk pin is 4.1.2. No `expo-audio ~57.0.3`.
- No `packages/mock-data`. `docs/brain` is an empty submodule.
- EAS identity is UNKNOWN / out of scope. `app.json` not touched.
- Autopilot DEV slug `ceaseless-dog-617` is **staging** in `docs/ENVIRONMENTS.md`; prod is `precious-wildcat-890`.

## Task 1 — Deepgram (option C) status

**Not executed.** `DEEPGRAM_API_KEY` is unset in this cloud env and still UNVERIFIED. No `storageId` was provided. I will not escalate to option A.

Signed-URL round trip cannot be validated from this VM without either:
1. a DEV `storageId` **and** a deployed `ctx.storage.getUrl` probe (you said no `convex dev` / no sanctioned push), or
2. you pasting a signed URL (not requested).

Next for Task 1: confirm the key (Cursor env secret, never in chat), upload a small audio file on DEV, send the `storageId`. Then I can POST — still no option A.

## Q4 — monthly ceiling (needs your approval before I implement the meter)

Daily caps stay HARD_RULES §9: Basic 30 / Pro 90 / Max 180 minutes, local midnight reset, walkie-talkie always available.

Proposed **fail-closed monthly ceiling** (calendar month in `profiles.timezone`, UTC if timezone missing):

| Tier | Daily (existing) | Monthly ceiling |
| --- | --- | --- |
| Basic | 30 min | **300 min** (10 × daily) |
| Pro | 90 min | **900 min** |
| Max | 180 min | **1,800 min** |
| God / founder | same as Max | **1,800 min** (not unlimited) |

Fail closed: meter read/write failure → deny live voice; remaining < 1 minute → deny live, walkie-talkie stays up. Not implemented in this PR.

## Refused

- Live Deepgram POST (key unverified, no storageId).
- Voice UI mount (Q5 deferred).
- Monthly meter implementation (waiting on ceiling approval).
- `app.json` / `eas init` / EAS identity.
- `expo-audio ~57.0.3`.
- Creating or guessing `T-XXXX` IDs (`docs/brain/` empty).
- Escalating Task 1 to option A.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87ffb0e7-ed63-427c-bfa2-0b90fdf44458?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87ffb0e7-ed63-427c-bfa2-0b90fdf44458&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

