### PR TITLE
ci: run Playwright e2e specs (tests/e2e) in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,21 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Check THIRD-PARTY-NOTICES.md covers every runtime dependency
         run: bun run check:notices
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+      - name: Run Playwright e2e tests
+        run: bunx playwright test


### PR DESCRIPTION
Adds a new E2E (Playwright) job to ci.yml that installs chromium and runs bunx playwright test against tests/e2e. Existing jobs unchanged. Not yet added to required checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow addition with no application or production runtime changes; main risk is flaky or slow e2e runs affecting PR feedback until the check is made required.
> 
> **Overview**
> Adds a new **E2E (Playwright)** job to `.github/workflows/ci.yml` so pull requests can run browser tests in GitHub Actions alongside the existing typecheck, lint, unit test, and scan jobs.
> 
> The job checks out the repo, installs dependencies with `bun install --frozen-lockfile` (using `BUN_VERSION` like most other jobs), installs Chromium via `bunx playwright install --with-deps chromium`, then runs `bunx playwright test` (the default Playwright test discovery, including `tests/e2e`). Other CI jobs are unchanged; the new job is not yet wired as a required status check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2211d8430075cab12c43ee0a488f0088aed650ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->