### PR TITLE
feat(auth): add gated e2e test sign-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,11 @@ RESEND_API_KEY=
 # Use a verified Resend domain in production, e.g. "Tempo Flow <no-reply@yourdomain.com>".
 RESEND_FROM_EMAIL=
 
+# E2E-only email OTP provider. Set exactly one email on dev/preview Convex
+# deployments only; never set this on production precious-wildcat-890.
+# Unset or empty disables the provider.
+E2E_TEST_AUTH_EMAIL=
+
 # ----------------------------------------------------------------------------
 # Beta gating (set in Convex dashboard env vars; NOT in Vercel / Next.js)
 # scope: [convex dashboard]

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,11 +1,13 @@
+import { ConvexCredentials } from "@convex-dev/auth/providers/ConvexCredentials";
 import { Email } from "@convex-dev/auth/providers/Email";
 import { Password } from "@convex-dev/auth/providers/Password";
-import { convexAuth } from "@convex-dev/auth/server";
+import { convexAuth, createAccount } from "@convex-dev/auth/server";
 import type { GenericMutationCtx } from "convex/server";
 import type { DataModel } from "./_generated/dataModel";
 
 const DEFAULT_FOUNDER_EMAIL = "amitlevin65@protonmail.com";
 const DEFAULT_BETA_MAX_TESTERS = 30;
