### PR TITLE
ci: auto-arm squash auto-merge on integration PRs

### DIFF
--- a/.github/workflows/auto-arm-merge.yml
+++ b/.github/workflows/auto-arm-merge.yml
@@ -1,0 +1,19 @@
+name: Auto-arm merge
+# Arms auto-merge (squash) on any PR opened against integration.
+# GUARD: the job-level "if" means this can never act on a PR targeting
+# master (or any branch other than integration).
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  arm:
+    if: github.event.pull_request.base.ref == 'integration' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Arm auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --auto --squash


### PR DESCRIPTION
Adds a workflow that arms squash auto-merge on any PR opened against integration. Guarded to never act on PRs targeting master.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only automation with an explicit base-branch guard; no application or auth code changes.
> 
> **Overview**
> Adds **`.github/workflows/auto-arm-merge.yml`**, which runs on PR **opened** and **ready_for_review** and calls `gh pr merge … --auto --squash` so squash auto-merge is armed without manual clicks.
> 
> The job runs only when the base branch is **`integration`** and the PR is **not a draft**, so PRs targeting **`master`** (or other bases) are never touched. Uses `GITHUB_TOKEN` with `contents: write` and `pull-requests: write`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bdae1dc8fdf30f24782c34c027054d44c9337d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->