+const E2E_TEST_AUTH_PROVIDER_ID = "e2e-test-email";
 
 function normalizeEmail(email: string | undefined | null): string {
   return (email ?? "").trim().toLowerCase();
@@ -15,6 +17,10 @@ function getFounderEmail() {
   return normalizeEmail(String(process.env.BETA_FOUNDER_EMAIL ?? DEFAULT_FOUNDER_EMAIL));
 }
 
+function getE2eTestAuthEmail() {
+  return normalizeEmail(process.env.E2E_TEST_AUTH_EMAIL);
+}
+
 function getAllowlistedEmails() {
   const fromEnv = (String(process.env.BETA_ALLOWLIST_EMAILS ?? ""))
     .split(",")
@@ -22,7 +28,39 @@ function getAllowlistedEmails() {
     .filter(Boolean);
   const allowlisted = new Set(fromEnv);
   allowlisted.add(getFounderEmail());
+  const e2eTestAuthEmail = getE2eTestAuthEmail();
+  if (e2eTestAuthEmail) {
+    allowlisted.add(e2eTestAuthEmail);
+  }
   return allowlisted;
+}
+
+function getE2eTestAuthProvider() {
+  const e2eTestAuthEmail = getE2eTestAuthEmail();
+  if (!e2eTestAuthEmail) {
+    return [];
+  }
+
+  return [
+    ConvexCredentials({
+      id: E2E_TEST_AUTH_PROVIDER_ID,
+      authorize: async (params, ctx) => {
+        const email = normalizeEmail(
+          typeof params.email === "string" ? params.email : undefined,
+        );
+        if (email !== e2eTestAuthEmail || params.code !== "123456") {
+          return null;
+        }
+
+        const { user } = await createAccount(ctx, {
+          provider: E2E_TEST_AUTH_PROVIDER_ID,
+          account: { id: e2eTestAuthEmail },
+          profile: { email: e2eTestAuthEmail, emailVerified: true },
+        });
+        return { userId: user._id };
+      },
+    }),
+  ];
 }
 
 function getBetaMaxTesters() {
@@ -87,6 +125,7 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
       maxAge: 60 * 30,
       sendVerificationRequest: sendMagicLinkEmail,
     }),
+    ...getE2eTestAuthProvider(),
   ],
   session: {
     totalDurationMs: 30 * 24 * 60 * 60 * 1000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL ?? "https://example.convex.cloud";
+
 export default defineConfig({
   testDir: "tests/e2e",
   timeout: 30_000,
@@ -13,7 +15,7 @@ export default defineConfig({
   webServer: {
     command: "bun run --cwd apps/web dev",
     env: {
-      NEXT_PUBLIC_CONVEX_URL: "https://example.convex.cloud",
+      NEXT_PUBLIC_CONVEX_URL: convexUrl,
       NEXT_PUBLIC_TEMPO_E2E_AUTH_BYPASS: "1",
       TEMPO_E2E_AUTH_BYPASS: "1",
       TEMPO_E2E_PUBLIC_CALENDAR: "1",

--- a/tests/e2e/auth.ts
+++ b/tests/e2e/auth.ts
@@ -1,0 +1,34 @@
+import type { Page } from "@playwright/test";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../../convex/_generated/api";
+
+const e2eTestAuthEmail = process.env.E2E_TEST_AUTH_EMAIL?.trim().toLowerCase();
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+
+export async function signInWithE2eTestEmail(page: Page) {
+  if (!e2eTestAuthEmail || !convexUrl) {
+    throw new Error("E2E test auth is not configured.");
+  }
+
+  const client = new ConvexHttpClient(convexUrl);
+  const result = await client.action(api.auth.signIn, {
+    provider: "e2e-test-email",
+    params: { email: e2eTestAuthEmail, code: "123456" },
+  });
+  const tokens = result.tokens;
+  if (!tokens?.token || !tokens.refreshToken) {
+    throw new Error("E2E test sign-in did not return tokens.");
+  }
+
+  const namespace = convexUrl.replace(/[^a-z0-9]/gi, "");
+  await page.addInitScript(
+    ({ jwt, namespace: authNamespace, refreshToken }) => {
+      window.localStorage.setItem(`__convexAuthJWT_${authNamespace}`, jwt);
+      window.localStorage.setItem(`__convexAuthRefreshToken_${authNamespace}`, refreshToken);
+    },
+    { jwt: tokens.token, namespace, refreshToken: tokens.refreshToken },
+  );
+
+  await page.goto("/today");
+  await page.waitForURL(/\/today(?:\?|$)/);
+}

--- a/tests/e2e/test-auth.spec.ts
+++ b/tests/e2e/test-auth.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+import { signInWithE2eTestEmail } from "./auth";
+
+test.skip(
+  !process.env.E2E_TEST_AUTH_EMAIL || !process.env.NEXT_PUBLIC_CONVEX_URL,
+  "E2E test auth requires E2E_TEST_AUTH_EMAIL and NEXT_PUBLIC_CONVEX_URL.",
+);
+
+test("E2E test email completes sign-in", async ({ page }) => {
+  await signInWithE2eTestEmail(page);
+
+  await expect(page.getByRole("main").getByRole("heading", { name: "Today" })).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Adds a server-gated Playwright sign-in path for one configured test account without changing the real password or magic-link providers. The provider is registered only when `E2E_TEST_AUTH_EMAIL` is non-empty, validates that exact normalized address plus fixed verification code `123456`, and returns a genuine Convex Auth session.

Task: Prompt 2 (no TASKS.md ID was supplied).

## Security and environment contract

- `E2E_TEST_AUTH_EMAIL` contains exactly one email address.
- Set it only on dev and preview Convex deployments.
- It is absent from production deployment `precious-wildcat-890` and must never be configured there.
- To switch the path off, unset or empty `E2E_TEST_AUTH_EMAIL`; the provider is then not registered, so the path does not exist.
- The real `Password` and `Email` magic-link providers are unchanged.
- No frontend auth gate was added.

## Files changed

- `.env.example`
- `convex/auth.ts`
- `playwright.config.ts`
- `tests/e2e/auth.ts`
- `tests/e2e/test-auth.spec.ts`

## Test plan

- [x] Focused TypeScript check for the Convex provider and Playwright helper
- [x] `bun run typecheck`
- [x] `bun run test` (60 passed)
- [x] `bunx playwright test --list` (3 tests discovered)
- [x] `bunx playwright test` without deployment variables (2 passed, gated auth test skipped, required check reports normally)
- [ ] Run the real auth test against a dev or preview deployment with both `NEXT_PUBLIC_CONVEX_URL` and `E2E_TEST_AUTH_EMAIL` configured

The final live-auth checkbox is intentionally open because this task forbids deploying code or changing external deployment configuration. No production or dev deployment was modified.

## Acceptance criteria

- One exact test email and fixed code `123456` are validated server-side.
- Missing or empty `E2E_TEST_AUTH_EMAIL` removes the provider entirely.
- Playwright has one helper and one mechanical sign-in assertion for the Today screen.
- Existing real-user authentication behavior remains unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a server-side auth bypass path (fixed OTP) that is safe only if `E2E_TEST_AUTH_EMAIL` never ships on production; misconfiguration would be critical.
> 
> **Overview**
> Adds an **optional Convex Auth credentials provider** for Playwright: it registers only when `E2E_TEST_AUTH_EMAIL` is set, accepts that normalized email plus fixed code `123456`, and issues a real session via `createAccount`. The test email is also added to the **beta allowlist** so sign-up gating does not block E2E.
> 
> **Playwright** wires `NEXT_PUBLIC_CONVEX_URL` from the environment (instead of a hardcoded placeholder), adds `signInWithE2eTestEmail` (Convex `signIn` action + JWT/refresh token in `localStorage`), and a **skipped-by-default** spec that asserts the **Today** heading after sign-in. `.env.example` documents the dev/preview-only contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b87c934f91e031c12f16e8ddc2e66c75c193f97e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->