### PR TITLE
chore: add CodeSpring skills for codebase mapping

### DIFF
--- a/.agents/skills/codespring/SKILL.md
+++ b/.agents/skills/codespring/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: codespring
+description: >
+  Project planning and management with CodeSpring. Use when the user wants to
+  work with CodeSpring projects, tasks, PRDs, mindmaps, or analyze a codebase
+  for project planning. Handles workspace selection, project linking, task
+  management, and syncing findings to CodeSpring.
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(node:*)
+metadata:
+  author: codespring
+  version: "1.1"
+---
+
+# CodeSpring CLI
+
+Manage project planning: workspaces, projects, tasks, PRDs, and mindmaps.
+
+## Prerequisites
+
+- **CLI installed**: `npm i -g @codespring-app/cli` or use `npx @codespring-app/cli`
+- **Authenticated**: Run `codespring auth status` to check. Login with `codespring auth login`.
+- **Project linked**: Check for `.codespring/config.json` or run `codespring init`.
+
+## Quick Start
+
+```bash
+# 1. Check auth
+codespring auth status
+
+# 2. Link project (interactive — picks workspace → project → writes config)
+codespring init
+
+# 3. Start working
+codespring tasks --status todo
+```
+
+## Core Commands
+
+| Command | Purpose |
+|---------|---------|
+| `codespring workspaces` | List available workspaces |
+| `codespring projects [--org ID]` | List projects |
+| `codespring project create --name <n>` | Create a new project |
+| `codespring features` | List features for linked project |
+| `codespring feature create --title <t>` | Create a feature |
+| `codespring tasks [--status S] [--feature ID]` | List tasks with filters |
+| `codespring task create --title <t> [--priority P]` | Create a task |
+| `codespring task start <id>` | Mark task as in_progress |
+| `codespring task done <id>` | Mark task as done |
+| `codespring task update <id> --status <s>` | Update task fields |
+| `codespring prds` | List PRDs by feature |
+| `codespring prd <id>` | Get full PRD content |
+| `codespring prd sync <id> --file <path>` | Update PRD from file |
+| `codespring mindmap` | Get mindmap structure |
+| `codespring mindmap set-info --title <t>` | Update project info node |
+| `codespring mindmap tech-stack --add '<json>'` | Sync tech stack |
+| `codespring mindmap features --add '<json>'` | Sync features |
+| `codespring mindmap note <featureId> --text '...'` | Add feature notes |
+| `codespring schema` | Data schema reference |
+| `codespring node-types` | Mindmap node type reference |
+
+**Note:** Task IDs can be UUIDs or row numbers (e.g., `task start 1` picks the first task from the list).
+
+## Output
+
+All commands default to markdown in terminals, JSON when piped.
+Add `--json` to force JSON, `--pretty` for formatted JSON, `--md` for markdown.
+
+## Agentic Task Workflow
+
+```bash
+# 1. Find available work
+codespring tasks --status todo
+
+# 2. Claim a task (UUID or row number)
+codespring task start 1
+
+# 3. Do the work using your coding tools
+
+# 4. Mark done
+codespring task done 1
+
+# Or create a new task
+codespring task create --title "Fix login bug" --priority high
+```
+
+## Syncing Codebase Analysis
+
+After analyzing a codebase, sync findings:
+
+```bash
+# Sync detected technologies
+codespring mindmap tech-stack --add '[{"id":"tech-react","title":"React","description":"Frontend"}]'
+
+# Sync discovered features
+codespring mindmap features --add '[{"title":"Authentication","description":"User login/signup"}]'
+
+# Add analysis notes to a feature
+codespring mindmap note feature-auth --text "Uses OAuth2 with PKCE flow..."
+```
+
+## Generating PRDs
+
+The CLI reads and syncs PRDs; it does not yet generate them. PRD generation and attaching PRD nodes to the canvas is a direct API call the CodeSpring app uses — see [prd-management.md](references/prd-management.md) and [mindmap-structure.md](references/mindmap-structure.md). The `cs-build-create-prd` skill wraps this end-to-end.
+
+## Scripts — run the checks, don't eyeball them
+
+**A check is a script; a judgement is prose.** Anything that must give the same answer every run lives in `scripts/`, read-only, writing nothing to the project or the repo:
+
+```bash
+bash scripts/fetch-project.sh --out /tmp/cs-state   # snapshot the linked project's JSON; prints the projectId
+node scripts/state.mjs        /tmp/cs-state         # the one-line state summary + booleans and counts
+node scripts/check-map.mjs    /tmp/cs-state [--expect-core N]   # map quality + post-write verification
+```
+
+`check-map.mjs` settles the core-feature count, duplicate titles, sub-features flattened to top level, missing notes, duplicate PRDs and unlinked tasks; exit 1 = a real failure, 2 = warnings only. Whether the map is *good* — sidebar-level features, verbs for sub-features, one-sentence card descriptions — stays a judgement and stays in prose. `cs-build-audit-codebase/scripts/check-repo.sh` does the same for the git/delivery reality.
+
+## Detailed References
+
+- [project-state.md](references/project-state.md) — **Start here.** State detection so any skill can be entered from anywhere; **the five questions that decide whether code is worth building on**; the Understand → Plan → Build stages and the seam between them; the map-quality caveat and the two-projects case; the quick health smell test
+- [auditing-and-fixing.md](references/auditing-and-fixing.md) — The audit → verdict → map → tasks pipeline; where audit errors actually come from (the orchestrator's own summarising); the moving-target/git reality; why the map shows the target; the rebuild-vs-fix decision table **and the has-users gate**; the defect categories worth hunting; scope discipline (problems / could-add-later / not-worth-adding) and where future ideas live; plain-language rules; idempotency + verification; FERB edge cases
+- [commands.md](references/commands.md) — Full CLI reference with all flags
+- [task-workflow.md](references/task-workflow.md) — Agentic task execution patterns
+- [analyze-codebase.md](references/analyze-codebase.md) — Codebase analysis checklist (stack detection + deep feature/backend/frontend passes; choosing the smallest core-feature set)
+- [mindmap-structure.md](references/mindmap-structure.md) — Mindmap data formats and node types (incl. PRD bridge nodes)
+- [prd-management.md](references/prd-management.md) — PRD read/sync + generate/attach/dedupe
+- [pitfalls.md](references/pitfalls.md) — Failure modes & guardrails (not checking what exists, wrong-project, flattening, duplicate PRDs, `features --replace` appending, no project delete/move)
+
+## Related skills
+
+This `codespring` skill is the shared knowledge base (how CodeSpring works + the CLI). The task-specific skills build on it. **Every one of them detects the project's real state on entry** (`project-state.md`), so it does not matter which the user invokes:
+
+- `cs-build-getting-started` — connect, report where the project actually is, and name the single next step. Routes on two questions: **is there code**, and **does it do the job** (the five questions in `project-state.md` — never "do we trust it").
+- `cs-build-plan-app` — no code yet, just an idea or a call recording. Interviews or mines the source, picks the platform on capability, proves the one hard part, cuts to a sellable v1, then writes the map and notes.
+- `cs-build-audit-codebase` — diagnose a codebase that isn't doing its job (run it, parallel specialists, git/CI audit), write a plain-English `FINDINGS.md`, and give a rebuild-or-fix-in-place verdict.
+- `cs-build-import-codebase` — map a repo into CodeSpring. With an audit it builds the corrected target map and findings-derived tasks; without one it documents what exists. Owns the map-quality ladder and the node model.
+- `cs-build-ui-mockup` — a throwaway clickable mockup and style guide from the notes, reviewed with the client, corrections fed back into the plan. **Before the PRDs**, for anything with a user interface.
+- `cs-build-create-prd` — generate a Frontend/Backend PRD for a chosen feature (the single source of truth for PRD creation).
+- `cs-build-create-tasks` — turn a feature's PRDs into a numbered, parallel-safe task list.
+- `cs-build-handoff` — turn the finished plan into the pack a paying client actually receives.
+- `cs-build-feature` — interactive build orchestrator (readiness checks → up to 5 sub-agents → break-risk guards).
+- `cs-build-resync-codebase` — keep CodeSpring in sync with the built code (read-only on code). This is what makes a target map describe reality again once the tasks are done.
+
+See `references/codespring-docs.md` for guiding users through web-app-only steps, and `claude-templates/` (repo root) for per-platform `CLAUDE.md` starters.

--- a/.agents/skills/codespring/references/analyze-codebase.md
+++ b/.agents/skills/codespring/references/analyze-codebase.md
@@ -1,0 +1,113 @@
+# Codebase Analysis Checklist
+
+Use this checklist when analyzing a local codebase to sync findings to CodeSpring. Sections 1–5 identify the stack and rough feature list. Sections 6–9 go deeper — they are what make notes and PRDs accurate. Read the code; don't guess.
+
+## 1. Project Identity
+
+- Read `package.json` for: name, version, description, scripts
+- Read `README.md` for: description, feature list, setup instructions
+
+## 2. Dependencies Analysis
+
+From `package.json` dependencies/devDependencies, identify:
+
+### Frontend Frameworks
+`react`, `react-dom`, `next`, `vue`, `nuxt`, `svelte`, `solid-js`, `angular`, `astro`, `remix`
+
+### Backend Frameworks
+`express`, `fastify`, `hono`, `koa`, `nestjs`, `elysia`, `hapi`
+
+### Database/ORM
+`prisma`, `drizzle-orm`, `mongoose`, `typeorm`, `sequelize`, `knex`, `pg`, `redis`, `ioredis`
+
+### State Management
+`zustand`, `jotai`, `recoil`, `valtio`, `mobx`, `xstate`, `redux`, `@reduxjs/toolkit`
+
+### Styling
+`tailwindcss`, `styled-components`, `@emotion/react`, `sass`, `@vanilla-extract/css`
+
+### Testing
+`jest`, `vitest`, `mocha`, `cypress`, `playwright`, `@testing-library/*`
+
+## 3. Directory Structure
+
+| Directory | Indicates |
+|-----------|-----------|
+| `src/app/` | Next.js App Router |
+| `src/pages/` | Next.js Pages Router |
+| `src/components/` | Component library |
+| `src/features/` | Feature-based architecture |
+| `src/hooks/` | Custom React hooks |
+| `src/lib/` or `src/utils/` | Utility functions |
+| `src/services/` | API/business logic |
+| `prisma/` | Prisma ORM |
+| `drizzle/` | Drizzle ORM |
+
+## 4. Feature Discovery
+
+Identify features from:
+1. **Route segments**: `/dashboard`, `/settings`, `/billing`
+2. **Feature directories**: `features/auth`, `features/payments`
+3. **README sections**: "Features", "What's Included"
+4. **Component directories**: Major UI sections
+
+## 5. Sync to CodeSpring
+
+### Tech Stack
+```bash
+codespring mindmap tech-stack --add '[
+  {"id":"tech-react","title":"React","description":"Frontend"},
+  {"id":"tech-typescript","title":"TypeScript","description":"DevTools"}
+]'
+```
+
+### Features
+```bash
+codespring mindmap features --add '[
+  {"title":"Authentication","description":"User login/signup"},
+  {"title":"Dashboard","description":"Main user interface"}
+]'
+```
+
+### Project Metadata
+Update project name/description if discovered from package.json/README.
+
+---
+
+## 6. Find the TRUE core features — read the sidebar first, then cut
+
+Section 4 gives candidates; this pins them down. In most webapps the **core features are the sidebar / primary-nav items = pages**. Find and read the nav/sidebar component (search for `sidebar`, `nav`, `navItems`, `routes`) and take its entries as the candidate list. Only fall back to routes/README when there is no nav. A core feature is the highest-level thing a user recognizes as "a thing the app does"; it should map to a page/section, not a file.
+
+**Then cut the list down.** Aim for **4–8 core features.** Above 8, argue for each one; above 10 you have almost certainly split one feature into many. Merge screens that are one job spread across pages, and drop pages the app shouldn't have (dead ends, orphans, internal galleries). A real run produced **13 confusing** core features before being cut to **6 clean** ones — the smaller list was the correct one. Read the list back to the user and ask them to cut it further before writing anything.
+
+## 7. Sub-features — things a user DOES
+
+Under each core feature, list the specialized capabilities that make it work — the actions inside that page, e.g. under a "Projects" page: Create Project, Invite Teammate, Project Detail. **A sub-feature is a verb: something the user does.** Create them parented to the core feature (`codespring feature create --parent <coreFeatureId>`). Keep descriptions to one sentence; depth goes in the note/PRD.
+
+**Do not turn report/page sections or form field-groups into sub-features.** This is the specific mistake that produced the 13-feature mess:
+- **A report or output section is not a feature.** "Government costs", "Tax benefits", "Glossary" are parts of one feature's output. Twelve report sections make **one** feature plus a good note — not twelve features.
+- **A form field-group is not a feature.** "Location", "Loan details", "Property details" are parts of one feature's input. The feature is *analysing a property*; those are panels of it.
+
+Symptoms you got this wrong: core features that read like a table of contents; sub-features that are nouns; more features than the app has screens; two sub-features a user couldn't tell apart. If detail is being lost, the **note** is too thin — enrich it rather than adding features.
+
+## 8. Backend depth (feeds the note + Backend PRD)
+
+For each core feature capture:
+- **API routes** — path, method, request/response, auth. **Flag any route used by more than one feature** (shared routes are where new features accidentally duplicate work).
+- **Data model** — tables/collections, key columns, enums, relationships; what's read vs written.
+- **Server actions / services / queries** — the reusable functions that already exist (new features should call these, not re-implement them).
+- **Security** — authn/authz, ownership checks, input validation, secrets/keys, row-level security, webhook signature verification.
+- **Shared backend systems** (call these out explicitly — new features collide with them): hosting/deploy target (AWS, Vercel…) and platform limits; crediting/usage metering; payment, subscription, and **refund** systems; background **jobs / pipelines / queues / cron**; storage — **S3 conventions / buckets**, file paths, signed-URL patterns; media/render pipelines (e.g. Remotion/video compositions); databases + migrations; **auth and row-level security (RLS)**; **environment variable names** to reuse; webhooks + signature verification.
+- **External services & env vars** — every integration and the env vars it needs.
+- **Infra & gotchas** — request timeouts/limits, async or polling jobs, hardcoded hosts, rate/credit logic, orphan/misnamed routes.
+- **Dependency / break-risk map** — what depends on this feature's code, so a future change doesn't silently break another feature.
+
+## 9. Frontend depth (feeds the note + Frontend PRD)
+
+- **Design tokens** — colors/branding, corner radius, spacing scale, typography, shadows (pull from the Tailwind config, CSS variables, or theme file).
+- **Component & UI styles** — which UI library, how buttons/cards/inputs/modals are styled, and their states (hover/active/disabled).
+- **Layout, positioning & spacing** — grid/flex, columns, breakpoints, gaps; where things sit relative to each other. Be concrete.
+- **What the user sees** — header, sections, cards, tables, empty/loading states, toasts.
+- **Navigation / interaction map** — the concrete path to and through the feature: which nav item/button opens it, what route it lands on, what it shows, and what each interaction does. Also where it links FROM and TO other features.
+
+Sections 8–9 are what you write into each core feature's "how it works" note before generating PRDs — the generator uses that note as context.

--- a/.agents/skills/codespring/references/auditing-and-fixing.md
+++ b/.agents/skills/codespring/references/auditing-and-fixing.md
@@ -1,0 +1,363 @@
+# Auditing & Fixing a Broken Codebase
+
+The process CodeSpring uses when a user says *"my app is a mess"*. This file holds the **reasoning**, not just the steps, because it is also the knowledge FERB needs to run this workflow without a user invoking a skill.
+
+Read this alongside `project-state.md` (**start here — how every skill detects where the project already is**), `analyze-codebase.md` (how to read a codebase), `mindmap-structure.md` (how the map is stored), `pitfalls.md` (CLI failure modes), and `task-workflow.md`.
+
+> **It must not matter which skill the user runs.** Every skill in this pipeline opens with the state-detection block in `project-state.md`, reports where the project actually is, and does the right *next* thing rather than the thing its own name implies. An audit run against a project that already has a good map updates that map — it does not build a second one.
+
+---
+
+## 1. Two entry points, split by intent
+
+There is one pipeline but two front doors, because users arrive with two different intents and they need different first moves.
+
+| The user says | Intent | Skill | First move |
+|---|---|---|---|
+| "get my app into CodeSpring", "map my app" | *Understand what I have* | `cs-build-import-codebase` | Document what exists |
+| "my app is a mess, diagnose it and plan the fix" | *Tell me what's wrong and what to do* | `cs-build-audit-codebase` | Diagnose, then hand off |
+
+**Routing is two questions: is there code, and does it do the job?** The second one is **never** "do we trust the code?" — that phrasing is meaningless to the person answering. It is the five questions in `project-state.md`:
+
+1. Does the app do what it actually needs to do?
+2. Is it getting things wrong, or presenting made-up or unverifiable figures as fact?
+3. Does the current architecture allow it to do what it needs to do?
+4. Can we build on it scalably?
+5. Can users use it without it breaking?
+
+**All five yes → keep building on it** (import). **Any no → consider rebuilding that part, or all of it** — which starts with an audit, because the audit is what turns a "no" into a specific, sized list, and the verdict (§5) decides fix-or-rebuild. **"The code runs" is not the same as "the code does the job":** a vibe-coded app very often runs fine and still fails 1–3.
+
+**Why split rather than one skill with a flag:** the audit is expensive (parallel sub-agents, running the app, hours of work) and the import is cheap. Code that does its job must not pay for an audit it doesn't need, and code that doesn't must not get a map of its own mess. Splitting by intent means the router asks two questions instead of interrogating the user.
+
+**Split by intent, not by hierarchy.** There is no wrapper skill and no routing tree. Both doors lead to the same pipeline, and each door is state-aware enough to be entered by mistake: an import that smells a broken codebase offers the audit first, and an audit that finds an existing map keeps it. See `project-state.md`.
+
+`cs-build-audit-codebase` does not build the map itself. It produces findings + a verdict and hands both to `cs-build-import-codebase`. One code path builds maps.
+
+---
+
+## 2. The pipeline
+
+```
+audit  ──►  verdict  ──►  map  ──►  tasks
+(what's   (rebuild or   (the      (the gap between
+ wrong)    fix in place)  target)   here and there)
+```
+
+1. **Audit** — run the app, fan out specialists, verify the headlines, audit the repo itself. Output: evidence-labelled findings + a plain-English `FINDINGS.md`.
+2. **Verdict** — rebuild, or fix in place. Argued against an explicit table (§5). Default is fix in place.
+3. **Map** — the corrected target feature map (§6). Same shape on both verdicts.
+4. **Tasks** — the gap between the map and reality, one task per defect or per feature-to-build, each mapped to a core feature and carrying a severity (§7).
+
+Stages 1–3 are **Understand** (they produce context). Stage 4 and PRDs are **Plan** (they produce instructions). The seam between them, and why a PRD is only as good as the note it reads, is in `project-state.md`.
+
+Every stage is idempotent and re-runnable (§8), and every stage may be entered directly — check what already exists first and skip what is already done.
+
+---
+
+## 3. Auditing: how to actually find things
+
+### Run the app. Do not only read it.
+The single highest-yield step. In the real audit this workflow was built from, driving the live app in a browser found things static analysis missed and *disproved* things static analysis suspected:
+
+- A form field cleared to empty threw an exception, the recompute aborted, and the report **kept displaying the previous numbers** with no error. Unreadable from the source; obvious in 10 seconds live.
+- The network panel proved the core calculation made **zero network requests** — which answered "how does it read the database?" with "it doesn't", and reframed the whole audit.
+- A "type anything to sign in" screen looked like an auth bypass in the code. Driving it showed a clearly labelled sample mode. **Running it prevented a false accusation.**
+
+So: start the app (or serve it), drive the main journeys, watch the console and the network panel, try empty and absurd inputs, and inspect where data is actually stored.
+
+### Fan out parallel specialists by domain
+Spawn independent sub-agents, one per domain, each read-only, each with a self-contained brief. Do not let them see each other's work — agreement between two independent methods is your strongest evidence.
+
+Standard domains: **security/auth**, **database/schema**, **core business logic**, **frontend/UX/dead controls**, **architecture/scalability**. Add domains the app clearly needs (a competitor comparison, a user-journey map, a data-provenance pass).
+
+Every finding must carry (a) a `file:line` reference or the exact command that reproduces it, and (b) an evidence label:
+
+- **CONFIRMED** — the agent ran it or read the exact line. Say what it ran.
+- **INFERRED** — deduced from code that was read, not executed. Say what the inference is.
+- **UNVERIFIED** — suspected, could not be checked. Say what would check it.
+
+Findings without a citation and a label do not go in the report. Ranking by consequence is impossible when confidence is unknown, and a confident wrong claim about someone's app destroys the audit's credibility.
+
+### Verify the headline claims yourself
+Do not relay a sub-agent's biggest number without independently reproducing it. In the real audit the orchestrator re-ran the core logic in a second, unrelated way (extracted into a scratch script) and separately in the live browser; both agreed to the cent, which is what made the headline dollar figure safe to put in front of a client. Where two methods agree, say so in the report.
+
+Also check for **contradictions between specialists** and resolve them before writing. A later, better-informed pass corrected an earlier one's table-ownership claim in the real audit; the corrected version is what shipped.
+
+### Audit the repo and delivery setup, not just the code
+Routinely skipped and routinely where the worst risk is:
+
+- **Is the local clone behind the remote?** `git fetch --all`, then compare `HEAD` with the upstream. Check this **first**, not last, report **how many commits behind**, and **offer to update before auditing** — findings from a stale clone may already be fixed. `cs-build-audit-codebase/scripts/check-repo.sh` does the whole check deterministically.
+- **What else is in flight?** Enumerate the remote branches with their dates and authors, so you do not write findings against work that has already been superseded.
+- **Is anyone else working in this repo right now?** Ask. If yes, the findings are a **snapshot at a named commit**: record the commit SHA in `FINDINGS.md` and recommend a **dedicated branch** for the fixes, saying plainly that merge conflicts will need managing.
+- **Assume the owner does not know git, and do not lecture them about it.** Non-technical owners commonly commit straight to `main` while an audit or rebuild is in flight. **Never assume a clean linear history, and never assume `main` is protected.** State what you are doing and why in one line and move on.
+  *Worked example: 12 remote branches, the owner committing directly to `main`, a helper working in parallel, and the audited clone 3 commits behind — with the newest commits touching the exact file under audit.*
+- **Is the app feature-complete, or still being built?** Ask this too, because it changes what "missing" means. If it is still being built, the map may be missing planned modules that the code does not contain yet, so **ask the owner what is planned but not yet built before finalising the feature list.** Real failure: an audit concluded that four pages were a separate product because nothing linked to them — they were unfinished modules of the same product.
+- **Is the whole backend even in the repo?** In the real case the entire server (13 endpoints, all SQL, the only definition of five tables) existed **only** inside a hosting dashboard — not in git, not on the machine. That is a total-loss risk and it was invisible from the code.
+- **Branch and PR structure** — is there a default branch, are branches short-lived, is work reviewed?
+- **CI** — does any automated check exist? Is deploy **gated** on it, or does merging ship straight to production? Auto-deploy with no test gate is the mechanism by which the real app shipped wrong tax law to production for nine days.
+- **Secrets in history** — scan for committed keys/tokens (`git log -p -S` for the obvious markers). Report the negative result too; "no privileged key was ever committed" is one of the most valuable things you can tell someone.
+- **Is there a staging environment?** If credentials are string literals, every preview and local session is talking to the production database.
+- **`.gitignore` adequacy** — fix this *before* telling anyone to commit their backend.
+
+---
+
+## 3a. Where audit errors actually come from
+
+The CONFIRMED / INFERRED / UNVERIFIED labels in §3 apply to **sub-agent output**. In the audit this workflow was generalised from, **nothing checked the orchestrator's own summarising — and that is where every error entered.** The specialists were careful; the write-up that compressed them was not. Label the sub-agents, then audit yourself against the rules below.
+
+Each one is a real mistake that reached the page. The specifics come from one audit of one app and are **labelled worked examples, not assumptions about the codebase in front of you** — the rule is the part that generalises.
+
+1. **Measuring one thing and claiming something broader.**
+   What happened: browser storage was measured on a single page — 45 bytes across 3 keys — and the write-up stated it as a fact about the whole app, which actually used 15 keys product-wide.
+   **Rule: state the scope of every measurement in the same sentence as the number.** *"45 bytes across 3 keys on the report page"* is true; *"45 bytes across 3 keys"* is not.
+
+2. **Compressing a sub-agent's finding into something stronger than it said.**
+   What happened: the write-up said *"the tax tables have drifted between the two engine copies."* A mechanical diff showed the rate tables were **byte-identical** — a different function had drifted. The claim sent the reader to the wrong file to fix the wrong thing.
+   **Rule: before repeating a sub-agent's headline claim, re-run the one command that proves it.** One `diff` would have caught this.
+
+3. **Overstating an advantage.**
+   What happened: the app was called "ahead" of the incumbent product on a feature when it had solved only the easy half of it — one property in one state, not land added up across a portfolio, which was the exact part the incumbent said was too hard.
+   **Rule: when claiming an app does something better, state what it does NOT do in the same breath.** "Better" with no boundary is a claim the owner will repeat to a customer.
+
+4. **Jargon that meant nothing to the reader.**
+   What happened: *"versioned rate tables stamped onto the saved file."* The person it was written for could not act on it.
+   **Rule: every term of art gets explained in the sentence it appears in, or is replaced.** The plain rewrite: *"when you save a report, also save which year's tax rates it used, so fixing a rate later doesn't change what a client was already shown."*
+
+5. **Concluding that part of the codebase was out of scope.**
+   What happened: four pages were called "a separate product" because nothing linked to them and they loaded a different script. The evidence was real, the conclusion was wrong. `git log` showed those files untouched since the initial import while everything around them changed weekly, and the owner had separately said he still had to work out the workflow for that part of the app — *"there is about 5-6 pages to it."* They were **unfinished modules of the same product**, not a different product.
+   **Rule: before concluding that part of a codebase is out of scope, check its git history and ask the owner.** Code that nothing references may be unfinished rather than foreign. `git log --format="%ad %s" -- <path>` per file is cheap and decisive: **a file untouched since the initial import while its siblings change weekly is a strong signal of "not finished yet", not "not part of this."**
+
+### The check that catches all five
+
+**Before writing the findings, list your headline claims and name the specific evidence for each one** — the command you ran, the `file:line` you read, or the screen you drove. **Anything you cannot point at gets dropped, or goes in labelled as unverified.** Write the list out deliberately; it takes minutes, and it is the only step that inspects the orchestrator's own work rather than a sub-agent's.
+
+---
+
+## 4. Defect categories worth hunting
+
+These recur across languages and stacks. Hunt them explicitly rather than hoping to notice them.
+
+### Stale hardcoded reference data
+Rates, prices, tax tables, fee schedules, thresholds, feature lists — anything with an expiry date — typed as literals into shipped source. The mechanism costs a deploy to update. The real cost is that **nothing notices when it expires**, and the output usually keeps asserting the data is current.
+*Real case: eight jurisdictions' tax tables as literals in a web page, plus a printed claim that they were "current for FY2026-27", with nothing checking the date.*
+Fix pattern: move to versioned records with `effective_from` / `effective_to`, ask "which value applied on the date of this event", surface a staleness warning when today is past the range, and stamp the version onto anything published.
+
+### Duplicated logic that has drifted
+The same function, table, or constant existing in two or more places. It is only a smell until it drifts — then it is a correctness bug that no single file review can see.
+*Real case: the calculation engine existed twice; the copy the secondary pages used stayed a financial year behind for nine days, so the same property produced different government charges on different pages. Nobody noticed because there were no tests.*
+Look for: copy-pasted modules, a "shared" file the main entry point never actually imports, constants defined more than once, and design tokens forked across stylesheets. Build a **duplication register**: what, how many copies, has it drifted, which copy is authoritative.
+
+### Silent failure paths
+An error that becomes a zero, an empty object, a stale screen, or a success message. The worst class of bug because the user cannot tell it happened.
+Signatures to grep for: empty catch blocks, `catch → return {}`, `catch → return 0`, promise rejections swallowed with a no-op, a truthiness check treating an error object as success, a lookup miss returning a default instead of "not found", and a save path that reports success without checking the result.
+*Real cases: a network blip wrote eight zeros into a market-data section and saved them, so "median price $0" read as real data; a failed disk write of a client record was swallowed, so the user believed it saved; a cleared input froze the report on the previous numbers, which then exported to PDF.*
+Rule to state in the report: **a missing value and a failure must never look the same.**
+
+### Data that lives only in a browser (or only on one machine)
+Records in `localStorage` / `IndexedDB` / a desktop file with no server copy. Survives a refresh, survives nothing else — a new browser, a second device, or clearing site data loses everything with no warning and no backup, and two colleagues can never see the same records.
+*Real case: every client file — names, incomes, property details — existed in one browser profile on one laptop.*
+Also flag the inverse where it is a genuine asset: if the core computation never touches the network, that is a real privacy property worth stating out loud rather than accidentally destroying.
+
+### Unverifiable currency or accuracy claims
+Any place the software *asserts* something it cannot check: "rates current for FY2026-27", "live data", "verified", a timestamp that is really a build constant, a source attribution read from a string typed next to the numbers. These are the findings that cost client trust rather than dollars, and they are usually one line.
+*Real case: a report named the government source and the financial year beside figures that nothing validated, including for an unrecognised jurisdiction where every charge came out as zero.*
+
+### Also worth a pass
+Numbers presented as precise that are actually unexamined assumptions (an auto-estimate whose "estimated" hint disappears when the mode changes is the nastiest version); controls that do nothing; pages nothing links to; validation that does not exist (no required fields, no bounds — a decimal separator read as a thousands separator silently divides a figure by a thousand); records generated from an empty form that look complete; and dead code paths calling endpoints that were never implemented.
+
+---
+
+## 4a. Scope discipline — three buckets, never blurred
+
+**The default posture of an audit is fix, not extend.** The user's words, and they are a rule rather than a preference: *"I want to avoid adding loads of features now. We just need to get what's currently working, working better."*
+
+Every observation the audit makes goes into exactly one of three buckets, and the buckets are reported separately and labelled:
+
+| Bucket | What goes in it | Where it ends up |
+|---|---|---|
+| **1. Problems** | What is broken, wrong, or silently lying right now. **This is the job.** | The findings write-up **and** the Kanban tasks |
+| **2. Could add later** | Real gaps and good ideas, deliberately **not** being built now | The findings write-up, in its own clearly-titled section. **Never in the task list.** |
+| **3. Not worth adding** | Suggestions that should stop coming up, **with the reason** | The findings write-up, one line each, so the question is closed |
+
+Rules, not suggestions:
+
+- **A feature suggestion may never enter the task list.** If it is not fixing something that is broken, it is bucket 2 or bucket 3. No exceptions, including "while we're in there".
+- **Bucket 3 needs a reason.** "Not worth adding" without a why is just an opinion and it will be raised again next month. In the real audit: *don't build an integration to fetch tax rates automatically — no free authoritative feed exists, and scraping eight government websites would be more fragile than a maintained table plus an annual review.* That closed the question permanently.
+- **Say bucket 2 out loud rather than silently dropping it.** A gap the audit noticed and consciously parked is reassuring. A gap the audit apparently missed is not.
+- **Watch the boundary case:** "this feature is missing" is bucket 2, but "this feature exists and produces a wrong answer" is bucket 1. Missing capital-gains modelling would be bucket 2; capital gains being understated by $337,000 by code that already runs is bucket 1.
+- When the user asks for something from bucket 2 anyway, that is their call — but it becomes its own piece of work with its own tasks, not a passenger on the fix list.
+
+### Where do future ideas actually live? — a real gap, with an interim convention
+
+CodeSpring has features, notes, PRDs and Kanban tasks. **It has no home for "things we might build later."** And those ideas must never be written as tasks: **a task list implies committed work**, so a parked idea sitting in Kanban will either get built by accident or make the board untrustworthy.
+
+**Interim convention, use it every time:** future ideas live in **`FINDINGS.md` in the repo**, in two explicitly titled sections, each entry one line with a reason:
+
+- **"Could add later — deliberately not doing now"** (bucket 2) — the reason is *why it is parked*, plus whether it is worth doing later.
+- **"Not worth adding"** (bucket 3) — the reason is *why the question is closed*, so it stops coming back.
+
+Nothing in either section becomes a task, a feature on the map, or a PRD. If the user later commits to one, it starts its own piece of work and moves out of the section.
+
+**Record this as a product gap for FERB:** there is no first-class "ideas" or "backlog" surface in CodeSpring that is visibly *not* a commitment. Until there is, the two `FINDINGS.md` sections are the answer and FERB should read and write them rather than inventing tasks.
+
+## 4b. Plain language — a hard rule, not a style note
+
+**Every finding must be readable by someone who does not know what a database migration is.** Any term of art must be explained in the same sentence it appears in, or not used.
+
+This is a rule because it has already failed in practice. The phrase *"versioned rate tables stamped onto the saved file"* was written and meant nothing to the person it was written for. The plain version says the same thing:
+
+> *"When you save a report, also save which year's tax rates it used — so that fixing a rate later doesn't change what a client was already shown."*
+
+Note what the good version does: it names the action ("when you save a report"), the thing to save ("which year's tax rates it used"), and — the part that actually persuades — **the consequence of not doing it** ("fixing a rate later changes what a client was already shown"). No jargon, and it is *more* specific than the technical phrasing, not less.
+
+Apply the same test to everything: *idempotent*, *RLS*, *IDOR*, *migration*, *ORM*, *schema drift*, *silent failure path*, *hydration*, *denormalised*. Either explain it inline or find the plain sentence. Full voice rules and structure for the deliverable live in `cs-build-audit-codebase/references/plain-english-writeup.md`.
+
+## 5. The verdict: rebuild or fix in place
+
+### Fix in place is the default. A rebuild has to be argued for.
+Say this plainly, to yourself and to the user: **rebuilding the whole architecture of an app is a large, risky job and is the wrong answer for most codebases.** It suits small apps with little irreplaceable logic — a tiny static-HTML app is a fair rebuild candidate; almost nothing else is.
+
+Users in distress ask for a rewrite, and an agent that agrees is doing the easy thing, not the right thing. A rebuild throws away every undocumented decision that is currently keeping the app working, restarts the bug count from zero, and delivers nothing until it is finished. Recommend it only when the gate and the table below actually point there, and say plainly which signals drove the call.
+
+### The gate: does the app have real users or paying customers?
+
+**Ask this before reading the table, because it can veto a rebuild on its own.**
+
+- **If yes — fix in place is strongly preferred, regardless of how bad the code is.** A rebuild means a migration, a cutover, and a period where both versions exist. That is risk a live business may not be able to absorb, and no amount of ugly code outweighs it.
+- **If a rebuild is genuinely unavoidable *with* live users**, it needs a **parallel-running plan**: the old app stays live, the new one is built alongside it, and there is an explicit cutover with a rollback. The user must understand and accept that before any work starts.
+- **Name the trap out loud:** parallel running usually means a second repo or a long-lived branch, and **multiple versions of an app across repos gets confusing fast** — nobody remembers which one is live. **Default to a branch in the same repo.** Use a separate repo only when the stack changes so completely that one repo genuinely cannot hold both.
+
+A "no users yet" answer does not argue *for* a rebuild — it just removes the veto and lets the table decide.
+
+### The decision table
+
+| Signal | Points to REBUILD | Points to FIX IN PLACE |
+|---|---|---|
+| **Can the current architecture host what the app needs to do?** | No — what is missing is structural (no server, no accounts, nowhere to put the data) and cannot be added where it is | Yes — what is missing can be added inside what already exists |
+| **How much irreplaceable domain logic is there?** | Small and isolatable — you can lift it out cleanly and carry it across | Large or diffuse — the valuable knowledge is spread through the whole app and cannot be lifted |
+| **How big is the total surface area?** | Small — few pages, routes and screens; rewriting is a known quantity | Large — many routes, migrations, integrations; a rewrite is an open-ended bet |
+| **Do tests or CI exist to protect a refactor?** | Irrelevant — you are replacing the code, not refactoring it | Helps a lot — a suite that catches regressions makes fixing in place safe and cheap |
+
+Read it as a whole, not a score. **Rebuild needs the gate to be clear *and* the first row to say "No".** If the architecture can host what's needed, the answer is fix in place regardless of how ugly the code is — ugly is not the same as wrong-shaped.
+
+### Worked both ways, from the real case
+
+**Rebuild — a static-HTML app.** No backend in the repo, no accounts, no database of its own; user records lived in one browser. ~8,800 lines total across 17 pages, of which only ~470 lines were irreplaceable domain logic (verified reference tables and one calculation pipeline) that could be lifted out in a day. Zero tests, zero CI. **No live customers depending on it yet**, so the gate was clear. Architecture row = **No** (there was nowhere to put durable, shared, authenticated data), surface = small, precious logic = small and isolatable. → **Rebuild**, and the plan led with "port these 470 lines deliberately, rewrite everything else".
+
+**Fix in place — a Next.js app.** Real authentication, 133 tables, 133 migrations, ~142 authorization policies, hundreds of routes and server actions. It had genuine, serious problems: signed agreements in a public bucket, endpoints failing open when a secret was unset, schema drift with ~38 undocumented production tables. Architecture row = **Yes** (every one of those is fixable where it stands), surface = large, precious logic = enormous and diffuse. → **Fix in place, never rebuild.** The problems were serious *and* the answer was still not a rewrite. Say that explicitly — a long defect list is not evidence for a rebuild.
+
+### What the verdict must contain
+The recommendation, **the answer to the users gate**, the two or three signals that decided it, an honest statement of the cost of the recommendation, and — if rebuild — **which specific parts get ported deliberately rather than rewritten** plus the parallel-running and rollback plan if the app is live. Also name the highest-value work that is worth doing *whichever* way the verdict goes; in the real case that was backing up the backend that was not in version control, and writing the first test suite — neither of which needed the rebuild to happen.
+
+---
+
+## 6. Why the map always shows the corrected target
+
+**Settled decision: the mindmap always shows the corrected target — what the app *should* be — never the current messy structure annotated with warnings.** This holds on both verdicts and it is deliberate.
+
+Rationale to keep on record:
+
+- **The map means one thing.** A user, or FERB, reading a CodeSpring map never has to ask "is this the real structure or the intended one?" It is always the intended one.
+- **The Kanban always means the same thing:** the gap between here and there. Every task closes a distance between the map and reality. That is true for a rebuild (build this feature) and for a fix in place (make this feature actually work).
+- **One drawing model.** No second node type for "broken", no warning badges, no annotation layer to maintain, and nothing extra to keep in sync when a task is finished.
+
+Accepted cost: **the map does not mirror the repository until the tasks are done.** That is real and must be disclosed to the user in one sentence. It is arguably a feature — the map shows people where they are going, which is what a non-expert needs to see. It is also why `cs-build-resync-codebase` exists: once the work is done, resync brings the map back to describing reality, and from then on the two agree.
+
+Where an audit finding has no home in the target map (a defect in a feature the target does not have, e.g. dead code being deleted), it becomes a task without a new feature — attach it to the closest core feature, or to a core feature named for the cleanup work. Do not invent a feature just to host a defect.
+
+**An existing map is not automatically a good map.** "A map already exists → keep it" is too blunt: an import can produce a map that is genuinely unusable. Judge it against the **map-quality ladder** in `cs-build-import-codebase/references/target-map.md` — exists? good? fixable? — and only recommend a second CodeSpring project when the map is beyond fixing, with the user's explicit confirmation. Two projects for one app is confusing later, so it has to be a deliberate, explained choice.
+
+---
+
+## 7. How findings become tasks
+
+**Only bucket 1 becomes tasks** (§4a). Bucket 2 and bucket 3 stay in the write-up. If the task list contains something that isn't fixing a real defect, it is in the wrong place.
+
+Every task, on either path: mapped to exactly one core feature, carrying a severity, one sentence of title, detail in the description.
+
+### If the verdict is REBUILD — two distinct sets
+1. **Build-to-spec tasks.** One per feature/sub-feature in the target map: build it to the spec in the note and PRDs. Ordered foundations-first.
+2. **Mistakes-to-avoid tasks.** One per significant defect found in the original, carried forward as an explicit "do not reintroduce this" instruction with the concrete example from the audit.
+
+**The second set is the entire reason for auditing before importing.** Without it, a rebuild recreates the same silent failure paths, the same hardcoded tables and the same duplicated logic, because nothing in the new plan says not to. Write them as verifiable constraints, not vibes:
+
+- *"Reference data must be date-scoped records, not literals in source. It must be impossible to update a rate by editing application code."*
+- *"A lookup failure must return an explicit not-found. No code path may substitute zero or an empty object for an error."*
+- *"There is exactly one copy of the calculation logic and both the client and the server import it."*
+- *"Every published document stores the inputs, the results, and the version of the reference data that produced them."*
+- *"Identity for authorization never comes from the request body. Body identifiers are targets, ownership-checked before use."*
+
+Where the audit produced a good test list, attach it here — a mistakes-to-avoid task with a failing test named in it is the strongest form of this.
+
+### If the verdict is FIX IN PLACE — one set
+One task per defect, at the place it lives, **with the file reference in the description** (the user-facing findings text has no file paths; the task description does, because an agent has to act on it). Sequence by consequence and by dependency: guard the silent failures first, then the wrong outputs, then the structural work, then polish. If the audit produced a suggested fix order, use it.
+
+### Severity
+Map audit severity straight onto task priority: Critical → `urgent`, High → `high`, Medium → `medium`, Low → `low`. Do not soften it. A finding that puts a wrong number in front of a paying customer is urgent even if it is a one-line fix.
+
+---
+
+## 8. Idempotency — required on every run
+
+Every skill in this pipeline must assume it is the *second* time it has run. **Check what exists, then update or skip. Never blindly overwrite and never duplicate.**
+
+**A check is a script; a judgement is prose.** Anything that must produce the same answer every run belongs in `codespring/scripts/`, not in a paragraph an agent can skim: state detection, the map's machine-checkable properties, and the post-write verification are all scripts. What stays prose is what needs reasoning — *is this map good? is this a sidebar item? fix or rebuild?* Never move a judgement into a script, and never leave a count in prose.
+
+Before writing anything:
+
+```bash
+bash  codespring/scripts/fetch-project.sh --out /tmp/cs-state   # read-only snapshot; prints the projectId
+node  codespring/scripts/state.mjs        /tmp/cs-state         # the summary line + booleans and counts
+node  codespring/scripts/check-map.mjs    /tmp/cs-state         # what is already wrong, before you add to it
+```
+
+What that reads, if you need it by hand: `codespring status` (the LOCAL project — print the projectId), `codespring mindmap` (nodes, features, notes, PRD bridges), `codespring features` (core + sub-features with ids), `codespring tasks` (**all** states), `codespring prds` (PRDs per feature).
+
+Then:
+
+- **Match on title** (case-insensitive, trimmed) before creating anything. An existing feature with that title is *the* feature — reuse its id, never create a second.
+- **Re-parent strays** rather than recreating them. A sub-feature that has been flattened to top level gets `feature update <id> --parent <coreId>`, not a delete-and-recreate.
+- **Never re-create an existing feature.** `codespring mindmap features --replace` does not replace — it appends (see `pitfalls.md`). Treat feature creation as add-only and diff first.
+- **Never regenerate an existing PRD unless asked.** Read it, report that it exists, and offer to refresh it.
+- **Never duplicate a task.** Match on the numbered title prefix and the feature id; continue the existing numbering rather than restarting.
+- **Update notes in place.** `codespring mindmap note` overwrites the single note for a feature, which is the desired behaviour — but read the existing note first and preserve anything still true.
+
+Report the diff to the user: created N, updated N, skipped N (already correct).
+
+## 9. Verification after every write
+
+**Run the script — it asserts all of this and exits non-zero on a real failure:**
+
+```bash
+bash codespring/scripts/fetch-project.sh --out /tmp/cs-verify
+node codespring/scripts/check-map.mjs    /tmp/cs-verify --expect-core <the number you intended>
+```
+
+Assert, do not assume:
+
+1. **Core-feature count** — fetch the mindmap and check `node-features.items.length` equals the number of core features you intended. Anything higher means sub-features were flattened.
+2. **No flattened sub-features** — every sub-feature still carries the right `parentFeatureId`. Re-parent any stray (`pitfalls.md` §2). Keep a stored sub→core map so this is a one-liner on re-runs.
+3. **No duplicates** — no two features share a title; no two PRDs share a `(feature, prdType)`.
+4. **Notes present** — one "how it works" note per core feature.
+5. **Tasks linked** — every task has a `--feature` id and a severity.
+
+Then give the user the project link: `https://v2.codespring.app/project/<projectId>`.
+
+---
+
+## 10. FERB edge cases
+
+Things FERB must handle deliberately, not discover:
+
+1. **The map is the target, not the repo.** Until the tasks are done, a feature on the map may not exist in the code, and code that exists may not be on the map. FERB must not "correct" the map toward the messy reality, and must not tell the user a feature exists because it is on the map. The Kanban is the source of truth for what is actually built.
+2. **After the tasks are done, resync.** `cs-build-resync-codebase` is what closes the loop and makes the map describe reality again. Prompt for it when a feature's tasks all reach done.
+3. **A fix-in-place map still shows the target.** Its features look almost identical to the current app's — the difference is in the notes (what it *should* do) and in the tasks (what is wrong today). Do not skip the corrected-target step just because the verdict was fix in place.
+4. **Findings text and task text differ on purpose.** The user-facing findings are plain English with no file paths; the task descriptions carry file references because an agent has to act on them. Never paste task text into a client-facing document.
+5. **Evidence labels survive the handoff.** An UNVERIFIED finding must not become a confident task. Turn it into an investigation task ("check whether X — here is what would confirm it") and keep the label.
+6. **The audit may be stale, and the codebase may be a moving target.** If the audit ran against a clone behind the remote, or a while ago, say so before acting on it and re-check the specific findings being worked. If the owner is still adding features to the same repo, the findings are a snapshot at a named commit (§3) — hold the SHA and re-check before acting.
+7. **An existing map is not automatically a good map.** Run the map-quality ladder (`cs-build-import-codebase/references/target-map.md`) before trusting one. Never create a second CodeSpring project for the same app without explicit confirmation, and if there are already two, establish **which one is authoritative** before writing anything.
+8. **There is no home for future ideas, and they must not become tasks.** Parked ideas live in the two named `FINDINGS.md` sections (§4a). A task list implies committed work; putting a "maybe later" idea on the board makes the whole board untrustworthy. This is a known product gap.
+9. **Ask what is planned but not yet built.** On an app that is still being built, code missing for a mapped feature may just be unfinished, and pages nothing links to may be unfinished modules rather than dead ends or a separate product. Check the file's git history before concluding otherwise (§3a, rule 5).
+10. **Routing is the five questions, never "do we trust it."** `project-state.md`. And "the code runs" is not the same as "the code does the job."
+11. **Project placement is manual.** There is no CLI way to create a project in a specific workspace/organisation, and no way to move or delete one afterwards. If the project must live in a team workspace, the user creates it in the web app **first**, then links to it. See `pitfalls.md`.
+12. **A rebuild verdict does not delete anything.** The old code stays until the new thing is proven. Any rebuild plan must include a rollback and an explicit point of no return. With live users it also needs a parallel-running plan and, by default, a branch in the same repo rather than a second one (§5).

--- a/.agents/skills/codespring/references/codespring-docs.md
+++ b/.agents/skills/codespring/references/codespring-docs.md
@@ -1,0 +1,33 @@
+# CodeSpring Docs — pointers for guiding the user
+
+Some steps happen in the **CodeSpring web app**, not the CLI (generating PRDs from the canvas, the Kanban board, picking a journey). Use this to guide users through those, and fetch the live docs when you need the current details.
+
+- Docs home: https://codespring.app/docs
+- Skills library: https://codespring.app/docs/skills
+- A project: `https://v2.codespring.app/project/<projectId>`
+
+> Agents: when you need the exact, current UI steps, fetch the relevant docs page (it's public) rather than relying on this summary, which may lag the product.
+
+## Install the skills (whole pack)
+```bash
+npx skills add CodeSpringApp/codespring-skills   # installs every skill in the pack, once
+```
+
+## Connect the CLI
+```bash
+npm i -g @codespring-app/cli
+codespring auth login      # browser OAuth
+codespring init            # link this directory to a project
+```
+
+## Pick your journey
+The docs frame two starting points: **build a new project from scratch** or **import an existing codebase**. `cs-build-getting-started` routes the user between them.
+
+## Generate a PRD in the web app
+If the user prefers the app over the CLI/API: open the project canvas → find the target **feature's bridge** → add a **PRD Bridge** to it → generate the **Frontend** and/or **Backend** PRD from that bridge → wait for it to finish. The PRD then appears as a `prdFrontend` / `prdBackend` node on that bridge. (Exact clicks are on the docs page — fetch it if unsure.) The same result is available programmatically via `prd-management.md`.
+
+## Kanban board
+Tasks created via the CLI show on the board: in the project, use the top-right **Map / Kanban** toggle → click **Kanban** to see tasks in `todo / in progress / on hold / done`.
+
+## When a user is stuck
+Point them at the relevant docs page (home or `/docs/skills`) rather than guessing UI details, and offer to do the CLI/API path for them where one exists.

--- a/.agents/skills/codespring/references/commands.md
+++ b/.agents/skills/codespring/references/commands.md
@@ -1,0 +1,137 @@
+# CodeSpring CLI — Full Command Reference
+
+## Auth
+
+### `codespring auth login`
+Log in via browser-based OAuth 2.1 flow (PKCE).
+- `--api-key` — Paste an API key instead of browser login
+- `--url <api-url>` — Custom API URL (default: auto-detected)
+
+### `codespring auth status`
+Show current authentication state. Returns `{ authenticated, type, apiUrl }`.
+
+### `codespring auth logout`
+Clear stored credentials from `~/.codespring/credentials.json`.
+
+## Setup
+
+### `codespring init`
+Interactive project linking (Vercel-style):
+1. Select workspace
+2. Select project (auto-detects by directory name)
+3. Writes `.codespring/config.json`
+
+Flags:
+- `--project <id>` — Direct link, skip interactive
+- `--force` — Re-link even if already linked
+
+### `codespring status`
+Show linked project info. Returns `{ linked, projectId, projectName, authenticated }`.
+
+## Data
+
+### `codespring workspaces`
+List all workspaces (personal + organizations). No flags.
+
+### `codespring projects`
+List projects in a workspace.
+- `--org <id>` — Filter by organization ID
+
+### `codespring project create`
+Create a new project.
+- `--name <n>` — Project name (required)
+- `--description <d>` — Project description
+
+### `codespring features`
+List features for the linked project. Requires linked project.
+
+### `codespring feature create`
+Create a new feature for the linked project.
+- `--title <t>` — Feature title (required)
+- `--description <d>` — Feature description
+
+## Tasks
+
+### `codespring tasks`
+List tasks with optional filters.
+- `--status <s>` — Filter: `todo`, `in_progress`, `on_hold`, `done`
+- `--feature <id>` — Filter by feature ID
+- `--priority <p>` — Filter: `low`, `medium`, `high`, `urgent`
+
+### `codespring task create`
+Create a new task for the linked project.
+- `--title <t>` — Task title (required)
+- `--description <d>` — Task description
+- `--priority <p>` — Priority: `low`, `medium`, `high`, `urgent`
+- `--feature <id>` — Link to a feature ID
+- `--estimate <e>` — Estimate (e.g., "2h", "1d")
+
+### `codespring task start <id>`
+Set task status to `in_progress`. Accepts UUID or row number.
+
+### `codespring task done <id>`
+Set task status to `done`. Accepts UUID or row number.
+
+### `codespring task update <id>`
+Update task fields.
+- `--status <s>` — New status
+- `--title <t>` — New title
+- `--description <d>` — New description
+- `--priority <p>` — New priority
+- `--estimate <e>` — New estimate (e.g., "2h", "1d")
+
+## PRDs
+
+### `codespring prds`
+List PRDs grouped by feature structure for the linked project.
+
+### `codespring prd <id>`
+Get full PRD content (includes markdown content, feature info, suggested path).
+
+### `codespring prd sync <id>`
+Update PRD content.
+- `--file <path>` — Read content from file
+- `--stdin` — Read content from stdin
+- `--name <name>` — Optionally update PRD name
+
+## Mindmap
+
+### `codespring mindmap`
+Get full mindmap structure (nodes + edges) for the linked project.
+
+### `codespring mindmap set-info`
+Update the project info node in the mindmap.
+- `--title <t>` — Project title
+- `--description <d>` — Project description
+- `--github <url>` — GitHub repository URL
+
+### `codespring mindmap tech-stack`
+Update the tech stack node.
+- `--add '<json>'` — JSON array of items: `[{"id":"tech-react","title":"React","description":"Frontend"}]`
+- `--replace` — Replace all items (default: merge)
+
+### `codespring mindmap features`
+Update the features node.
+- `--add '<json>'` — JSON array: `[{"title":"Auth","description":"Login/signup"}]`
+- `--replace` — Replace all items (default: append)
+
+### `codespring mindmap note <featureId>`
+Add notes to a specific feature. Creates bridge + notes nodes if needed.
+- `--text '<content>'` — Note content (supports markdown)
+- `--title '<title>'` — Note title (default: "Notes")
+
+## Reference
+
+### `codespring schema`
+Output the CodeSpring data schema (project, mindmap, tech stack items, features, PRDs).
+
+### `codespring node-types`
+Output mindmap node type definitions (primary, secondary, bridge, tertiary, handle patterns).
+
+## Global Flags
+
+- `--md` — Force markdown output (default in terminal)
+- `--json` — Force JSON output (default when piped)
+- `--pretty` — Pretty-print JSON output
+- `--help`, `-h` — Show help
+- `--version`, `-v` — Show version

--- a/.agents/skills/codespring/references/mindmap-structure.md
+++ b/.agents/skills/codespring/references/mindmap-structure.md
@@ -1,0 +1,137 @@
+# Mindmap Structure Reference
+
+## Node Types
+
+### Primary Node (`node-primary`)
+Central project node. Fields: `title`, `description`, `githubUrl`.
+
+### Secondary Nodes
+Major category branches from primary:
+- `node-features` — Features list (items array) — holds the **CORE features**
+- `node-tech-stack` — Technology stack (items array, grid layout)
+- `node-competitors` — Market competitors
+- `node-audience` — Target audience
+- **Sub-feature group nodes** — one per core feature; each holds that feature's sub-features. Its `data.parentFeatureId` = the core feature id.
+
+Data structure for list nodes:
+```json
+{
+  "title": "Features",
+  "subtitle": "Core functionality",
+  "handlePosition": "left",
+  "layout": "list",
+  "items": [
+    { "id": "feature-auth", "title": "Authentication", "description": "User login" }
+  ]
+}
+```
+
+Sub-feature items carry `parentFeatureId`:
+```json
+{ "id": "feature-signup", "title": "Sign up", "description": "Email signup", "parentFeatureId": "feature-auth" }
+```
+
+### Bridge Nodes
+Connector between a feature item and its detail nodes.
+- ID pattern: `bridge-feature-{featureId}` (note the doubled `feature-feature` when a featureId already starts with `feature-`)
+- Data: `{ featureId, count, isExpanded, handlePosition }`
+
+### Tertiary Nodes
+Detail nodes attached via a bridge:
+- **Notes**: `notes-{featureId}` with `{ type: "notes", title, content }` — created by `codespring mindmap note`.
+- **PRDs**: attached through a **PRD Bridge** (see below), not as a plain tertiary node.
+
+## PRD Bridge & PRD Nodes
+
+PRDs render on the canvas as a small sub-graph hanging off a feature's bridge:
+
+```
+feature bridge  →  prdBridge  →  prdFrontend
+                            \→  prdBackend
+```
+
+### `prdBridge` node
+- Type: `prdBridge`
+- ID: `prdBridge-{bridgeNodeId}` (e.g. `prdBridge-bridge-feature-feature-123`)
+- Data:
+  - `title`: `"PRD Bridge"`
+  - `itemId`: the **selected feature card id** (the core feature, or the sub-feature)
+  - `featureId`: the **container node that holds that card** — this is the field the PRD generator uses to locate the feature:
+    - For a **core feature** → `"node-features"`
+    - For a **sub-feature** → that feature's **sub-feature group node id**
+  - `isCollapsed`: `false`, `generatingType`: `null`, `handlePosition`: `"left"`
+- **Common failure:** setting `featureId` to the feature card's own id gives *"Features node not found in mindmap"* on generation. It must point to the container node.
+
+### `prdFrontend` / `prdBackend` nodes
+- Type: `prdFrontend` or `prdBackend`
+- ID: `prdFrontend-{unique}` / `prdBackend-{unique}`
+- Data: `{ prdId: "<PRD record id>", title: "Frontend PRD" | "Backend PRD", isGenerating: false, handlePosition: "left" }`
+
+## Edge / Handle Patterns
+
+### Features → Bridge
+```
+source: "node-features"
+target: "bridge-feature-{featureId}"
+sourceHandle: "node-features-source-{featureId}"
+targetHandle: "bridge-feature-{featureId}-target-{featureId}"
+```
+
+### Bridge → Notes
+```
+source: "bridge-feature-{featureId}"
+target: "notes-{featureId}"
+sourceHandle: "bridge-feature-{featureId}-source-notes"
+targetHandle: "notes-{featureId}-target-notes"
+```
+
+### Bridge → PRD Bridge → PRD nodes
+```
+# feature bridge → prdBridge
+source: "{bridgeNodeId}"       target: "prdBridge-{bridgeNodeId}"
+sourceHandle: "{bridgeNodeId}-source-prd"
+targetHandle: "prdBridge-{bridgeNodeId}-target-prd-bridge"
+
+# prdBridge → prdFrontend / prdBackend
+source: "prdBridge-{bridgeNodeId}"   target: "{prdNodeId}"
+sourceHandle: "prdBridge-{bridgeNodeId}-source-prd-bridge"
+targetHandle: "{prdNodeId}-target-prd"
+```
+All edges use `{ type: "default", className: "stroke-foreground", style: { strokeWidth: 2 } }`.
+
+## Reading & Writing the Mindmap
+
+- Read: `codespring mindmap` (or the raw record via the API `GET /mindmaps/project/{projectId}`).
+- The CLI writes specific parts (`set-info`, `tech-stack`, `features`, `note`). Adding PRD/other nodes uses a direct API write: `PUT /mindmaps/project/{projectId}` with body `{ flowJson: { nodes, edges } }`. This **replaces the whole flowJson**, so fetch the current one, ADD your nodes/edges, and preserve everything else. See `prd-management.md`.
+
+## Tech Stack Categories
+
+Use these in the `description` field when syncing:
+- **Frontend**: react, vue, svelte, next, angular, astro
+- **Backend**: express, fastify, hono, nestjs, elysia
+- **Database**: prisma, drizzle, mongoose, pg, redis
+- **State**: zustand, redux, jotai, mobx, xstate
+- **Styling**: tailwindcss, styled-components, emotion, sass
+- **Testing**: jest, vitest, playwright, cypress
+- **DevTools**: typescript, eslint, prettier, biome
+- **Infrastructure**: vercel, docker, aws-sdk
+
+## Sync Commands
+
+```bash
+# Tech stack (merge by default)
+codespring mindmap tech-stack --add '[{"id":"tech-react","title":"React","description":"Frontend"}]'
+
+# Features (append by default)
+codespring mindmap features --add '[{"title":"Auth","description":"Login/signup"}]'
+
+# Sub-features: create as features parented to a core feature
+codespring feature create --parent <coreFeatureId> --title "Sign up" --description "Email signup"
+
+# Feature notes (creates bridge + notes nodes automatically; ROOT feature ids only; overwrites the single note)
+codespring mindmap note feature-auth --text "OAuth2 implementation notes..." --title "How it works — Auth"
+
+# Replace mode (overwrites existing items)
+codespring mindmap tech-stack --add '[...]' --replace
+codespring mindmap features --add '[...]' --replace
+```

--- a/.agents/skills/codespring/references/pitfalls.md
+++ b/.agents/skills/codespring/references/pitfalls.md
@@ -1,0 +1,53 @@
+# Pitfalls & Guardrails
+
+Hard-won failure modes when driving CodeSpring from an agent. Check these on every run.
+
+## 0. Not checking what already exists (the most common one)
+Every skill must open with the state-detection block in `project-state.md` and then **update or skip, never blindly overwrite or duplicate**. Match on title before creating anything, re-parent strays instead of recreating them, never re-create an existing feature, never regenerate an existing PRD without being asked, never restart task numbering. A skill invoked from "the wrong place" must still do the right next thing. Rules in `auditing-and-fixing.md` §8.
+
+## 1. Wrong project
+The linked project lives in the **local** `<cwd>/.codespring/config.json`. The **global** `~/.codespring/config.json` points at whatever project was last used somewhere else. Any script that reads the global config will silently write to the WRONG project.
+- Always read `projectId` from the local config (or hardcode the intended one) and **print it before any write**.
+- Symptom of getting it wrong: API writes "succeed" but nothing changes in the project you're looking at, or a "bridge/feature not found" error because the ids belong to a different project.
+
+## 2. Sub-features flattened into core features
+After PRD generation and/or creating a checkpoint, sub-features' `parentFeatureId` can reset to `null`, which **promotes every sub-feature into the core features list** (`node-features` balloons while the sub-feature groups still exist). This shows up as "suddenly there are way too many core features."
+- **Detect:** fetch the mindmap and assert `node-features.items.length === <the real number of core features>`.
+- **Fix:** re-parent each stray sub-feature: `codespring feature update <subFeatureId> --parent <coreFeatureId>`. Keep a stored subId→coreId map so you can re-run this quickly.
+- Re-check this after every PRD-generation batch and checkpoint.
+
+## 3. Duplicate PRDs from client timeouts
+`POST /prds/generate` streams for ~20–30s. A client-side abort does NOT stop the server — it finishes and creates the record anyway. A short HTTP timeout + retry therefore creates **duplicates**.
+- Use a timeout ≥ 120s.
+- If duplicates happen: create a checkpoint (`POST /projects/<id>/checkpoints`) then `DELETE /prds/<id>` the extras, keeping the most complete per (feature, prdType). Group by the PRD `name` field, not the unreliable `featureName`.
+
+## 4. PRD bridge metadata
+`prdBridge.data.featureId` must point to the **container** node, not the feature card:
+- core feature → `"node-features"`
+- sub-feature → that feature's sub-feature group node id
+
+`prdBridge.data.itemId` is the selected feature card id. Getting `featureId` wrong yields *"Features node not found in mindmap"* at generation time.
+
+## 5. Notes are one-per-feature and root-only
+`codespring mindmap note <featureId>` accepts only **root (core) feature ids** and **overwrites** the single note node for that feature. Sub-features cannot get a note via the CLI (only via direct `flowJson` editing). Put sub-feature detail and cross-feature links inside the parent core feature's note.
+
+## 6. `PUT /mindmaps/project/<id>` replaces everything
+The flowJson PUT is a full replace. Always fetch the current flowJson, ADD your nodes/edges, and preserve the rest. After writing, re-verify pitfall #2.
+
+## 7. Auth / connection
+Every skill should start by checking `codespring auth status` (this also refreshes an expired OAuth token) and `codespring status` (project link). If not ready, direct the user to `codespring auth login` / `codespring init` and stop.
+
+## 8. Spec / research / planning documents
+Not reachable from the agent token (endpoints 404 / 401). These are web-app-only for now — do not promise to create them from the CLI.
+
+## 9. `mindmap features --replace` does NOT replace — it appends
+`codespring mindmap features --add '[...]' --replace` **appends the items and creates duplicates.** Despite the flag name, nothing is removed. Running an import twice this way doubles the core-feature list.
+- **Treat feature creation as add-only.** Read `codespring features` first, diff by title (case-insensitive, trimmed), and add only what is missing.
+- **Recovery:** `codespring feature delete <id> --yes` does work, and it cascades (the feature's sub-features, bridge, note and PRD nodes go with it). Delete the duplicates, keep the originals whose ids are referenced by existing tasks/PRDs.
+- The same caution does not apply to `tech-stack --replace`, which does replace, or to `mindmap note`, which correctly overwrites the single note for a feature.
+
+## 10. No `project delete`, and no way to move a project
+- **There is no `project delete` command.** A project created by mistake stays. Name it carefully.
+- **`project create` ignores `--org`** and stamps `organizationId: null`, so it always lands in the personal workspace. There is no CLI way to move a project between workspaces or organisations afterwards.
+- **Therefore:** if the project must live in a team/organisation workspace, tell the user to **create it in the web app first**, then `codespring projects` → `codespring init --project <id> --force` to link. Do this before writing anything; a full map in the wrong workspace cannot be relocated and has to be rebuilt.
+- Do not burn time looking for a flag or an API for this. It isn't there.

--- a/.agents/skills/codespring/references/prd-management.md
+++ b/.agents/skills/codespring/references/prd-management.md
@@ -1,0 +1,100 @@
+# PRD Management
+
+## Listing PRDs
+
+```bash
+# List PRDs grouped by feature (tree view)
+codespring prds
+```
+
+Returns PRDs organized by feature with: id, name, featureName, prdType.
+
+> Caveat: when reading a single PRD's detail, the `featureName` field can be unreliable. To group PRDs by feature, key off the PRD `name` (e.g. `"Frontend PRD: Dashboard"` / `"Backend PRD: Dashboard"`).
+
+## Getting PRD Content
+
+```bash
+# Get full PRD with markdown content
+codespring prd <prd-id>
+```
+
+Returns:
+- `id`, `name`, `projectId`, `projectName`
+- `featureName`, `featureSlug`, `prdSlug`
+- `content` — Full markdown content
+- `suggestedPath` — e.g., `.codespring/PRDs/{feature-slug}/{prd-slug}.md`
+- `createdAt`, `updatedAt`
+
+## Syncing PRD Content
+
+Update a PRD's content from a local file:
+
+```bash
+# From file
+codespring prd sync <prd-id> --file ./path/to/prd.md
+
+# From stdin (pipe from another command)
+cat generated-prd.md | codespring prd sync <prd-id> --stdin
+
+# Optionally update the name too
+codespring prd sync <prd-id> --file ./prd.md --name "Updated PRD Title"
+```
+
+## PRD Types
+
+- **frontend** — UI/UX specs: design tokens, component styles, layout, navigation/interaction
+- **backend** — API endpoints, business logic, data model, security, infra
+- **database** — Schema design, migrations, data models
+
+## Generating PRDs (API)
+
+The CLI reads and syncs PRDs but does not yet have a `create`/`generate` command. Generation is a direct API call the CodeSpring app uses. Authenticate first (`codespring auth status` refreshes an expired token), then call the API base `https://server.codespring.app/api` with `Authorization: Bearer <accessToken>` (or `x-api-key: <apiKey>`) read from `~/.codespring/credentials.json`. Use the `projectId` from the **local** `.codespring/config.json`.
+
+```
+POST /prds/generate
+body: { "projectId": "<uuid>", "bridgeNodeId": "bridge-feature-<featureId>", "prdType": "frontend" | "backend" | "database" }
+```
+
+Notes:
+- It **streams (SSE)** and takes ~20–30s. Use an HTTP timeout **≥ 120s**. A client-side abort does NOT stop the server — it still creates the record — so a short timeout + retry produces **duplicate PRD records**.
+- Generation reads the feature's **note** as context (`relatedNotes`), so writing a strong "how it works" note first (`codespring mindmap note`) directly improves PRD quality.
+- It creates the PRD **record** but does NOT add a node to the mindmap. See "Attaching a PRD to the canvas".
+
+## Attaching a PRD to the canvas
+
+A generated PRD will not appear until you add nodes to the mindmap `flowJson` and PUT it back. Build the `prdBridge → prdFrontend/prdBackend` sub-graph (full node/edge schema in `mindmap-structure.md`), then:
+
+```
+PUT /mindmaps/project/<projectId>
+body: { "flowJson": { "nodes": [...], "edges": [...] } }
+```
+
+This **replaces the whole flowJson** — fetch current, ADD your nodes/edges, keep everything else. Key correctness point: `prdBridge.data.featureId` must be the **container** node (`"node-features"` for a core feature, or the sub-feature group node id for a sub-feature), and `itemId` the selected feature card id.
+
+## Deduplicating PRDs
+
+If timeouts caused duplicates, delete the extras. `DELETE /prds/<id>` requires an active checkpoint:
+
+```
+POST /projects/<projectId>/checkpoints   body: { "message": "..." }
+DELETE /prds/<id>
+```
+
+Keep the most complete PRD per (feature, prdType); group by the PRD `name` field.
+
+## Export Workflow
+
+To export all PRDs to local files:
+
+```bash
+# 1. List PRDs to get IDs and suggested paths
+codespring prds
+
+# 2. For each PRD, get content and write to suggested path
+codespring prd <id>
+# Extract content field and write to suggestedPath
+```
+
+## Spec / research / planning documents
+
+These are currently **web-app only** — there is no CLI/API endpoint accessible to the agent token for creating spec, research, or planning documents. Do them in the CodeSpring web app.

--- a/.agents/skills/codespring/references/project-state.md
+++ b/.agents/skills/codespring/references/project-state.md
@@ -1,0 +1,165 @@
+# Project State Detection — enter from anywhere
+
+**The user should never have to know which skill to run.** They will invoke whichever one they remember, from whatever point they are actually at, and it must work. That is only possible if every skill starts by finding out where the project already is and then does the right *next* thing — not the thing its own name implies.
+
+So: **every CodeSpring skill begins with the same state-detection block.** This file is that block. Skills point here rather than re-implementing it.
+
+---
+
+## The three stages, and the seam between them
+
+| Stage | Produces | Artefacts | Skills |
+|---|---|---|---|
+| **Understand** | **context** — what is true now, and what it should be | audit findings, `FINDINGS.md`, core features + sub-features, one "how it works" note per core feature, tech stack | `cs-build-audit-codebase`, `cs-build-import-codebase` |
+| **Plan** | **instructions** — what to build and in what order | PRDs (Frontend / Backend), numbered Kanban tasks with severities | `cs-build-create-prd`, `cs-build-create-tasks` |
+| **Build** | **changed code** | commits, tasks moving to done | `cs-build-feature` |
+| *(then)* | **truth again** | the map redrawn to match what was actually built | `cs-build-resync-codebase` |
+
+**Where Understand ends and Plan begins — this is the seam people get wrong.** Understand writes *context*. Plan writes *instructions*. They connect in exactly one direction: **a PRD reads the note that Understand wrote.** The PRD generator uses the feature's note as its context, so a Backend PRD for a calculation engine belongs to Plan — but it is only any good if Understand wrote a real note first. A thin note produces a thin PRD, which produces vague tasks, which produces the wrong code. If a note is thin, go back and fix the note; do not compensate in the PRD.
+
+The practical rule: **never generate a PRD or a task for a feature that has no note.** Write the note first, always.
+
+---
+
+## The detection block
+
+Run this at the start of every skill, before any write. It is cheap.
+
+**Run it as the script, not by hand** — the summary must be identical every run, and a hand count is exactly where the core-feature number goes wrong:
+
+```bash
+bash codespring/scripts/fetch-project.sh --out /tmp/cs-state   # read-only snapshot; prints the projectId
+node codespring/scripts/state.mjs        /tmp/cs-state         # the summary line + every boolean and count below
+node codespring/scripts/check-map.mjs    /tmp/cs-state         # what is already wrong with the map, before you add to it
+```
+
+What that reads, if you ever need it by hand:
+
+```bash
+cat .codespring/config.json 2>/dev/null      # LOCAL project id — the only one to trust. Print it.
+codespring auth status                       # also refreshes an expired token
+codespring status                            # linked? which project?
+codespring mindmap --json                    # project info, tech stack, node-features items, notes, PRD bridges
+codespring features                          # core features (root) + sub-features, with ids and titles
+codespring prds                              # PRDs per feature
+codespring tasks --json                      # tasks in ALL states, not just todo
+ls FINDINGS.md 2>/dev/null                   # has an audit already been written up?
+```
+
+Reduce the output to six booleans and two counts:
+
+| Signal | How to read it |
+|---|---|
+| `linked` | local `.codespring/config.json` exists and has a `projectId` |
+| `coreFeatures` | count of `node-features.items` in the mindmap |
+| `subFeatures` | count of features with a `parentFeatureId` |
+| `notes` | count of `notes-*` nodes — should equal `coreFeatures` |
+| `prds` | count of PRD records |
+| `tasks` | count of tasks in **all** states |
+| `audited` | `FINDINGS.md` exists in the repo, or a note/task references an audit |
+| `stack` | `node-tech-stack` has items |
+
+**Print the summary to the user in one line before doing anything else**, e.g.
+`Project "PIA App (clean)" — 6 core features, 25 sub-features, 6 notes, 0 PRDs, 0 tasks. Audit: not yet.`
+
+That single line is what makes entering from the wrong place harmless: the user immediately sees where they are, and you immediately know what to skip.
+
+---
+
+## Branch on what you found
+
+| What exists | Where the project is | The single next step |
+|---|---|---|
+| Not linked | Nothing | Link it. Existing project → `codespring projects` + `codespring init --project <id> --force`. New → create it **in the web app** if it must live in a team workspace (see `pitfalls.md`), then link. |
+| Linked, no features | Understand not started | Run the **five questions** below. All five yes → `cs-build-import-codebase`. Any no → `cs-build-audit-codebase`. No code yet → plan from scratch. |
+| Features, no notes | Skeleton map only | Write the "how it works" note per core feature. Do not generate PRDs yet. |
+| Features + notes, no PRDs, no tasks | **Understand done, Plan not started** | If not `audited` and the user came in wanting fixes → audit, then tasks. Otherwise → PRDs (`cs-build-create-prd`) then tasks (`cs-build-create-tasks`). |
+| Features + notes + PRDs, no tasks | Plan half done | `cs-build-create-tasks`. |
+| Tasks in `todo` | Ready to build | `cs-build-feature`. |
+| Tasks mostly `done`, code has moved | Built | `cs-build-resync-codebase`. |
+| `audited` but no tasks | Audit done, nothing actionable yet | Turn the findings into tasks. Re-read `FINDINGS.md` first; do not re-audit. |
+
+**Always name exactly one next step.** Not a menu. If two are genuinely equal, pick one and say why.
+
+---
+
+## The five questions — is this code worth building on?
+
+**Never ask "do you trust the code?"** or "is it working well, or is it a mess?" Those mean nothing to the person answering, and the answer changes with their mood. Ask these five, in this order, and get an answer to each:
+
+1. **Does the app do what it actually needs to do?**
+2. **Is it getting things wrong, or presenting made-up or unverifiable figures as fact?**
+3. **Does the current architecture allow it to do what it needs to do?**
+4. **Can we build on it scalably?**
+5. **Can users use it without it breaking?**
+
+**All five yes → keep building on it** (`cs-build-import-codebase`). **Any no → consider rebuilding that part, or all of it** — start with `cs-build-audit-codebase`, because a "no" tells you *which* part is not fit for purpose, and the verdict (`auditing-and-fixing.md` §5, including the has-users gate) decides whether that part gets fixed where it stands or rebuilt. A "no" is never on its own an instruction to rewrite the app.
+
+**The distinction that matters: "the code runs" is not the same as "the code does the job."** A vibe-coded app very often runs fine — no crashes, no errors in the console — and still fails questions 1, 2 and 3. Running is the cheapest of the five properties to have and the one users notice least.
+
+> **Worked example (illustrative only — not an assumption about the codebase in front of you).** A calculator that technically works: every button responds, nothing throws. It silently reports **$0 in government charges** when a location code is entered in the wrong case, and it has no accounts, no server and no database of its own. It runs fine. It fails **1** (it cannot do the job for a second user or a second device), **2** (it prints a confident zero and claims official figures) and **3** (there is nowhere to put durable, shared data).
+
+Where the answers are guesses rather than knowledge — the user often does not know — run the quick health smell test below and answer questions 2, 4 and 5 from evidence instead.
+
+### Two things the counts alone won't tell you
+
+- **An existing map is not automatically a good map.** Before building anything on top of one, judge it against the **map-quality ladder** in `cs-build-import-codebase/references/target-map.md`: does it exist → is it good → is it fixable → is it beyond fixing. A map with 13 core features that read like a table of contents is worse than no map, because every note, PRD and task inherits the confusion. Fix it in place where you can; recommend a second project only when it is genuinely unsalvageable, and only with the user's explicit confirmation.
+- **There may be more than one project for the same app.** `codespring projects` can show two, because an unusable map was once replaced by a clean one rather than repaired. If so, **establish which project is authoritative before writing anything** and tell the user which one you are using. There is no `project delete`, so both will stay.
+
+---
+
+## Worked example — the case this was designed against
+
+`PIA App (clean)`: **6 core features, 25 sub-features, 6 notes, 0 PRDs, 0 tasks.** The user runs `cs-build-audit-codebase`.
+
+Correct behaviour:
+
+1. Detect: `coreFeatures = 6`, `notes = 6`, `tasks = 0`, `prds = 0`. Understand is essentially done, and the map passes the quality ladder — 6 core features, all sidebar-level, sub-features are verbs, a note each, no duplicates, nothing flattened.
+2. **Do not create features.** Do not "build the target map" — it already exists. Print the six titles and the ids and move on.
+3. Run the audit on the code.
+4. **Update** the existing notes only where the audit adds something the note did not know (a defect, a silent failure path, a stale data set). Read each note first; preserve what is still true.
+5. Create the Kanban tasks from the findings, each linked to one of the **existing** six feature ids.
+6. Verify: still 6 core features, still 25 sub-features correctly parented, notes still 6.
+
+The failure mode this exists to prevent: producing a **second** set of features, so the project ends up with 12 core features and a map nobody trusts. `codespring mindmap features --replace` appends rather than replaces (`pitfalls.md`), so that mistake is one command away and is tedious to undo.
+
+Note the project's name — *"(clean)"*. It is the **second** CodeSpring project for that app: the first import produced 13 confusing core features, and the map was replaced rather than repaired. That is why the ladder exists, why a second project needs explicit confirmation, and why any session that finds two projects for one app must say which one is authoritative before it writes.
+
+---
+
+## Quick health smell test
+
+Used when the user doesn't know whether their app is "healthy" or "a mess", and by `cs-build-import-codebase` to decide whether to offer an audit before importing. Two minutes, read-only, no sub-agents:
+
+```bash
+git fetch --quiet; git rev-list --left-right --count HEAD...@{u}   # is the local clone behind the remote?
+ls -a .github/workflows 2>/dev/null                 # any CI?
+# tests present at all? (adapt to stack)
+grep -rEl '(^|[^a-z])(test|spec)\.' --include='*' -m1 . 2>/dev/null | head
+# swallowed errors
+grep -rEn 'catch *\([^)]*\) *\{ *\}|catch *\{ *\}|except *:? *pass' . | head -20
+# secrets in shipped source
+grep -rEn 'eyJ[A-Za-z0-9_-]{20,}|sk_live_|AKIA[0-9A-Z]{16}|BEGIN [A-Z ]*PRIVATE KEY' . | head
+# browser-only storage
+grep -rEn 'localStorage|indexedDB|sessionStorage' . | wc -l
+# duplicated logic: the same distinctive constant or function name in more than one file
+```
+
+Six smells, any two of which mean "offer the audit":
+
+1. No tests and no CI — nothing protects a change.
+2. Deploy is not gated — merge ships straight to production.
+3. The local clone is behind the remote — you would be auditing the wrong code.
+4. Swallowed errors — silent failure paths.
+5. Credentials in shipped source.
+6. Records that live only in a browser, or reference data (rates, prices, thresholds) hardcoded in source.
+
+Report the count plainly — *"I found 4 of the 6 things that usually mean an app needs diagnosing before mapping. Want me to audit first?"* — and let the user decide. Never audit without being asked; never import a mess silently either.
+
+---
+
+## Idempotency and verification
+
+Both are non-negotiable on every run and are specified once in `auditing-and-fixing.md` §8 (idempotency: match on title, re-parent strays, never re-create, never regenerate a PRD unasked) and §9 (verification: core-feature count, no flattened sub-features, no duplicates, notes present, tasks linked). Every skill applies both.
+
+**A check is a script; a judgement is prose.** The verification above is `codespring/scripts/check-map.mjs` — run it and read the exit code rather than re-deriving the counts in prose. What stays a judgement, and stays in prose: whether the map is *good*, whether a core feature is really a sidebar item, and whether to fix or rebuild.

--- a/.agents/skills/codespring/references/task-workflow.md
+++ b/.agents/skills/codespring/references/task-workflow.md
@@ -1,0 +1,83 @@
+# Agentic Task Workflow
+
+## Overview
+
+CodeSpring tasks follow a Kanban workflow: `todo` → `in_progress` → `done` (with optional `on_hold`).
+
+## Discovery Flow
+
+```bash
+# 1. List features to find the right area
+codespring features
+
+# 2. Find available tasks (optionally filter by feature)
+codespring tasks --status todo --feature <feature-id>
+
+# 3. Pick a task by examining its title and description
+```
+
+## Execution Pattern
+
+```bash
+# Claim the task (UUID or row number from the task list)
+codespring task start 1
+
+# Do the work using your native coding tools (Read, Edit, Bash, etc.)
+# ...
+
+# Mark complete
+codespring task done 1
+```
+
+## Creating Tasks
+
+```bash
+# Create a task with all options
+codespring task create --title "Fix login redirect" --priority high --feature <feature-id> --estimate "2h"
+
+# Simple task
+codespring task create --title "Update README"
+```
+
+## Multi-Task Batch Workflow
+
+When working through multiple tasks:
+
+```bash
+# Get all todo tasks
+TASKS=$(codespring tasks --status todo)
+
+# For each task:
+# 1. Read the task details
+# 2. Start it: codespring task start <id>
+# 3. Implement the changes
+# 4. Complete it: codespring task done <id>
+# 5. Move to next task
+```
+
+## Priority Levels
+
+- **urgent** — Blocking other work, do first
+- **high** — Important, do soon
+- **medium** — Standard priority
+- **low** — Nice to have
+
+Filter by priority: `codespring tasks --status todo --priority high`
+
+## Status Transitions
+
+| From | To | When |
+|------|-----|------|
+| `todo` | `in_progress` | Starting work |
+| `in_progress` | `done` | Work completed |
+| `in_progress` | `on_hold` | Blocked/paused |
+| `on_hold` | `in_progress` | Unblocked, resuming |
+| `done` | `todo` | Reopening |
+
+## Updating Task Details
+
+You can update more than just status:
+
+```bash
+codespring task update <id> --status in_progress --priority high --estimate "2h"
+```

--- a/.agents/skills/codespring/scripts/check-map.mjs
+++ b/.agents/skills/codespring/scripts/check-map.mjs
@@ -1,0 +1,163 @@
+// check-map.mjs — the deterministic half of map quality and post-write verification.
+//
+// These are CHECKS, not judgements. Whether a map is *good* — whether "Reports"
+// is really a sidebar item, whether a sub-feature is a verb — needs reasoning and
+// stays in prose (cs-build-import-codebase/references/target-map.md). Everything a
+// machine can settle is settled here, identically every run. Read-only.
+//
+// Usage:
+//   bash fetch-project.sh --out /tmp/cs-state
+//   node check-map.mjs /tmp/cs-state [--expect-core N] [--min 4] [--max 8] [--json]
+//
+// Checks:
+//   FAIL  duplicate feature titles (case-insensitive, trimmed)
+//   FAIL  sub-features flattened to top level (a sub-feature also present in node-features)
+//   FAIL  a core feature with no note card
+//   FAIL  duplicate PRDs for the same (feature, type)
+//   FAIL  a task with no feature link
+//   FAIL  --expect-core N given and the count differs
+//   WARN  core-feature count outside 4–8 (needs an argument, not a rewrite)
+//   WARN  a core feature with no sub-features
+//   WARN  a task with no priority
+//
+// Exit codes: 0 = all pass · 1 = at least one FAIL · 2 = only WARNs · 3 = snapshot unusable
+
+import { readJson, mindmapModel, featureModel, taskModel, prdModel, normTitle } from './parse.mjs';
+
+const args = process.argv.slice(2);
+const dir = args[0];
+const flag = (name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i !== -1 && args[i + 1] !== undefined ? Number(args[i + 1]) : fallback;
+};
+const MIN = flag('min', 4);
+const MAX = flag('max', 8);
+const EXPECT = flag('expect-core', null);
+const jsonOnly = args.includes('--json');
+
+if (!dir) {
+  console.error('usage: node check-map.mjs <snapshot-dir> [--expect-core N] [--min 4] [--max 8] [--json]');
+  process.exit(3);
+}
+
+const map = mindmapModel(readJson(dir, 'mindmap.json'));
+const features = featureModel(readJson(dir, 'features.json'));
+const tasks = taskModel(readJson(dir, 'tasks.json'));
+const prds = prdModel(readJson(dir, 'prds.json'));
+
+if (!map.ok) {
+  console.error(`CANNOT CHECK: ${map.reason}`);
+  process.exit(3);
+}
+
+const results = [];
+const add = (level, check, detail) => results.push({ level, check, detail });
+
+const coreItems = map.coreItems;
+const coreCount = coreItems.length;
+
+// --- core-feature count -----------------------------------------------------
+if (EXPECT !== null && coreCount !== EXPECT) {
+  add('FAIL', 'core-feature count', `expected ${EXPECT}, found ${coreCount} — something created or flattened features`);
+} else if (coreCount < MIN || coreCount > MAX) {
+  add('WARN', 'core-feature count', `${coreCount} core features (target ${MIN}–${MAX}) — above ${MAX}, argue for each one; well above it usually means an output document or a form was split into features`);
+} else {
+  add('PASS', 'core-feature count', `${coreCount} core features`);
+}
+
+// --- duplicate titles -------------------------------------------------------
+const byTitle = new Map();
+for (const f of [...coreItems.map((i) => ({ id: String(i.id ?? ''), title: String(i.title ?? '') })), ...features.all]) {
+  const key = normTitle(f.title);
+  if (!key) continue;
+  if (!byTitle.has(key)) byTitle.set(key, new Set());
+  byTitle.get(key).add(f.id);
+}
+const dupes = [...byTitle.entries()].filter(([, ids]) => ids.size > 1);
+if (dupes.length) {
+  add('FAIL', 'no duplicate titles', dupes.map(([t, ids]) => `"${t}" → ${[...ids].join(', ')}`).join(' · ') + ' — recover with: codespring feature delete <id> --yes');
+} else {
+  add('PASS', 'no duplicate titles', `${byTitle.size} distinct titles`);
+}
+
+// --- flattened sub-features -------------------------------------------------
+const coreIds = new Set(coreItems.map((i) => String(i.id ?? '')));
+const coreTitles = new Set(coreItems.map((i) => normTitle(i.title)));
+const flattened = [];
+for (const group of map.subGroups) {
+  for (const item of group.items) {
+    const id = String(item?.id ?? '');
+    if (coreIds.has(id) || coreTitles.has(normTitle(item?.title))) {
+      flattened.push({ id, title: String(item?.title ?? ''), parent: group.parentFeatureId });
+    }
+  }
+}
+for (const item of coreItems) {
+  if (item?.parentFeatureId) {
+    flattened.push({ id: String(item.id ?? ''), title: String(item.title ?? ''), parent: String(item.parentFeatureId) });
+  }
+}
+if (flattened.length) {
+  add('FAIL', 'no flattened sub-features', flattened.map((f) => `"${f.title}" belongs under ${f.parent}`).join(' · ') + ' — fix with: codespring feature update <subId> --parent <coreId>');
+} else {
+  add('PASS', 'no flattened sub-features', `${map.subGroups.length} sub-feature groups intact`);
+}
+
+// --- a note per core feature ------------------------------------------------
+const noteIds = new Set(map.noteIds);
+const hasNote = (id) => noteIds.has(`notes-${id}`) || [...noteIds].some((n) => n.endsWith(String(id)));
+const missingNotes = coreItems.filter((i) => !hasNote(String(i.id ?? ''))).map((i) => String(i.title ?? i.id));
+if (missingNotes.length) {
+  add('FAIL', 'a note per core feature', `no note for: ${missingNotes.join(', ')} — never generate a PRD or a task for a feature with no note`);
+} else {
+  add('PASS', 'a note per core feature', `${noteIds.size} notes`);
+}
+
+// --- sub-features present ---------------------------------------------------
+const emptyCores = coreItems.filter((i) => !map.subGroups.some((g) => g.parentFeatureId === String(i.id ?? '') && g.items.length));
+if (emptyCores.length) {
+  add('WARN', 'sub-features present', `no sub-features under: ${emptyCores.map((i) => String(i.title ?? i.id)).join(', ')}`);
+} else if (coreItems.length) {
+  add('PASS', 'sub-features present', 'every core feature has sub-features');
+}
+
+// --- duplicate PRDs ---------------------------------------------------------
+const prdKeys = new Map();
+for (const p of prds) {
+  const key = `${p.featureId ?? '?'}::${normTitle(p.prdType)}`;
+  if (!prdKeys.has(key)) prdKeys.set(key, []);
+  prdKeys.get(key).push(p.id);
+}
+const dupPrds = [...prdKeys.entries()].filter(([, ids]) => ids.length > 1);
+if (dupPrds.length) {
+  add('FAIL', 'no duplicate PRDs', dupPrds.map(([k, ids]) => `${k} × ${ids.length}`).join(' · ') + ' — a client timeout does not stop generation; keep the most complete per (feature, type)');
+} else {
+  add('PASS', 'no duplicate PRDs', `${prds.length} PRDs`);
+}
+
+// --- tasks linked -----------------------------------------------------------
+const unlinked = tasks.filter((t) => !t.featureId);
+if (unlinked.length) {
+  add('FAIL', 'every task linked to a feature', `${unlinked.length} unlinked: ${unlinked.slice(0, 5).map((t) => t.title || t.id).join(' · ')}${unlinked.length > 5 ? ' …' : ''}`);
+} else if (tasks.length) {
+  add('PASS', 'every task linked to a feature', `${tasks.length} tasks`);
+}
+const noPriority = tasks.filter((t) => !t.priority);
+if (noPriority.length) {
+  add('WARN', 'every task carries a severity', `${noPriority.length} without a priority — Critical→urgent, High→high, Medium→medium, Low→low`);
+}
+
+// --- report -----------------------------------------------------------------
+const fails = results.filter((r) => r.level === 'FAIL');
+const warns = results.filter((r) => r.level === 'WARN');
+
+if (jsonOnly) {
+  console.log(JSON.stringify({ coreCount, fails: fails.length, warns: warns.length, results }, null, 2));
+} else {
+  for (const r of results) console.log(`${r.level.padEnd(4)}  ${r.check} — ${r.detail}`);
+  console.log(`\n${fails.length} fail, ${warns.length} warn, ${results.length - fails.length - warns.length} pass`);
+  if (fails.length) console.log('A FAIL is a machine-checkable defect: fix it before writing anything else.');
+  if (warns.length && !fails.length) console.log('WARNs need a human judgement, not an automatic fix.');
+}
+
+process.exit(fails.length ? 1 : warns.length ? 2 : 0);

--- a/.agents/skills/codespring/scripts/fetch-project.sh
+++ b/.agents/skills/codespring/scripts/fetch-project.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# fetch-project.sh — snapshot the linked CodeSpring project to a directory of JSON files.
+#
+# READ-ONLY. It runs only `codespring` read commands and writes nothing to the
+# project, the mindmap or the repo. Its output directory is disposable.
+#
+# Why a script: the state-detection block must produce the SAME answer every run.
+# Prose invites the agent to skip a command or eyeball a count. This does not.
+#
+# Usage:
+#   bash fetch-project.sh --out /tmp/cs-state [--repo /path/to/repo]
+#
+# Then:
+#   node state.mjs     /tmp/cs-state
+#   node check-map.mjs /tmp/cs-state --expect-core 6
+#
+# Writes into --out:
+#   mindmap.json features.json prds.json tasks.json   (raw CLI output)
+#   repo.json                                         (projectId, cwd, FINDINGS.md present?)
+#   errors.log                                        (any command that failed)
+#
+# Exit codes: 0 = every command succeeded · 1 = not linked / CLI missing · 2 = some command failed (see errors.log)
+
+set -u
+
+OUT=""
+REPO="$PWD"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --out)  OUT="${2:-}"; shift 2 ;;
+    --repo) REPO="${2:-}"; shift 2 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+[ -n "$OUT" ] || { echo "fetch-project.sh: --out <dir> is required" >&2; exit 1; }
+
+CLI="codespring"
+command -v codespring >/dev/null 2>&1 || CLI="npx @codespring-app/cli"
+
+mkdir -p "$OUT"
+: > "$OUT/errors.log"
+
+CONFIG="$REPO/.codespring/config.json"
+if [ ! -f "$CONFIG" ]; then
+  echo "NOT LINKED: no $CONFIG" | tee -a "$OUT/errors.log"
+  echo "Link it first: codespring projects  →  codespring init --project <id> --force" >&2
+  printf '{"linked":false,"cwd":"%s"}\n' "$REPO" > "$OUT/repo.json"
+  exit 1
+fi
+
+PROJECT_ID="$(node -e 'const fs=require("fs");try{const c=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));process.stdout.write(String(c.projectId||c.project_id||c.id||""))}catch(e){}' "$CONFIG")"
+[ -n "$PROJECT_ID" ] || { echo "NOT LINKED: no projectId in $CONFIG" | tee -a "$OUT/errors.log" >&2; exit 1; }
+
+# Print the projectId before anything else — the local config is the only one to trust.
+echo "projectId: $PROJECT_ID  (from $CONFIG)"
+
+FINDINGS=false
+[ -f "$REPO/FINDINGS.md" ] && FINDINGS=true
+
+node -e '
+  const [id, cwd, findings] = process.argv.slice(1);
+  process.stdout.write(JSON.stringify({ linked: true, projectId: id, cwd, findingsMd: findings === "true" }, null, 2));
+' "$PROJECT_ID" "$REPO" "$FINDINGS" > "$OUT/repo.json"
+
+STATUS=0
+fetch() { # fetch <outfile> <args...>
+  local file="$1"; shift
+  if ( cd "$REPO" && $CLI "$@" --json ) > "$OUT/$file" 2>>"$OUT/errors.log"; then
+    [ -s "$OUT/$file" ] || { echo "empty output: $CLI $* --json" >> "$OUT/errors.log"; STATUS=2; }
+  else
+    echo "failed: $CLI $* --json" >> "$OUT/errors.log"
+    echo 'null' > "$OUT/$file"
+    STATUS=2
+  fi
+}
+
+fetch mindmap.json  mindmap
+fetch features.json features
+fetch prds.json     prds
+fetch tasks.json    tasks
+
+if [ "$STATUS" -ne 0 ]; then
+  echo "some commands failed — see $OUT/errors.log (auth expired? run: codespring auth login)" >&2
+fi
+
+echo "snapshot: $OUT"
+exit "$STATUS"

--- a/.agents/skills/codespring/scripts/parse.mjs
+++ b/.agents/skills/codespring/scripts/parse.mjs
@@ -1,0 +1,155 @@
+// parse.mjs — shared, shape-tolerant readers for a `fetch-project.sh` snapshot.
+//
+// The CLI's JSON envelope has changed before (bare array vs { data: [...] } vs
+// { features: [...] }), and the mindmap arrives as a record wrapping flowJson.
+// So nothing here indexes a fixed path: it searches for the shape it needs and
+// says so loudly when it cannot find it. Read-only; pure functions.
+//
+// Node model it expects (see codespring/references/mindmap-structure.md):
+//   node-features        → data.items = the CORE features
+//   sub-feature group    → one node per core feature, data.parentFeatureId = coreId, data.items = sub-features
+//   bridge-feature-<id>  → connector from a feature card to its detail nodes
+//   notes-<featureId>    → the single "how it works" note card for that core feature
+//   node-tech-stack      → data.items = the tech stack
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function readJson(dir, name, fallback = null) {
+  const p = join(dir, name);
+  if (!existsSync(p)) return fallback;
+  const raw = readFileSync(p, 'utf8').trim();
+  if (!raw || raw === 'null') return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // Some CLI versions print a human line before the JSON body.
+    const start = raw.search(/[[{]/);
+    if (start > 0) {
+      try { return JSON.parse(raw.slice(start)); } catch { /* fall through */ }
+    }
+    return fallback;
+  }
+}
+
+/** Breadth-first search for the first array of objects reachable from `root`. */
+export function findArray(root, preferKeys = []) {
+  if (Array.isArray(root)) return root;
+  if (!root || typeof root !== 'object') return null;
+  for (const key of preferKeys) {
+    if (Array.isArray(root[key])) return root[key];
+  }
+  const queue = [root];
+  const seen = new Set();
+  while (queue.length) {
+    const node = queue.shift();
+    if (!node || typeof node !== 'object' || seen.has(node)) continue;
+    seen.add(node);
+    for (const key of preferKeys) {
+      if (Array.isArray(node[key])) return node[key];
+    }
+    for (const value of Object.values(node)) {
+      if (Array.isArray(value) && value.some((v) => v && typeof v === 'object')) return value;
+      if (value && typeof value === 'object') queue.push(value);
+    }
+  }
+  return null;
+}
+
+/** The mindmap's flow nodes, wherever they are wrapped. */
+export function mindmapNodes(mindmap) {
+  if (!mindmap) return null;
+  const candidates = [
+    mindmap?.flowJson?.nodes,
+    mindmap?.mindmap?.flowJson?.nodes,
+    mindmap?.data?.flowJson?.nodes,
+    mindmap?.nodes,
+  ];
+  for (const c of candidates) if (Array.isArray(c)) return c;
+  const found = findArray(mindmap, ['nodes']);
+  return Array.isArray(found) ? found : null;
+}
+
+const itemsOf = (node) => {
+  const items = node?.data?.items ?? node?.items;
+  return Array.isArray(items) ? items : [];
+};
+
+export function mindmapModel(mindmap) {
+  const nodes = mindmapNodes(mindmap);
+  if (!nodes) {
+    return { ok: false, reason: 'could not find the mindmap nodes array', nodes: [], coreItems: [], subGroups: [], noteIds: [], techItems: [] };
+  }
+  const featuresNode = nodes.find((n) => n?.id === 'node-features');
+  const techNode = nodes.find((n) => n?.id === 'node-tech-stack');
+  const noteIds = nodes
+    .filter((n) => String(n?.id ?? '').startsWith('notes-') || n?.data?.type === 'notes')
+    .map((n) => String(n.id));
+  const subGroups = nodes
+    .filter((n) => n?.id !== 'node-features' && n?.data?.parentFeatureId && itemsOf(n).length >= 0)
+    .filter((n) => Array.isArray(n?.data?.items ?? n?.items))
+    .map((n) => ({ id: String(n.id), parentFeatureId: String(n.data.parentFeatureId), items: itemsOf(n) }));
+  return {
+    ok: Boolean(featuresNode),
+    reason: featuresNode ? null : 'no node with id "node-features" — is the mindmap for this project initialised?',
+    nodes,
+    coreItems: itemsOf(featuresNode),
+    subGroups,
+    noteIds,
+    techItems: itemsOf(techNode),
+  };
+}
+
+/** Features as reported by `codespring features --json`, split core vs sub. */
+export function featureModel(features) {
+  const list = findArray(features, ['features', 'items', 'data']) ?? [];
+  const norm = list
+    .filter((f) => f && typeof f === 'object')
+    .map((f) => ({
+      id: String(f.id ?? f.featureId ?? ''),
+      title: String(f.title ?? f.name ?? ''),
+      parentFeatureId: f.parentFeatureId ?? f.parent_feature_id ?? f.parentId ?? null,
+    }));
+  return {
+    all: norm,
+    core: norm.filter((f) => !f.parentFeatureId),
+    sub: norm.filter((f) => Boolean(f.parentFeatureId)),
+  };
+}
+
+export function taskModel(tasks) {
+  const list = findArray(tasks, ['tasks', 'items', 'data']) ?? [];
+  return list
+    .filter((t) => t && typeof t === 'object')
+    .map((t) => ({
+      id: String(t.id ?? ''),
+      title: String(t.title ?? t.name ?? ''),
+      status: String(t.status ?? ''),
+      priority: t.priority ?? null,
+      featureId: t.featureId ?? t.feature_id ?? t.feature?.id ?? null,
+    }));
+}
+
+export function prdModel(prds) {
+  const list = findArray(prds, ['prds', 'items', 'data']) ?? [];
+  return list
+    .filter((p) => p && typeof p === 'object')
+    .map((p) => ({
+      id: String(p.id ?? ''),
+      name: String(p.name ?? p.title ?? ''),
+      featureId: p.featureId ?? p.feature_id ?? null,
+      prdType: String(p.prdType ?? p.type ?? ''),
+    }));
+}
+
+export const normTitle = (s) => String(s ?? '').trim().toLowerCase().replace(/\s+/g, ' ');
+
+/** Leading task number, so numbering can be continued rather than restarted. */
+export function highestTaskNumber(tasks) {
+  let max = 0;
+  for (const t of tasks) {
+    const m = /^\s*(\d+)\s*[.)\-:]/.exec(t.title);
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  return max;
+}

--- a/.agents/skills/codespring/scripts/state.mjs
+++ b/.agents/skills/codespring/scripts/state.mjs
@@ -1,0 +1,74 @@
+// state.mjs — the state-detection block, as a deterministic script.
+//
+// Prints the one-line summary every skill must show before it does anything,
+// then the booleans and counts from references/project-state.md. Read-only.
+//
+// Usage:
+//   bash fetch-project.sh --out /tmp/cs-state
+//   node state.mjs /tmp/cs-state [--json]
+//
+// Exit codes: 0 = state read · 1 = snapshot unusable (not linked, or the mindmap could not be parsed)
+
+import { readJson, mindmapModel, featureModel, taskModel, prdModel, highestTaskNumber } from './parse.mjs';
+
+const dir = process.argv[2];
+const jsonOnly = process.argv.includes('--json');
+
+if (!dir) {
+  console.error('usage: node state.mjs <snapshot-dir> [--json]   (make one with: bash fetch-project.sh --out <dir>)');
+  process.exit(1);
+}
+
+const repo = readJson(dir, 'repo.json', {});
+if (repo.linked === false) {
+  console.error('NOT LINKED — no local .codespring/config.json. Link the project before anything else.');
+  process.exit(1);
+}
+
+const map = mindmapModel(readJson(dir, 'mindmap.json'));
+const features = featureModel(readJson(dir, 'features.json'));
+const tasks = taskModel(readJson(dir, 'tasks.json'));
+const prds = prdModel(readJson(dir, 'prds.json'));
+
+// Core-feature count: the mindmap's node-features items are authoritative
+// (that is the list the canvas draws, and the list pitfalls.md §2 inflates).
+const coreCount = map.ok ? map.coreItems.length : features.core.length;
+const subCount = map.subGroups.length
+  ? map.subGroups.reduce((n, g) => n + g.items.length, 0)
+  : features.sub.length;
+
+const state = {
+  projectId: repo.projectId ?? null,
+  cwd: repo.cwd ?? null,
+  linked: true,
+  coreFeatures: coreCount,
+  subFeatures: subCount,
+  notes: map.noteIds.length,
+  prds: prds.length,
+  tasks: tasks.length,
+  tasksByStatus: tasks.reduce((acc, t) => ({ ...acc, [t.status || 'unknown']: (acc[t.status || 'unknown'] ?? 0) + 1 }), {}),
+  highestTaskNumber: highestTaskNumber(tasks),
+  audited: Boolean(repo.findingsMd),
+  stack: map.techItems.length > 0,
+  mindmapParsed: map.ok,
+};
+
+if (jsonOnly) {
+  console.log(JSON.stringify(state, null, 2));
+} else {
+  const bits = [
+    `${state.coreFeatures} core features`,
+    `${state.subFeatures} sub-features`,
+    `${state.notes} notes`,
+    `${state.prds} PRDs`,
+    `${state.tasks} tasks`,
+  ];
+  console.log(`Project ${state.projectId} — ${bits.join(', ')}. Audit: ${state.audited ? 'FINDINGS.md present' : 'not yet'}.`);
+  console.log(JSON.stringify(state, null, 2));
+  if (!map.ok) console.error(`WARNING: ${map.reason} — counts fell back to \`codespring features\`.`);
+  if (state.notes !== state.coreFeatures) {
+    console.error(`WARNING: ${state.notes} notes for ${state.coreFeatures} core features — every core feature needs one before any PRD or task.`);
+  }
+}
+
+process.exit(0);

--- a/.agents/skills/cs-build-audit-codebase/SKILL.md
+++ b/.agents/skills/cs-build-audit-codebase/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: cs-build-audit-codebase
+description: >
+  Diagnose a broken or untrusted codebase and plan the fix. Runs the app for
+  real, fans out parallel specialist sub-agents (security, database, core logic,
+  frontend/UX, architecture), audits the git/CI/deploy setup, verifies the
+  headline claims independently, then gives a plain-English findings list ranked
+  by real-world cost, writes FINDINGS.md into the repo, and delivers a
+  rebuild-or-fix-in-place verdict (fix in place wins by default, and having real
+  users can veto a rebuild outright) before handing off to cs-build-import-codebase and
+  creating the Kanban tasks. Works on any codebase in any language. Triggers,
+  "my app is a mess", "audit my codebase", "what's wrong with my app", "diagnose
+  this codebase", "should I rebuild or fix this", "find the bugs in my app",
+  "review my whole app".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(git:*) Bash(gh:*) Bash(node:*) Bash(npm:*) Bash(python3:*) Bash(curl:*) Bash(grep:*) Bash(rg:*)
+metadata:
+  author: codespring
+  version: "0.2"
+---
+
+# Audit a codebase and plan the fix
+
+For when the user says *"my app is a mess — tell me what's wrong and what to do about it."* Diagnostic, language-agnostic, and evidence-based. It ends with a plain-English findings list, a `FINDINGS.md` in the repo, a **verdict** (rebuild or fix in place), and Kanban tasks.
+
+**Read first:** the `codespring` skill's `references/project-state.md` (enter-from-anywhere, the five questions), `references/auditing-and-fixing.md` (**the reasoning behind every step here**), `references/analyze-codebase.md`, `references/pitfalls.md`. Then this skill's `references/specialist-briefs.md` (copy-ready sub-agent briefs) and `references/plain-english-writeup.md` (the deliverable's structure and voice).
+
+**Scripts** — run these instead of doing the equivalent by hand; a check must give the same answer every time. `scripts/check-repo.sh` (this skill: git/delivery reality) and the `codespring` skill's `scripts/fetch-project.sh` + `state.mjs` + `check-map.mjs` (state detection and map verification). All read-only. Judgement calls stay prose.
+
+**Script paths below are relative to this skill's own folder**, and the skills install side by side — so `../codespring/scripts/…` reaches the core skill's scripts. Resolve them once at the start (`SKILL_DIR=$(dirname <this file>)`) and use absolute paths after that, because your working directory will be the user's repo.
+
+**Language- and stack-agnostic.** Every named specific in this skill and its references — a rate table, a report, a state code — is a **labelled worked example** from the audit this was generalised from, never an assumption about the codebase in front of you. Translate the pattern; do not look for the example.
+
+**Guardrails:** read-only on the target codebase, with exactly one exception — `FINDINGS.md` at the repo root, written only after asking, never committed. Live probing of the user's own running app and own services is fine and must be non-destructive.
+
+## 0. Detect where the project already is
+Run the state-detection **scripts** — same answer every run, no hand-counting (the `codespring` skill's `scripts/`, installed alongside this one):
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state   # read-only snapshot; prints the projectId
+node ../codespring/scripts/state.mjs       /tmp/cs-state          # the one-line summary + booleans and counts
+node ../codespring/scripts/check-map.mjs   /tmp/cs-state          # the machine-checkable map faults
+```
+
+Print the one-line summary to the user. **This decides what you skip.**
+
+- Not linked → link first (or tell the user to create the project in the web app if it must live in a team workspace — `pitfalls.md`).
+- **A map already exists → judge it before you keep it** (the ladder below). Either way, do not create features, do not "build the target map", do not run `mindmap features` here. Print the existing core features and their ids, then audit.
+- `FINDINGS.md` already present → read it. You are updating an audit, not starting one.
+- Tasks already exist → note the highest task number; you will continue the sequence, not restart it.
+
+Always read `projectId` from the **local** `.codespring/config.json` and print it before any write.
+
+### 0a. Is the existing map any good? — the ladder
+*"A map exists → keep it"* is too blunt. An unusable map poisons every note, PRD and task built on it. Full version, including the CLI commands: `cs-build-import-codebase/references/target-map.md`.
+
+1. **Does a map exist?** No → it gets built later, by `cs-build-import-codebase` (§10). Not here.
+2. **Is it good?** `check-map.mjs` (above) settles the count, duplicate titles, flattened sub-features and missing notes. **You** judge the rest: are the core features **4–8** and each one something a user would recognise as a **sidebar item**; are sub-features things a user **does**, not sections of an output document or groups of form fields; are card descriptions one sentence with the depth in the notes. A map can pass every automated check and still be incomprehensible.
+3. **Good → keep it.** Update the notes, add the tasks. **Never recreate it.**
+4. **Fixable** (mostly right, a few strays) → **fix in place and say what you changed:** `codespring feature update <subId> --parent <coreId>` to re-parent, `codespring feature delete <dupId> --yes` to remove a duplicate, `codespring feature update <id> --title "..."` to rename.
+5. **Not fixable** (so wrong it is confusing — wildly too many core features, output sections standing in as features, no coherent structure) → **do not try to salvage it.** Explain plainly why, and recommend a **new CodeSpring project** with a clean map; the old one **stays as history**. **Get explicit confirmation before creating a second project — never silently.**
+
+⚠️ **Two projects for one app is confusing later**, so it must be a deliberate, explained choice — and the user must be told **which project is now authoritative**. The real case: a 13-core-feature import was unusable, a second project with a clean 6-feature map replaced it, and both still exist. There is no `project delete`, so this is permanent. If you arrive and find two projects for one app, establish which is authoritative before writing anything.
+
+## 1. Scope the audit with the user (short)
+Confirm: the repo path, how to start the app, what the app is *for*, whether there is an incumbent product it replaces, and anything already known to be broken. Ask what they most want answered — the real audit was shaped by three of the owner's own questions ("is it wrong in different areas?", "how is it reading the database?", "why do some reports look better?") and each produced a headline finding.
+
+Three more questions, because each one changes what the findings mean (§2):
+- **Does the app have real users or paying customers?** This can veto a rebuild on its own (§9) — ask it now, not at verdict time.
+- **Is anyone else working in this repo right now?**
+- **Is the app feature-complete, or still being built?**
+
+State the posture up front: **the job is making what already works work properly, not adding features.** See `auditing-and-fixing.md` §4a.
+
+## 2. Recon + the repo/delivery audit (do this yourself, first)
+It caveats everything else, so it comes before the fan-out. Commands in `specialist-briefs.md` §6. Establish:
+- **Is the local clone behind the remote?** `git fetch`, then compare local `HEAD` with `origin/<branch>`. If behind, **say so and offer to update before auditing** — auditing a stale clone produces findings that may already be fixed. (The real audit ran two merges behind production.)
+- Is the **server-side source even in the repo**, or does it live only in a hosting dashboard? If the latter, that is a critical, total-loss finding — give the exact backup commands.
+- Branch/PR structure; **is deploy gated on any automated check** or does merging ship to production; any CI at all; `.gitignore` adequacy; secrets in history (report the negative result too); is there a staging environment or does every session talk to production.
+- Fix the stack description now so the sub-agents don't each re-derive it.
+
+### 2a. The codebase is a moving target — run the script first
+```bash
+bash scripts/check-repo.sh --repo <abs repo path> [--paths <suspect files…>]
+```
+Read-only (`git fetch` touches remote-tracking refs only). It prints the commit the findings will apply to, how far behind the remote you are and which files those unseen commits touch, every remote branch with its date and author, recent authors, whether the working tree is dirty, and whether any automated check exists. Exit code 2 means the clone is behind.
+
+**Worked example of what this catches, from a real audit:** 12 remote branches, the owner committing directly to `main`, a helper working in parallel, and the audited clone **3 commits behind** — with the newest commits touching the exact file under audit.
+
+Then:
+- **If behind: say how many commits, and offer to update before auditing.** One line, no lecture. **Never audit a stale clone silently** — findings from old code may already be fixed.
+- **Enumerate the remote branches and report what is in flight**, so you do not write findings against work that has already been superseded.
+- **Record the exact commit SHA in `FINDINGS.md`**, in the header beside the review dates. The findings are a snapshot of that commit and nothing else.
+- **Anyone else working in the repo right now?** Ask. If yes, recommend a **dedicated branch** for the fixes and say plainly that merge conflicts will need managing.
+- **Feature-complete, or still being built?** If still being built, the map may be missing planned modules the code does not yet contain, so **ask the owner what is planned but not yet built before finalising the feature list.** Real failure: an audit concluded four pages were a separate product because nothing linked to them — they were unfinished modules of the same product (§6a, rule 5).
+- If the remote moves during the audit, re-check the specific findings you are about to ship rather than re-running everything.
+
+**Assume no git knowledge and do not lecture the owner about it.** Non-technical owners commonly do not understand branches and will commit straight to `main` while an audit or a rebuild is in flight. State what you are doing and why in one line — *"I'll work on a branch called `fixes` so your own commits to main don't collide with mine"* — and never assume a clean linear history or that `main` is protected.
+
+## 3. Run the app and drive it
+**The highest-yield step. Do not skip it and do not substitute reading the code.** Start or serve the app, drive the main journeys, watch the console and the network panel, try empty/zero/negative/absurd/wrong-case inputs, and find where data is actually stored.
+
+In the real audit this found a cleared input that froze the report on stale numbers, proved the core calculation made zero network requests (which reframed the whole audit), and *disproved* a suspected auth bypass that was really a labelled sample mode. Running it prevents false accusations as often as it finds bugs.
+
+## 4. Fan out parallel specialists
+Launch them **in one message, concurrently**, each read-only, each with a fully self-contained brief and no sight of the others. Independence is the evidence. Briefs in `references/specialist-briefs.md`:
+
+**security/auth · database/schema · core business logic · frontend/UX/dead controls · architecture/scalability**
+
+Add domains the app warrants — an incumbent/competitor comparison, a user-journey-and-failure map, a data-provenance pass. Every finding must carry a `file:line` or a reproducing command, plus an evidence label: **CONFIRMED** (ran it / read the exact line), **INFERRED** (deduced, not executed), **UNVERIFIED** (suspected, say what would check it). Unlabelled, uncited findings are dropped.
+
+While they run, keep driving the app. You are the sixth agent and the one who resolves disagreements.
+
+## 5. Hunt the specific defect categories
+Named in `auditing-and-fixing.md` §4 — hunt these deliberately rather than hoping to notice them:
+- **Stale hardcoded reference data** — rates/prices/thresholds as literals in source, with nothing noticing when they expire.
+- **Duplicated logic that has drifted** — build a duplication register; check whether the copies agree *today* and whether they ever didn't; check which copy the main entry point actually loads.
+- **Silent failure paths** — an error becoming a zero, an empty object, a stale screen, or a success message. *A missing value and a failure must never look the same.*
+- **Data that lives only in a browser** — or only on one machine, with no backup and no warning.
+- **Unverifiable currency/accuracy claims** — anything the software asserts that it cannot check.
+
+## 6. Verify the headlines yourself
+Do not relay a sub-agent's biggest number. Reproduce it independently — a second method (extract the logic into a scratch harness) and/or the live app. In the real audit both agreed to the cent, which is what made the headline dollar figure safe to show a client; say so in the write-up when they do. Reconcile contradictions between specialists; a later, better-informed pass beats an earlier one — record the correction rather than shipping both.
+
+### 6a. Then audit yourself — this is where the errors actually came from
+The CONFIRMED / INFERRED / UNVERIFIED labels only govern **sub-agent output**. In the real audit **nothing checked the orchestrator's own summarising, and that is where every error entered.** Full worked examples in `auditing-and-fixing.md` §3a. The four rules:
+
+1. **State the scope of every measurement in the same sentence as the number.** *"45 bytes across 3 keys"* was measured on one page; the app used 15 keys product-wide.
+2. **Before repeating a sub-agent's headline claim, re-run the one command that proves it.** *"The tax tables have drifted between the two engine copies"* was written when a `diff` showed the rate tables byte-identical and a different function drifted — it sent the reader to the wrong file.
+3. **When claiming an app does something better, state what it does NOT do in the same breath.** Calling the app "ahead" of the incumbent hid the fact that it had solved only the easy half of that feature.
+4. **Every term of art gets explained in the sentence it appears in, or is replaced.** *"Versioned rate tables stamped onto the saved file"* → *"when you save a report, also save which year's tax rates it used, so fixing a rate later doesn't change what a client was already shown."*
+5. **Concluding that part of the codebase is out of scope.** Four pages were called "a separate product" because nothing linked to them and they loaded a different script. The evidence was real; the conclusion was wrong — `git log` showed those files untouched since the initial import while their siblings changed weekly, and the owner had already said he still had to work out that part's workflow. They were **unfinished modules of the same product**. **Rule: before concluding that part of a codebase is out of scope, check its git history and ask the owner.** Unreferenced code may be unfinished rather than foreign: `git log --format="%ad %s" -- <path>` per file is cheap and decisive, and `scripts/check-repo.sh --paths <files>` does it for a list.
+
+**Required step, before writing anything in §8: list your headline claims and name the specific evidence for each one** — the command, the `file:line`, or the screen you drove. **Anything you cannot point at gets dropped or labelled unverified.** Write the list out; it is the only check on your own work rather than a sub-agent's.
+
+## 7. Sort everything into the three buckets
+**Rule, not a suggestion** (`auditing-and-fixing.md` §4a). The audit's default posture is **fix, don't extend** — the goal is usually getting something live, not making it richer.
+1. **Problems** — broken or wrong now. *This is the job*, and the only bucket that becomes tasks.
+2. **Could add later** — real gaps, deliberately parked. Written up in their own section, **never in the task list**.
+3. **Not worth adding** — with the reason, so the question is closed.
+
+A feature suggestion may never enter the task list, including "while we're in there". "This is missing" is bucket 2; "this exists and gives a wrong answer" is bucket 1.
+
+### 7a. Where future ideas go — there is nowhere else yet
+CodeSpring has features, notes, PRDs and Kanban tasks. **It has no home for "things we might build later"**, and those must never become tasks: **a task list implies committed work**, so a parked idea on the board either gets built by accident or makes the board untrustworthy.
+
+**Interim convention — use it every time:** future ideas live in **`FINDINGS.md` in the repo**, in two explicitly titled sections, one line each **with a reason**:
+- **"Could add later — deliberately not doing now"** — the reason it is parked, plus whether it is worth doing later.
+- **"Not worth adding"** — the reason the question is closed, so it stops coming up.
+
+Nothing in either section becomes a task, a feature on the map, or a PRD. Say the posture out loud once in the document. **Report this to the user as a product gap for FERB** — there is no first-class ideas surface that is visibly *not* a commitment.
+
+## 8. Write the plain-English findings
+Full structure and voice in `references/plain-english-writeup.md`. Non-negotiables:
+- **Roughly third-grade reading level.** Short bullets, one concrete example per problem.
+- **Ranked by real-world consequence** — dollar impact or client-trust impact — hardest-hitting first.
+- **No file paths, no line numbers, no jargon** in the user-facing text. Every finding readable by someone who does not know what a database migration is; any term of art explained in the same sentence. (*"Versioned rate tables stamped onto the saved file"* failed this test. *"When you save a report, also save which year's tax rates it used, so fixing a rate later doesn't change what a client was already shown"* passes.)
+- **Say what is good**, and mark it as not-to-break.
+- **Two explicitly titled sections for future ideas** (§7a): *"Could add later — deliberately not doing now"* and *"Not worth adding"*, one line and one reason each.
+- **Name the commit** the audit was based on in the header, with the review dates — findings are a snapshot (§2a).
+- **Close with what you did not verify**, and what would verify it.
+
+Ask, then write `FINDINGS.md` at the repo root. If it exists, update in place and preserve anything the user edited. **Never commit it.** The quality bar, and the structure section by section, is in `references/plain-english-writeup.md`.
+
+## 9. The verdict — rebuild or fix in place
+**Fix in place is the default. A rebuild has to be argued for.** State it plainly, to the user and to yourself: **rebuilding the whole architecture of an app is a large, risky job and is the wrong answer for most codebases.** It suits small apps with little irreplaceable logic — a tiny static-HTML app is a fair rebuild candidate; almost nothing else is. Warn yourself against over-recommending one: users in distress ask for a rewrite, and agreeing is the easy move, not the right one. A long defect list is *not* evidence for a rebuild.
+
+### The gate — ask this before the table, because it can veto a rebuild on its own
+**Does the app have real users or paying customers?**
+
+- **If yes → fix in place is strongly preferred, regardless of how bad the code is.** A rebuild means a migration, a cutover, and a period where both versions exist — risk a live business may not be able to absorb.
+- **If a rebuild is genuinely unavoidable *with* live users**, it needs a **parallel-running plan**: the old app stays live, the new one is built alongside it, with an explicit cutover and a rollback. The user must understand and accept that before work starts.
+- **Say the trap out loud:** that usually means a second repo or a long-lived branch, and **multiple versions of an app across repos gets confusing fast**. **Default to a branch in the same repo**; use a separate repo only if the stack changes so completely that one repo cannot hold both.
+- "No users yet" does not argue *for* a rebuild. It only removes the veto and lets the table decide.
+
+| Signal | Points to REBUILD | Points to FIX IN PLACE |
+|---|---|---|
+| **Can the current architecture host what the app needs to do?** | No — what is missing is structural (no server, no accounts, nowhere to put the data) and cannot be added where it is | Yes — what is missing can be added inside what already exists |
+| **How much irreplaceable domain logic is there?** | Small and isolatable — you can lift it out cleanly and carry it across | Large or diffuse — the valuable knowledge is spread through the whole app and cannot be lifted |
+| **How big is the total surface area?** | Small — few pages, routes and screens; rewriting is a known quantity | Large — many routes, migrations, integrations; a rewrite is an open-ended bet |
+| **Do tests or CI exist to protect a refactor?** | Irrelevant — you are replacing the code, not refactoring it | Helps a lot — a suite that catches regressions makes fixing in place safe and cheap |
+
+Read it whole, not as a score. **Rebuild needs the gate to be clear *and* the first row to say "No".** If the architecture can host what's needed, fix in place regardless of how ugly the code is — ugly is not the same as wrong-shaped.
+
+Worked both ways from the real case: a static-HTML app with no backend in the repo, no accounts, records in one browser, no live customers yet, ~8,800 lines total and only ~470 lines of irreplaceable domain logic → **rebuild** (and port those 470 lines deliberately). A Next.js app with real authentication, 133 migrations, ~142 authorization policies and hundreds of routes, with serious security problems → **fix in place, never rebuild**, because every one of those problems is fixable where it stands.
+
+Deliver: the recommendation, **the answer to the gate**, the two or three signals that decided it, the honest cost of following it, and on a rebuild **which parts get ported rather than rewritten** plus the parallel-running and rollback plan if the app is live. Also name the highest-value work that is worth doing *either way* — in the real case, backing up the backend that was not in version control and writing the first test suite, neither of which needed the rebuild.
+
+## 10. Hand off to the map
+Call **`cs-build-import-codebase`**, passing the findings, the verdict, and **which rung of the ladder the existing map landed on** (§0a). It builds the **corrected target map** — what the app *should* look like — on either verdict, and it keeps or repairs an existing map rather than duplicating it. Do not build the map here; one code path builds maps.
+
+## 11. Create the Kanban tasks
+Task writing happens **inside `cs-build-import-codebase` §7**, because that is where the feature ids exist — don't re-implement it here. Your job is to hand it a clean input and check the result.
+
+Hand over, per finding: the **bucket-1 findings only**, each with its severity (Critical → `urgent`, High → `high`, Medium → `medium`, Low → `low`), its evidence label, its file reference, and which core feature it belongs to. Bucket 2 and bucket 3 stay in the write-up and **must not appear in the task list**.
+
+Then confirm the shape is right for the verdict:
+- **Rebuild** → build-to-spec tasks **plus a distinct set of "mistakes to avoid" tasks** carrying forward the specific defects found, so they are not reintroduced. That second set is the whole reason for auditing first — if it is missing, the handoff failed.
+- **Fix in place** → one task per defect, where it lives, **with the file reference in the description** (the user-facing text has none; the task needs it because an agent has to act on it).
+
+An **UNVERIFIED** finding becomes an investigation task that keeps its label — never a confident fix task.
+
+## 12. Verify, then report
+**Run the check, don't eyeball it** (`auditing-and-fixing.md` §9):
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-verify
+node ../codespring/scripts/check-map.mjs   /tmp/cs-verify --expect-core <the count you intended>
+```
+
+It asserts the core-feature count, no flattened sub-features, no duplicate features or PRDs, one note per core feature, and every task linked to a feature with a severity. A non-zero exit is a real failure — fix it before reporting. Then report the diff plainly — created N, updated N, skipped N — and give the project link `https://v2.codespring.app/project/<projectId>`.
+
+## What good looks like
+- The app was actually run, and at least one finding exists that reading the code could not have produced.
+- Every finding cites a `file:line` or a command and is labelled CONFIRMED / INFERRED / UNVERIFIED; the headline numbers were independently reproduced.
+- **Your own headline claims were listed with their evidence before you wrote them**, every measurement states its scope, and no claim is stronger than what a sub-agent actually found.
+- The clone was compared to the remote **before** auditing, the commit the findings are based on is named, and the user was asked who else is in the repo and whether the app is finished.
+- The git/CI/deploy setup was audited, and the user knows whether their backend is backed up and whether anything gates their deploys.
+- The user-facing findings are plain, ranked by what they cost, contain no file paths, and say what is good as clearly as what is broken — including what a "better than the competitor" feature still does not do.
+- Problems, could-add-later and not-worth-adding are separated; the task list contains only problems, and the future ideas are in the two named `FINDINGS.md` sections.
+- The users gate was asked and answered, a verdict was given with its reasons, and "fix in place" was the answer unless the app has no users *and* the architecture genuinely couldn't host what's needed.
+- Nothing in CodeSpring was duplicated — an existing map was kept, or repaired in place, and a second project was only ever created with explicit confirmation.

--- a/.agents/skills/cs-build-audit-codebase/references/plain-english-writeup.md
+++ b/.agents/skills/cs-build-audit-codebase/references/plain-english-writeup.md
@@ -1,0 +1,117 @@
+# The plain-English write-up — structure, voice, and the quality bar
+
+An audit produces two different documents. Do not mix them up.
+
+| | Internal notes | `FINDINGS.md` (the deliverable) |
+|---|---|---|
+| Audience | you, and the agents that will do the work | the app's owner — often not a developer |
+| Language | technical | plain English, roughly third-grade reading level |
+| References | `file:line`, commands, evidence labels | **none** — no file paths, no line numbers, no function names |
+| Ordering | by domain | by real-world consequence |
+| Lives | scratchpad | committed into the audited repo as `FINDINGS.md` |
+
+The internal notes feed the tasks. `FINDINGS.md` is what the owner reads and decides with.
+
+**Every named specific below is a labelled worked example** from the audit this structure was generalised from — a rate table, a report, a suburb figure. They are there to show the *shape* of a good sentence. Nothing here assumes anything about the codebase in front of you, which may be in any language and any domain.
+
+---
+
+## Voice rules for `FINDINGS.md`
+
+1. **Third-grade reading level.** Short sentences. Common words. If a nine-year-old couldn't follow the sentence structure, rewrite it. (The *subject* can be advanced — the *language* cannot.)
+2. **Short bullets.** One idea per bullet. No paragraph longer than three lines.
+3. **One concrete example per problem.** Not "validation is missing" — "typing a full stop instead of a comma turns 800,000 into $800."
+4. **Name the consequence, not the mechanism.** The owner needs to know what it costs them, not where the bug is. Say "the report shows $0 in government charges while still claiming it used official rates", not "the lookup is case-sensitive with no default branch".
+5. **Put a number on it wherever you honestly can** — dollars, a count, a percentage. Numbers are what make an owner act. If you can't size it, say what it damages instead (client trust, a legal obligation, a sale). **State what the number covers in the same sentence** — "45 bytes across 3 keys" measured on one page is not a fact about the whole app (`auditing-and-fixing.md` §3a).
+6. **No file paths, no line numbers, no function or variable names, no jargon.** Hard rule: **every finding must be readable by someone who does not know what a database migration is.** Any term of art is either explained in the same sentence it appears in, or not used.
+
+   This has already failed once in practice. *"Versioned rate tables stamped onto the saved file"* meant nothing to the person it was written for. The plain version says the same thing and is **more** specific:
+
+   > *"When you save a report, also save which year's tax rates it used — so that fixing a rate later doesn't change what a client was already shown."*
+
+   Notice the shape: the action, the thing, then **the consequence of not doing it**. The consequence is what persuades. Run the same test over *idempotent, RLS, IDOR, migration, ORM, schema drift, silent failure path, denormalised* — explain inline or find the plain sentence.
+7. **Rank by consequence, hardest-hitting first** — inside every section and across the whole document. The reader should be able to stop after section 2 and still have the important part.
+8. **Say what is good — with its boundary.** A write-up that only lists faults is neither trustworthy nor useful. Where something is genuinely well done — a verified data set, a correct security check, a decision better than the competitor's — say so in the same plain voice, and mark it as something not to break.
+
+   **When you claim the app does something better, say what it does NOT do in the same breath.** This has already failed once. *Worked example: the app was called "ahead" of the incumbent product on one calculation when it had in fact solved only the easy half of it — the single-record case, not the case of combining records across a portfolio, which was the exact part the incumbent had said was too hard.* The owner will repeat "we're ahead on this" to a customer, so the boundary has to travel with the claim.
+9. **Be explicit about what you did not verify.** Give it a closing section. It protects the owner and it protects you.
+10. **Distinguish "wrong today" from "wrong later".** *"This is wrong today, not wrong next year"* is the most action-forcing sentence available — use it only when it is true.
+
+---
+
+## Structure
+
+Open with a two-line header: what this document is, what it is based on, and the dates. **Name the commit** — findings are a snapshot, and on a repo someone else is still working in that matters.
+
+> Plain-English record of what the app gets wrong, what it can't do, and what needs to change.
+> No code. Real-world implications only.
+> Reviewed *dates*, against commit *short SHA* on *branch*. Based on the live app, the code, the database, and *any other sources*.
+
+Then the sections below. Drop any that don't apply — do not pad.
+
+**1. The most important thing to understand.**
+One structural truth that reframes everything else, then a short "that means:" list. This is the section that changes the owner's mind. In the real audit it was: almost nothing comes from a database — every figure is calculated in the browser from typed-in values, and the rate tables are typed into the web page itself.
+
+**2. Where it's wrong — in order of how much it matters.**
+The core of the document. One `###` sub-heading per defect, written as a plain statement of the problem *with its size in it* ("Capital gains tax is understated by about $337,000"). Two to five bullets under each: what it does, when it happens, what it costs. Hardest-hitting first.
+
+**3. Numbers that look precise but are actually fixed assumptions.**
+Anything the app presents as a computed fact that is really a choice someone made. Open with the framing sentence: *these are not calculated from anything; someone chose them, and the user cannot see or change them.* One bullet each, with the value and its effect.
+
+**4. Data that isn't really data.**
+Anything typed in by hand, stale, defaulted to zero on failure, or asserted without verification. Say plainly what a missing value and a failure look like to the user (identical, usually). If an integration is expected to fix this, **set the expectation honestly** — in the real case, connecting the data provider would stop the typing but would not change a single calculated figure, and saying so up front prevented a wasted project.
+
+**5. Why it behaves inconsistently.**
+The "why do some outputs look different from others" section. Users notice inconsistency before they notice errors, and the answer is often "nothing is broken, the setting is just invisible". Worth its own section because it converts a suspicion into a fact.
+
+**6. Where the work actually lives.**
+Storage, durability, sharing. What survives a refresh, a new browser, a new machine, two colleagues. What is lost permanently, with no backup, and with no warning that it was ever a risk.
+
+**7. Compared to what it's replacing.** *(only if there is an incumbent or named competitor)*
+Three lists, in this order: **where this app is already better** (put it first — it is true, and it earns the rest of the document a fair hearing), **what the other product has that this one doesn't**, and **differences worth deciding deliberately** rather than calling bugs.
+
+**8. What it cannot do at all.**
+Not bugs — gaps. The things a customer or a competitor will raise. Rank by how likely they are to come up in a real conversation.
+
+**8a. Could add later — deliberately not doing now.** *(bucket 2, `auditing-and-fixing.md` §4a)*
+Real gaps that are consciously parked. Title the section in those words so it is unmistakable, and say the posture out loud once: *the job right now is making what already works work properly, not adding to it.* One line each, with the reason it is parked and whether it is worth doing later. Nothing in this section becomes a task.
+
+**8b. Not worth adding.** *(bucket 3)*
+One line each, **with the reason**, so the question stops coming up. A "not worth it" without a why gets asked again next month. Real example: *don't build an integration to fetch tax rates automatically — no free authoritative feed exists, and scraping eight government websites would be more fragile than a maintained table plus a yearly review.*
+
+> **These two sections are the only home a future idea has.** CodeSpring has features, notes, PRDs and Kanban tasks and no "ideas" surface, and a parked idea must never be written as a task because **a task list implies committed work**. So they live here, in the repo, titled exactly as above. Flag it to the user as a known product gap.
+
+**9. What needs to change — the principle, not the code.**
+The fix direction, as principles a non-developer can hold in their head and check work against. `###` per principle. In the real audit: reference data moves out of the app and into dated records; reading it must not happen on every output; there must be a visible staleness check; a published document must be frozen; there is no free API for this so it is a maintained table plus an annual review; assumptions should become fields.
+
+**10. Not yet verified.**
+Everything you could not confirm, and what would confirm it. Short. Honest.
+
+---
+
+## Where the verdict goes
+
+The rebuild-or-fix verdict does **not** go in `FINDINGS.md` — that document is about the app, not about the plan. Deliver the verdict in the conversation, and if the user wants it written down, as a separate plan document. Keeping them apart means the owner can circulate the write-up without circulating a recommendation they haven't agreed to yet.
+
+Spoken, the verdict is four things: the recommendation, the two or three signals that decided it (from the decision table in `auditing-and-fixing.md`), the honest cost of following it, and — on a rebuild — exactly which parts get carried across rather than rewritten.
+
+---
+
+## Writing it out
+
+- `FINDINGS.md` at the audited repo's root is the **one** file this skill may add to the target repo. Say so before you write it, and ask.
+- **Never commit it.** Leave it as an untracked change for the user to review.
+- If it already exists, read it first and **update in place**: keep any section the user has edited, fold in what's new, add the new review date to the header. Never silently discard their words.
+- Keep it a single file. A pack the owner has to navigate is a pack the owner won't read.
+
+## The quality bar
+
+Measured against the audit this structure was generalised from, a `FINDINGS.md` is good when:
+
+- **Every problem is sized** — in money where money applies, otherwise in a count, a percentage, or the specific trust it costs.
+- **The good parts are stated as clearly as the faults**, each with the boundary of what it does *not* do.
+- **Expectations are set honestly** where the owner is about to spend money on the wrong fix. In the real case, one paragraph explaining that connecting a paid data provider would stop the manual typing but would not change a single calculated figure prevented a wasted project. That paragraph was worth more than any single defect.
+- **There is not one file path, line number or function name in the whole document** — and no term of art that isn't explained where it appears.
+- **A non-technical owner can read it top to bottom and act on it**, and can circulate it without a translation layer.
+
+Test it before you hand it over: read the first three sections as if you had never seen the code. If any sentence needs you to know what a database migration is, rewrite it.

--- a/.agents/skills/cs-build-audit-codebase/references/specialist-briefs.md
+++ b/.agents/skills/cs-build-audit-codebase/references/specialist-briefs.md
@@ -1,0 +1,106 @@
+# Specialist Sub-Agent Briefs
+
+Copy-ready briefs for the parallel audit fan-out. Every brief is **self-contained** — the sub-agent gets the target path, the rules, and its own domain, and nothing from the other agents. Independence is the point: two agents reaching the same conclusion by different routes is the strongest evidence you can get, and that only works if they never saw each other's output.
+
+## The shared preamble — prepend to EVERY brief
+
+> **Target:** `<absolute repo path>` · **Live app:** `<url the orchestrator started, or "not running">`
+> **Stack (already established, do not re-derive):** `<one paragraph — languages, frameworks, build, hosting, backend, database>`
+> **Scratchpad for your output:** `<absolute path>/findings-<domain>.md`
+>
+> **Rules:**
+> - **READ-ONLY on the repo.** Do not create, edit, move or delete any file under the target path. Write only to your scratchpad file.
+> - Cite everything. Every finding carries a `file:line` reference **or** the exact command you ran and its output.
+> - Label every finding **CONFIRMED** (you executed it or read the exact line — say which), **INFERRED** (deduced from code you read but did not run — state the inference), or **UNVERIFIED** (suspected, not checked — state what would check it). A finding with no label is not a finding.
+> - **Report honestly.** If you cannot verify something, say so. Never present a guess as fact. Do not inflate severity to seem useful, and do not soften a real problem.
+> - **Report the positives too.** "No privileged key was ever committed", "the input sanitiser is genuinely correct", "these controls are all correctly wired" are high-value findings. Include a "what works well — don't break it" section.
+> - Rank findings **Critical → High → Medium → Low** by real-world consequence (money, legal/regulatory exposure, or loss of customer trust), not by how interesting the bug is.
+> - Structure: executive summary (5–8 bullets, the headline first) → evidence tables → numbered findings → what works well.
+> - Live probing of the user's own running app and own services is authorised where stated in your brief, and must be **non-destructive**: no deletes, no updates, no bulk data extraction. If you must prove write access, one clearly-labelled test row, and report exactly what you inserted and where.
+
+## 1. Security / auth / trust boundary
+
+> Audit the trust boundary between whatever ships to the user and whatever runs on a server.
+> 1. **Enumerate the API surface** — every endpoint/action/route the client can call: what it sends, what it returns, what the server checks. One row per call.
+> 2. **Test authentication for real.** Strip the credential and call anyway. Does it 401 at the gateway, or does it run? Is identity a verified session/token, or an opaque identifier the client supplies?
+> 3. **Test authorization per action** — separately for reads and writes. Can a caller act on a record they do not own? Does a write with a bogus identifier return success? Does the server scope results, or does the client filter after receiving everything?
+> 4. **Secrets** — what is embedded in shipped code, and what does it actually grant? Scan history for privileged keys. State the negative result explicitly if there is one.
+> 5. **Row-level / database-level protection** — is it on and effective? Prove it (a table with data that reads empty through the public path proves the policy works; an empty result alone proves nothing).
+> 6. **Third-party code** — scripts loaded from a CDN, pinned versions, integrity hashes, what those pages have access to.
+> 7. **Response headers**, error verbosity (do errors leak internal names?), rate limiting, payment/entitlement paths.
+> 8. For each finding: what an attacker gets, what it would take, and the fix.
+
+## 2. Database / schema / data layer
+
+> Audit how data is stored and reached.
+> 1. **Trace the full data path** from user action to storage. Name every hop.
+> 2. **Inventory the schema** — every table/collection/store, key columns, enums, relationships. Mark each **CONFIRMED (named in code)**, **CONFIRMED (observed live)** or **INFERRED**.
+> 3. **Ownership** — which tables does *this* app own, which are shared with another system, which are read-only for it. A shared naming prefix does not prove shared ownership; check the actual call sites both ways.
+> 4. **Schema management** — are there migrations? In version control? Can the schema be rebuilt from the repo? Is there a local/staging database, or does every change hit production?
+> 5. **Is the server-side source in the repo at all?** If the backend lives only in a hosting dashboard, that is a critical finding — say what would be lost and give the exact commands to back it up.
+> 6. **Orphans and unknowns** — what is unused, and what you *cannot* determine from where you sit (say so, and give the query that would answer it).
+> 7. **Typing** — does the client guess field names? Fallback chains for a single field are a symptom; count them.
+> 8. Output a concrete capture-and-migrate sequence the user can run.
+
+## 3. Core business logic
+
+> Audit the part of this app that produces its actual output — the calculation, the pipeline, the ranking, the decision, whatever the product is *for*. This is usually where the money is.
+> 1. **Establish ground truth by executing the real code**, not by reading it. Extract the logic into a scratch harness and run it, or drive it in the live app. Prove your harness is faithful (identical source, only the environment stubbed) and say how. Where two independent methods agree, state that.
+> 2. **Verify the outputs against authoritative external sources** where the domain has any — published rates, specifications, official documentation. Report which ones you checked and which you could not.
+> 3. **Walk one complete output end to end**, showing every intermediate figure, so a human can check it by hand.
+> 4. **Edge and degenerate inputs**: empty, zero, negative, absurdly large, wrong case, wrong type, wrong format, whitespace. For each: correct result, wrong result, exception, or **silent wrong result** — the last is the worst and the most important to find.
+> 5. **Hunt hardcoded reference data** — anything with an expiry date typed as a literal. Table it: what, where, duplicated where, what happens when it goes stale, and whether the output *claims* to be current.
+> 6. **Hunt drift** — is this logic duplicated? Do the copies agree *today*? Did they ever disagree (check history)? Which copy does the main entry point actually load?
+> 7. **Separate genuine errors from undisclosed assumptions.** A number that is a guess presented as precise is a finding even when the arithmetic is perfect.
+> 8. **Size every error in the units the user cares about** — dollars, percentage points, hours.
+
+## 4. Frontend / UX / dead controls
+
+> Audit what the user actually experiences. Test live where possible, not just statically.
+> 1. **Dead controls** — every interactive element: is it wired, does its handler exist, does it do anything? Report the negative loudly if wiring is good ("not one inert button in 194 controls" is a real finding).
+> 2. **Orphan pages/screens** — reachable by URL, linked from nowhere. And the reverse: dead ends with no way out.
+> 3. **Validation** — count required fields, bounds, patterns. Test what a wrong format does (a decimal separator read as a thousands separator silently divides by a thousand). Are negatives and absurd values accepted and printed confidently?
+> 4. **Persistence** — which screens save work and which lose it on refresh? Is there an unsaved-changes guard? Does anything reload placeholder/demo content over real work?
+> 5. **Failure and empty states** — what does the user see when a request fails? Is a failure distinguishable from an empty result? Does anything **fabricate plausible content** on failure? Does anything report success without checking?
+> 6. **Destructive actions** without confirm or undo.
+> 7. **Accessibility** — accessible names on controls, label association, live regions for content that updates, keyboard reachability, focus visibility, colour contrast (compute it, per theme).
+> 8. **Mobile and print** — the output the customer is actually handed. Check the printed/exported artefact specifically; it is often styled differently from the screen.
+
+## 5. Architecture / quality / scalability
+
+> Audit structure, maintainability and limits. Be balanced — say plainly where the current design is a *reasonable* choice for the app's size, and do not recommend a rewrite by reflex.
+> 1. **Measure it**: total lines, files, largest file, dependency count, build step, test count.
+> 2. **Duplication register** — one row per duplicated thing: what, how many copies, where, drifted (today? historically? check history), which copy is authoritative, which copy is actually loaded.
+> 3. **Test / lint / CI** — what exists. If nothing, say what the cheapest suite that would have caught the worst bug you found looks like.
+> 4. **Delivery** — branch structure, review practice, whether deploy is gated on any automated check, whether the local clone is current with the remote, staging vs production, environment-variable mechanism.
+> 5. **Error handling and observability** — count swallowed errors, count log/report calls, is there any global handler. If it breaks in production, does anyone find out?
+> 6. **Measured performance limits** — payload size, largest assets versus their rendered size, work per interaction, caching, anything unbounded (a list with no pagination, a loop that never stops).
+> 7. **Supply chain** — external origins, third-party scripts, integrity, privacy implications.
+> 8. **A recommended path forward in three buckets:** this week / this month / **explicitly not doing** — and justify the "not doing" list.
+
+## 6. Repository & delivery setup (do this yourself, it is fast)
+
+Not a sub-agent brief — the orchestrator runs these directly, **before** the fan-out, because the answers caveat everything else.
+
+```bash
+git -C <repo> rev-parse --abbrev-ref HEAD          # current branch
+git -C <repo> rev-parse HEAD                       # local head
+git -C <repo> ls-remote --heads origin             # remote heads → is the clone behind?
+git -C <repo> log --oneline -30                    # commit quality, intent-revealing messages?
+git -C <repo> branch -a                            # branch structure, stale branches
+ls -a <repo>/.github/workflows 2>/dev/null         # any CI at all?
+cat <repo>/.gitignore                              # is it adequate before anyone commits secrets?
+git -C <repo> log -p -S 'BEGIN PRIVATE KEY' --oneline | head
+git -C <repo> log -p -S 'service_role' --oneline | head     # adapt markers to the stack
+gh pr list --state all --limit 30                  # review practice (if gh is available)
+```
+
+Answer, in the report: is the clone current with the remote (if not, **caveat the whole audit**); is the server-side source in the repo; is deploy gated on any check or does merge ship to production; were secrets ever committed; is there a staging environment.
+
+## Fan-out mechanics
+
+- Launch all specialists **in one message, concurrently**. They are independent.
+- Give each one only its own brief plus the shared preamble. No cross-talk.
+- While they run, do the live pass yourself (§Run the app in `auditing-and-fixing.md`) — you are the sixth agent and the one who resolves disagreements.
+- Add domains the app warrants: a competitor/incumbent comparison (invaluable when the app replaces a known product), a user-journey-and-failure map, a data-provenance pass ("which figures are real, which are typed in, which are assumptions"). Give each the same preamble.
+- When they return: reconcile contradictions, independently reproduce the headline claims, and only then write the report. A later, better-informed pass beats an earlier one — record the correction rather than shipping both.

--- a/.agents/skills/cs-build-audit-codebase/scripts/check-repo.sh
+++ b/.agents/skills/cs-build-audit-codebase/scripts/check-repo.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# check-repo.sh — is this clone the code you think you are auditing?
+#
+# Run this FIRST, before the fan-out. Every answer below caveats every finding.
+# Read-only: `git fetch` updates remote-tracking refs only — it does not touch the
+# working tree, any branch, or any file. Nothing here writes to the repo.
+#
+# Usage:
+#   bash check-repo.sh [--repo /path/to/repo] [--paths file1 file2 ...]
+#
+#   --paths  files or directories you suspect are out of scope. For each one it
+#            prints first commit, last commit and commit count, so "unreferenced"
+#            can be told apart from "unfinished" (see the rule in
+#            codespring/references/auditing-and-fixing.md §3a).
+#
+# Exit codes: 0 = clone is current · 2 = clone is behind the remote · 1 = not a git repo
+
+set -u
+
+REPO="$PWD"
+PATHS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) REPO="${2:-}"; shift 2 ;;
+    --paths) shift; while [ $# -gt 0 ] && [ "${1#--}" = "$1" ]; do PATHS+=("$1"); shift; done ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  echo "NOT A GIT REPO: $REPO"
+  echo "There is no version history at all. Say so plainly — it is a finding in its own right:"
+  echo "  nothing can be rolled back, and no change can be traced to a reason."
+  exit 1
+}
+
+BRANCH="$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+HEAD_FULL="$(git -C "$REPO" rev-parse HEAD)"
+HEAD_SHORT="$(git -C "$REPO" rev-parse --short HEAD)"
+
+echo "=== The commit these findings apply to (record this in FINDINGS.md) ==="
+echo "branch: $BRANCH"
+echo "commit: $HEAD_SHORT ($HEAD_FULL)"
+git -C "$REPO" log -1 --format='date:   %ad%nauthor: %an%nsubject:%s' --date=iso
+
+echo
+echo "=== Is this clone current with the remote? ==="
+if git -C "$REPO" remote | grep -q .; then
+  git -C "$REPO" fetch --all --quiet 2>/dev/null || echo "(fetch failed — no network, or no access to the remote)"
+  UPSTREAM="$(git -C "$REPO" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+  if [ -n "${UPSTREAM:-}" ]; then
+    COUNTS="$(git -C "$REPO" rev-list --left-right --count "HEAD...$UPSTREAM" 2>/dev/null || echo "0	0")"
+    AHEAD="$(printf '%s' "$COUNTS" | cut -f1)"
+    BEHIND="$(printf '%s' "$COUNTS" | cut -f2)"
+    echo "upstream: $UPSTREAM — $AHEAD ahead, $BEHIND behind"
+    if [ "${BEHIND:-0}" -gt 0 ]; then
+      echo
+      echo "*** BEHIND BY $BEHIND COMMIT(S). Tell the owner in one line and offer to update BEFORE auditing."
+      echo "*** Auditing a stale clone produces findings that may already be fixed."
+      echo "Commits you do not have yet, and the files they touch:"
+      git -C "$REPO" log --oneline --name-only "HEAD..$UPSTREAM" | head -60
+    else
+      echo "up to date with $UPSTREAM"
+    fi
+  else
+    echo "no upstream set for $BRANCH — cannot tell whether it is behind. Compare against origin's default branch by hand."
+  fi
+else
+  echo "no remote configured — this code exists only on this machine. That is a finding: there is no off-machine copy."
+fi
+
+echo
+echo "=== What else is in flight? (do not write findings against superseded work) ==="
+echo "remote branches:"
+git -C "$REPO" for-each-ref --sort=-committerdate --format='  %(refname:short)  %(committerdate:short)  %(authorname)  %(contents:subject)' refs/remotes 2>/dev/null | head -30
+echo "recent authors (last 50 commits):"
+git -C "$REPO" log -50 --format='%an' | sort | uniq -c | sort -rn
+echo
+echo "Ask the owner: is anyone else working in this repo right now?"
+echo "If yes: the findings are a snapshot at $HEAD_SHORT, recommend a dedicated branch for the fixes,"
+echo "and say plainly that merge conflicts will need managing. Do not lecture them about git."
+
+echo
+echo "=== Working tree ==="
+if [ -n "$(git -C "$REPO" status --porcelain)" ]; then
+  echo "DIRTY — uncommitted work is present, so the audited state is not any commit:"
+  git -C "$REPO" status --short | head -20
+else
+  echo "clean"
+fi
+
+echo
+echo "=== Delivery: is anything gated? ==="
+if [ -d "$REPO/.github/workflows" ]; then
+  ls -1 "$REPO/.github/workflows"
+else
+  echo "no .github/workflows — no automated check, so merging ships straight to production unless the host gates it"
+fi
+
+if [ "${#PATHS[@]}" -gt 0 ]; then
+  echo
+  echo "=== Suspected out-of-scope paths: unreferenced, or just unfinished? ==="
+  echo "A file untouched since the initial import while its siblings change weekly is"
+  echo "a strong signal of \"not finished yet\", NOT \"not part of this product\"."
+  echo "Repo activity window, for comparison:"
+  git -C "$REPO" log -1 --format='  newest commit: %ad' --date=short
+  git -C "$REPO" log --reverse -1 --format='  oldest commit: %ad' --date=short
+  for p in "${PATHS[@]}"; do
+    echo
+    echo "--- $p"
+    COUNT="$(git -C "$REPO" log --oneline -- "$p" | wc -l | tr -d ' ')"
+    echo "  commits touching it: $COUNT"
+    git -C "$REPO" log -1 --format='  last:  %ad  %s' --date=short -- "$p"
+    git -C "$REPO" log --reverse --format='  first: %ad  %s' --date=short -- "$p" | head -1
+  done
+  echo
+  echo "Then ASK THE OWNER before concluding anything is out of scope."
+fi
+
+if [ -n "${BEHIND:-}" ] && [ "${BEHIND:-0}" -gt 0 ]; then exit 2; fi
+exit 0

--- a/.agents/skills/cs-build-create-prd/SKILL.md
+++ b/.agents/skills/cs-build-create-prd/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: cs-build-create-prd
+description: >
+  Specialist for creating CodeSpring PRDs. Interactive — it lists the user's
+  core features, asks which one and whether to generate a Frontend, Backend, or
+  Both PRD, then deep-dives the real code and generates the PRD(s) and attaches
+  them to the feature's bridge on the canvas. The PRDs capture the shared
+  backend contracts and design system so new features are built without
+  duplicating or breaking what exists. Use when the user wants a PRD / spec for
+  a feature. Triggers, "create a PRD", "make a frontend PRD", "make a backend
+  PRD", "generate PRDs for this feature", "document this feature in CodeSpring",
+  "spec out X so I can design new features".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(node:*) Bash(curl:*)
+metadata:
+  author: codespring
+  version: "0.2"
+---
+
+# Create a PRD in CodeSpring
+
+A PRD gives CodeSpring a full, accurate understanding of a feature so new features build on what exists instead of duplicating backend, re-creating a shared API route, or reinventing the design system. This skill makes the **Frontend** and/or **Backend** PRD for a chosen feature, grounded in the real code.
+
+This is the single source of truth for how PRDs get made — other skills (e.g. `cs-build-import-codebase`) call this rather than re-implementing it.
+
+Shared knowledge is in the `codespring` skill's references: `references/analyze-codebase.md`, `references/mindmap-structure.md`, `references/prd-management.md`, `references/pitfalls.md`, `references/codespring-docs.md`.
+
+## 0. Connect first
+`codespring auth status` (login if needed) + `codespring status`. Use the projectId from the **local** `.codespring/config.json`; print it. If the codebase isn't in CodeSpring yet, run `cs-build-import-codebase` first. This skill READS code and WRITES only to CodeSpring — never modify the codebase.
+
+## 1. Ask what to generate (interactive)
+Show the user their **core features** (from `codespring features` / the mindmap `node-features` items), then ask:
+1. **Which feature?** (one, several, or all)
+2. **Frontend, Backend, or Both?**
+Wait for their choice unless they already said.
+
+## 2. Deep-dive the real code
+Read the actual code for the feature (don't guess). Pull in the depth from `analyze-codebase.md` §8–9. Cover:
+
+### Backend PRD — capture the shared contracts (this is the riskiest part when adding new features)
+- **Architecture & structure** — how the feature's code is organized and the conventions it follows.
+- **Routers / API routes / endpoints** — path, method, request/response, and **flag every route shared by more than one feature**.
+- **Data model** — tables + enums, key columns, relationships; reads vs writes.
+- **Reusable server code** — actions/services/queries/hooks that already exist and should be reused, not re-implemented.
+- **Shared backend systems** — call these out explicitly because new features collide with them:
+  - hosting / deploy target (AWS, Vercel, Fly, etc.) and any platform limits
+  - crediting / usage-metering systems; payment, subscription, and **refund** systems
+  - background **jobs / pipelines / queues / cron**; long-running or async generation jobs
+  - storage: **S3 conventions / buckets**, file paths, signed-URL patterns
+  - media/render pipelines (e.g. Remotion/video compositions) if present
+  - databases, migrations
+  - **auth and row-level security (RLS)**
+  - **environment variable names** that must be used or can be reused
+  - webhooks (and signature verification)
+- **Security** — authz, ownership checks, validation, secrets, RLS, webhook signing.
+- **Reuse & dependency map** — a "reuse this, don't rebuild it" list, PLUS **what depends on this** so a future change doesn't silently break other features.
+
+### Frontend PRD — capture the design system AND the navigation
+- **Design tokens** — colors/branding, corner radius, spacing scale, typography, shadows (from Tailwind config / CSS vars / theme).
+- **Component & UI styles** — the UI library and how buttons/cards/inputs/modals are styled, incl. states.
+- **Layout, positioning & spacing** — grid/flex, columns, breakpoints, gaps; where things sit relative to each other. Be concrete.
+- **What the user sees** — header, sections, cards, tables, empty/loading states, toasts.
+- **Navigation / interaction map** — the concrete path: which nav item/button opens it → route → what it shows → what each interaction does; plus links FROM/TO other features.
+
+### Write it into the feature's note first (it is the generator's context)
+```bash
+codespring mindmap note <coreFeatureId> --title "How it works — <Feature>" --text "$(cat note.txt)"   # redirect output to /dev/null
+```
+
+## 3. Generate (see prd-management.md)
+```
+POST /prds/generate  { projectId, bridgeNodeId: "bridge-feature-<featureId>", prdType: "frontend" | "backend" }
+```
+Timeout ≥120s (a client abort still creates the record → duplicates). For "Both", make two calls. After generation, read the PRD back (`codespring prd <id>`) and confirm the shared-systems detail above actually landed; if thin, enrich the note and regenerate, or `prd sync` a better version.
+
+## 4. Attach to the canvas (see mindmap-structure.md)
+Add `prdBridge → prdFrontend/prdBackend` nodes and `PUT /mindmaps/project/<projectId>`. For a **core** feature `prdBridge.data.featureId = "node-features"`; for a **sub-feature** it's that feature's sub-feature group node id. `itemId` = the selected feature id. If a `prdBridge` already exists for the feature, add the PRD node to it instead of creating a second bridge.
+
+> The user can also generate PRDs in the CodeSpring web app (right-click the feature's PRD bridge → add + generate). If they'd rather do that, point them at `references/codespring-docs.md`.
+
+## 5. Dedupe if needed + verify
+Duplicates from timeouts → checkpoint then delete extras (`prd-management.md`). Verify (`pitfalls.md`): PRD content is real and includes the shared-systems detail; the canvas shows the `prdBridge` + PRD node(s) with valid `prdId`; and `node-features` still has the right core-feature count (re-parent any flattened sub-features). Give the user their project link.
+
+## What good looks like
+- The Backend PRD reads like a contract for the shared systems: routes (with the shared ones flagged), data model, auth/RLS, jobs/cron, storage/buckets, payments/credits/refunds, env vars, and a clear "reuse this / don't break this" dependency map.
+- The Frontend PRD captures the design system and the concrete navigation path.
+- Both are attached to the feature's bridge and grounded in the real code.

--- a/.agents/skills/cs-build-create-tasks/SKILL.md
+++ b/.agents/skills/cs-build-create-tasks/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: cs-build-create-tasks
+description: >
+  Turn a CodeSpring feature's notes + PRDs into a numbered, prioritized Kanban
+  task list linked to that feature. Reads the feature, its sub-features, its
+  PRDs, and any features that link to it, then writes ordered tasks that are
+  safe to build in parallel — each with what/why/what-it-touches/what-not-to-
+  touch/dependencies. Use when the user has a feature planned and wants a build
+  plan. Triggers, "create tasks", "make a task list", "break this feature into
+  tasks", "generate a build plan", "turn my PRD into tasks", "what do I build
+  first".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*)
+metadata:
+  author: codespring
+  version: "0.2"
+---
+
+# Create a task list for a feature
+
+Turn a feature's plan into a numbered Kanban task list that an agent (or a fleet of sub-agents) can build safely. See the `codespring` skill's `references/task-workflow.md`, `references/prd-management.md`, `references/pitfalls.md`.
+
+This skill READS the CodeSpring plan and WRITES tasks. It does not modify the codebase.
+
+## 0. Connect first
+`codespring auth status` + `codespring status` (use the LOCAL project config; print the projectId).
+
+## 1. Pick the feature
+```bash
+codespring features        # core features are the root features
+```
+Ask the user which feature to create tasks for.
+
+## 2. Load the FULL context for that feature
+Before writing any task, gather everything CodeSpring knows so the tasks are safe:
+- The feature's **note** (how it works) and its **Frontend + Backend PRDs** (`codespring prds`, then `codespring prd <id>`).
+- Its **sub-features** (`codespring features --parent <featureId>`).
+- **Other features that link to it** — read the whole mindmap and the notes/PRDs of features referenced by this one (and that reference it). The Backend PRD's shared-systems + dependency map is the key input.
+- If PRDs are missing, stop and tell the user to generate them first (run `cs-build-create-prd`, or generate in the web app — see `references/codespring-docs.md`). Do not invent tasks without the PRDs.
+
+## 3. Work out the numbering
+CodeSpring tasks are numbered like `X.Y.Z` (e.g. `0.1.0`, `0.1.1`). Continue the existing sequence — do not restart at 0:
+```bash
+codespring tasks --json    # or: codespring tasks --status todo / in_progress / on_hold / done
+```
+Scan tasks in ALL states (todo, in_progress, on_hold, done) for this feature, find the **highest number already used**, and start the new tasks at the next increment (e.g. existing max `0.1.2` → new tasks `0.1.3`, `0.1.4`, …). Put the number at the start of each task title.
+
+## 4. Break the work into tasks (ordered + parallelizable)
+Derive tasks from the PRDs. A task = one deliverable a person/agent can finish and verify (not a whole feature). Rules:
+- **Foundations first:** data model / migrations → shared backend/services → API routes → UI that consumes them.
+- **Parallel-safe:** group tasks so independent ones can run at the same time by different sub-agents; sequence only true dependencies. Note which tasks can run concurrently.
+- **Flag shared systems:** any task touching a shared API route, shared table, credits/payments/jobs/storage/auth from the Backend PRD must say so.
+
+For EACH task write a detailed description containing:
+- **What** it builds and **why**.
+- **What it may touch** (files/routes/tables).
+- **What it must NOT touch** (out of scope; protected shared systems).
+- **What already exists to reuse** (from the PRD reuse map) so it isn't rebuilt.
+- **Dependencies / break-risk:** what else depends on the code it changes, so it doesn't silently break another feature.
+
+## 5. Create the tasks — always linked to the feature
+```bash
+codespring task create --title "0.1.3 Add users table + migration" --priority high --feature <featureId> --description "..."
+codespring task create --title "0.1.4 POST /api/login (auth + validation)" --priority high --feature <featureId> --description "..."
+codespring task create --title "0.1.5 Login form UI + client validation" --priority medium --feature <featureId> --description "..."
+```
+- Always pass `--feature <featureId>` so the task is linked to the feature.
+- Sub-features are also features (they have ids); linking a task to a sub-feature via `--feature <subFeatureId>` may work — try it and confirm it attaches correctly, otherwise link to the parent core feature and name the sub-feature in the title.
+- Set priorities (`urgent|high|medium|low`). New tasks land in `todo`.
+
+## 6. Confirm
+```bash
+codespring tasks --status todo --feature <featureId>
+```
+Report the numbered list and the recommended build order (and which can run in parallel). Point the user to the Kanban board in CodeSpring (see `references/codespring-docs.md`). Hand off to `cs-build-feature` to actually build them.
+
+## What good looks like
+- A numbered, prioritized set of tasks in `todo`, linked to the feature, continuing the existing numbering.
+- Foundations sequenced before dependents; independent tasks marked parallel-safe.
+- Every task states what to reuse, what not to touch, and what it could break — so a fleet of agents can build without duplicating or breaking shared systems.

--- a/.agents/skills/cs-build-feature/SKILL.md
+++ b/.agents/skills/cs-build-feature/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: cs-build-feature
+description: >
+  Interactive orchestrator that builds a feature from its CodeSpring plan. It
+  interviews the user about what they're building, checks the feature has enough
+  context (notes + Frontend/Backend PRDs) and a numbered task list, guides them
+  to fill any gaps, then builds the Kanban tasks — optionally spawning up to 5
+  parallel sub-agents — while guarding the shared systems it could break. Use
+  when the user wants to build/implement a feature they planned in CodeSpring.
+  Triggers, "build this feature", "implement my feature", "start building from
+  CodeSpring", "let's build X", "work through my Kanban tasks".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*)
+metadata:
+  author: codespring
+  version: "0.1"
+---
+
+# Build a feature from its CodeSpring plan
+
+A guided, interactive build. Do NOT jump straight to writing code — walk the user through readiness first, then build in a controlled way. This skill both reads the plan and (in the build phase) edits the codebase, so be deliberate.
+
+Uses: `codespring` skill references (`task-workflow.md`, `prd-management.md`, `pitfalls.md`, `codespring-docs.md`), and the sibling skills `cs-build-create-prd` and `cs-build-create-tasks`.
+
+## 0. Connect first
+`codespring auth status` + `codespring status` (LOCAL project; print it).
+
+## 1. Interview — what are we building?
+Ask the user what feature they want to build. Then read what CodeSpring has and reflect it back in **3 simple bullet points**: "Here's what I think we're building — confirm or correct." Keep it plain-language.
+
+## 2. Readiness check — is there enough context?
+For the target feature, verify:
+- A **how-it-works note** exists and is substantive.
+- **Frontend and Backend PRDs** exist (`codespring prds` / `codespring prd <id>`).
+- The Backend PRD actually covers the shared systems (routes, data model, auth/RLS, jobs/cron, storage, payments/credits, env vars) and a dependency map.
+
+If context is missing:
+- Offer to generate PRDs now via **`cs-build-create-prd`**, OR
+- Tell the user to do it in the CodeSpring web app and walk them through it using `references/codespring-docs.md` (open the project → the feature's PRD bridge → add + generate the Frontend/Backend PRD). Then: "Come back and tell me when that's done," and re-check.
+
+## 3. Tasks check — is there a plan to build?
+Check the Kanban for numbered tasks on this feature (`codespring tasks --feature <id>`). If there are none, run **`cs-build-create-tasks`** first. Then point the user to the board: in CodeSpring, top-right toggle **Map / Kanban** → click **Kanban** to see the tasks (see `references/codespring-docs.md`).
+
+## 4. Build mode — ask, don't assume
+Ask the user two things:
+1. **How do you want to build?**
+   - **One task at a time** (more control, review between each), or
+   - **Run for a while** (build a batch autonomously).
+2. If autonomous: **how many parallel sub-agents?** (1–5; cap at 5). Then confirm which tasks each will take.
+
+## 5. Choose the tasks + order
+List the feature's `todo` tasks by number. Recommend which to do first — pick the set that gets to a **testable slice** soonest (foundations/backend before dependent UI). Ask the user which tasks to work on now.
+
+## 6. Break-risk guard (important)
+Ask: **"Are there any existing features you're worried this could break?"** If yes:
+- Add explicit Kanban check tasks (via `cs-build-create-tasks` numbering) to verify those features still work after the build, and
+- Tell every sub-agent, in its brief, not to modify the shared systems those features depend on (from the Backend PRD dependency map) without flagging it.
+
+## 7. Build
+- Move each task to in progress (`codespring task start <id>`), implement it, then `codespring task done <id>`.
+- For parallel builds, spawn up to N sub-agents (max 5). Give each a self-contained brief: its task number + description, the reuse map, the "must not touch" list, and the break-risk guard. Assign independent (parallel-safe) tasks to different agents; keep dependent tasks sequential.
+- Report progress against task numbers so the user can watch the board move.
+
+## 8. Wrap up
+Summarize what was built, which tasks are done, and what remains. Recommend running the app / tests to verify the testable slice. Suggest **`cs-build-resync-codebase`** once the feature is finalized, so CodeSpring reflects what was actually built.
+
+## What good looks like
+- The user confirmed a 3-bullet understanding before any code was written.
+- Missing PRDs/tasks were filled (in-app or via the sibling skills) before building.
+- The build ran at the control level the user chose (single-step or up to 5 agents), foundations first, with explicit guards so existing features weren't broken.

--- a/.agents/skills/cs-build-getting-started/SKILL.md
+++ b/.agents/skills/cs-build-getting-started/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: cs-build-getting-started
+description: >
+  The CodeSpring entry point. Connects the agent to the user's CodeSpring
+  account, reports where the project actually is (map? notes? PRDs? tasks?), and
+  names the single next step — audit an app that isn't doing its job, import one
+  that is, plan a new one from scratch, or carry on from wherever the project
+  already got to. Routes on two questions: is there code, and does it do the job
+  (five specific checks, not "do you trust it").
+  Safe to run at any point, not just the beginning. Use when the user is unsure
+  where to begin or what to do next, or right after installing the CodeSpring
+  skills. Triggers, "get started with CodeSpring", "set up CodeSpring", "connect
+  CodeSpring", "I just installed the CodeSpring skills", "what can I do with
+  CodeSpring", "where do I start", "what should I do next".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(node:*) Bash(git:*) Bash(grep:*) Bash(rg:*)
+metadata:
+  author: codespring
+  version: "0.4"
+---
+
+# Getting started with CodeSpring
+
+Connect, say where the project is, name **one** next step. Keep it short — then hand off.
+
+Uses the `codespring` skill's `references/project-state.md` (state detection, the five questions, the three stages), `references/pitfalls.md`, and its `scripts/` (deterministic state detection).
+
+## Step 1 — Connect
+1. **CLI installed?** If `codespring` is missing: `npm i -g @codespring-app/cli`.
+2. **Authenticated?** `codespring auth status`. If not, ask them to run `codespring auth login` and wait. (Running it also refreshes an expired token.)
+3. **Project linked?** `codespring status`.
+   - Linked → note the name and continue.
+   - Not linked → link an existing project (`codespring projects` → `codespring init --project <id> --force`), or create one. **If it must live in a team workspace, they create it in the web app first** — `project create` ignores `--org` and there is no way to move or delete a project from the CLI (`pitfalls.md`).
+   - Always trust the **local** `.codespring/config.json` for which project is active, and print the projectId.
+
+## Step 2 — Say where the project is
+Run the state-detection **scripts** rather than eyeballing the CLI output — the summary must be identical every run. They live in the `codespring` skill, which installs alongside this one, so the path is relative to this skill's folder; resolve it to an absolute path first, because your working directory will be the user's repo.
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state   # read-only snapshot; prints the projectId
+node ../codespring/scripts/state.mjs /tmp/cs-state                # the one-line summary + the counts
+```
+
+Then report it in one line:
+
+> Connected as *workspace*, project *name* — 6 core features, 25 sub-features, 6 notes, 0 PRDs, 0 tasks. Audit: not yet.
+
+That line is the whole point of this skill. It tells the user what they already have, so they stop guessing which skill to run.
+
+## Step 3 — Name the single next step
+Use the branch table in `project-state.md`. **One recommendation, not a menu.** If the project already has a map, notes, PRDs or tasks, the next step comes from that table — don't restart from the beginning.
+
+If the project is empty, there are only two questions: **is there code?** and, if there is, **does it do the job?** The second one is the five-question diagnostic in `project-state.md` — ask it, do not ask "do you trust it":
+
+1. Does the app do what it actually needs to do?
+2. Is it getting things wrong, or presenting made-up or unverifiable figures as fact?
+3. Does the current architecture allow it to do what it needs to do?
+4. Can we build on it scalably?
+5. Can users use it without it breaking?
+
+| Answer | Next step |
+|---|---|
+| **Any of the five is a no** | **`cs-build-audit-codebase`** — diagnose it, get a plain-English list of what's wrong ranked by what it costs, and a rebuild-or-fix verdict (having real users can veto a rebuild on its own). It then builds the map and the tasks. |
+| **All five yes** | **`cs-build-import-codebase`** — map the real code into core features with notes and PRDs. (It will offer the audit anyway if the code smells broken.) |
+| **There's no code yet — it's an idea** | **`cs-build-plan-app`** — the no-code-yet counterpart to import. Interviews them (or mines a call recording), walks the screens, picks the platform on capability, finds the one hard part and real prior art for it, cuts to a sellable v1, then **reads the whole plan back for a yes before writing anything**. It writes the map and notes itself, then hands to `cs-build-create-prd`. |
+
+**"The code runs" is not the same as "the code does the job."** A vibe-coded app often runs fine and still fails questions 1–3, so do not accept "it works" as five yeses. If the user can't answer from knowledge — most can't — run the quick health smell test in `project-state.md` and answer from evidence: *"4 of the 6 things that usually mean an app needs diagnosing"*, then let them choose.
+
+It does not matter if they picked "wrong". Every skill detects the real state on entry and does the right next thing.
+
+## The rest of the journey
+Once there's a map with notes: **`cs-build-ui-mockup`** → **`cs-build-create-prd`** → **`cs-build-create-tasks`** → **`cs-build-feature`** → **`cs-build-resync-codebase`**.
+
+**`cs-build-ui-mockup` comes before the PRDs, and it is not optional for anything with a user interface.** It builds a throwaway clickable mockup from the notes and runs the review that catches what a written plan cannot express — screen order, hierarchy, position, and choices that turn out to be incomplete. A PRD generated from a plan nobody has looked at just encodes the misunderstanding in more detail. Understand produces context (the map + notes); Plan produces instructions (PRDs + tasks); a PRD is only as good as the note it reads (`project-state.md`).
+
+## What good looks like
+- Authenticated and pointed at the correct **local** project before anything else — and if two projects exist for one app, the user was told which one is authoritative (`project-state.md`).
+- The user is told where their project actually is, in one line, from the script's output rather than a hand count.
+- Routing came from the **five questions**, not from "do you trust it" — and "it works" was not accepted as five yeses.
+- Exactly one next step is named, and it fits the state the project is really in — not a wall of options.

--- a/.agents/skills/cs-build-handoff/SKILL.md
+++ b/.agents/skills/cs-build-handoff/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: cs-build-handoff
+description: >
+  Turn a finished CodeSpring plan into the pack a paying client actually
+  receives — a plain-English summary of what is being built, the mockup and its
+  style guide, the plan and task links, an honest phase-by-phase build order,
+  what was assumed, what is still open, what is needed from them, and exactly
+  what to do next to start building. Written at a reading level a non-technical
+  owner can follow, with no file paths and no jargon. Run it once the map,
+  notes, PRDs and tasks exist and the plan is about to leave your hands.
+  Triggers, "hand this over to the client", "create the client pack", "write the
+  handover", "send them the plan", "what do I send the client", "onboard them
+  onto this plan", "package this up for delivery".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(node:*) Bash(git:*) Bash(grep:*) Bash(rg:*)
+metadata:
+  author: codespring
+  version: "0.1"
+---
+
+# Hand the plan over
+
+**When the plan is the product, the handover is the delivery.** Everything upstream produced artefacts for the build — a map, notes, PRDs, a task board. None of those are written for the person paying, and handing someone a link to a canvas they have never opened is not a delivery.
+
+This produces the thing they receive.
+
+Run it **after** `cs-build-create-tasks`, once the map, notes, PRDs and tasks all exist.
+
+Read: `codespring` skill `references/project-state.md` and `references/pitfalls.md`, and **`cs-build-audit-codebase/references/plain-english-writeup.md`** — the voice rules there apply here exactly. Third-grade reading level, no file paths, no jargon, no framework names.
+
+---
+
+## 0. Check there is something to hand over
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state
+node ../codespring/scripts/state.mjs       /tmp/cs-state
+node ../codespring/scripts/check-map.mjs   /tmp/cs-state
+```
+
+**Do not hand over a plan with holes in it.** Check and say plainly if any of these are missing:
+
+- Core features, each with a real note
+- PRDs on every core feature
+- Tasks, numbered, ordered, each linked to a feature
+- A mockup, if the thing has a user interface
+
+A missing piece is not a reason to write around it — go back and finish it. The one exception is where something is deliberately deferred, and then it belongs in **"what we haven't decided yet"** rather than being quietly absent.
+
+## 1. Know who is reading it
+
+Usually a non-technical owner who has paid real money and is nervous. Often they have been burned by a previous agency or program.
+
+**Write for them, not for the builder.** Two consequences that decide the whole tone:
+
+- **No jargon, no file paths, no framework names, no task IDs in the prose.** They do not need to know what a PRD is to understand what they are getting.
+- **Say what it does for their user, not how it is built.** "She picks how long she has and the app runs the session" — not "the session controller reads the workout schema".
+
+If they *are* technical, they will not be annoyed by clarity. The reverse is not true.
+
+## 2. Write the pack
+
+One document. Sections in this order, because that is the order their questions arrive in.
+
+### What we're building
+Two or three paragraphs, plain English, in **their own words wherever possible** — pull the phrasing straight out of the call or the notes. They should recognise their idea, said back more clearly than they said it.
+
+State the job it does and who it does it for. No feature list yet.
+
+### What it does
+The core features, each with a sentence or two on what the person using it can actually do. **Named the way they talk**, not the way the map is organised.
+
+If there is a mockup, put the screenshots here, beside the feature each one shows. This is the section they will read most carefully.
+
+### What you'll see
+The mockup: how to run it, or where it is hosted, and one line making clear it is **a sketch of the finished thing, not the app** — nothing in it works yet, the data is made up, and it exists so they can react to the shape before anything is built.
+
+Include the **style guide** page if there is one, and say what it is for: the colours, type and spacing are all set in one place, so changing the look later is a small job rather than a rebuild.
+
+### How it gets built
+The task list as **phases, not tasks.** Nobody wants to read sixty rows. Group them into the four or five stages they already exist in, and for each give: what happens, roughly how long, and what it unlocks.
+
+Two things must be honest here:
+- **Name the hard part** and say it is being proven first, before the screens are built around it. If the plan has a spike as task one, explain why in one sentence.
+- **Name what they have to do.** Content, decisions, reviews, accounts. This is the most-skipped section and the most common cause of a stalled build.
+
+**Do not give a total delivery date** unless one was actually agreed. Give the shape and the sequence.
+
+### What we assumed
+Every assumption made on their behalf, in plain words, each with a one-line reason. Platform, scope, audience, anything cut from v1.
+
+This section buys trust rather than spending it. An assumption they disagree with is cheap to fix now and expensive after the build — and surfacing them is what separates a plan from a guess.
+
+### What we haven't decided yet
+The genuinely open questions, and **who needs to answer each one.** Be specific about what a decision unblocks: *"we need your exercise list before the content work can start"* is actionable; *"TBC"* is not.
+
+### What's not in the first version
+Named explicitly, each with a reason, and clearly marked as *later* rather than *never*. An unspoken cut is heard as a broken promise the moment they see the build.
+
+### What to do next
+Numbered, concrete, and short. Typically:
+1. Open the plan (link)
+2. Look at the mockup (link or command)
+3. Send back the things in "what we haven't decided yet"
+4. Open the project in the build tool and start with task one
+
+Assume they have never used any of these tools. **Include the actual links and the actual first task**, not a description of them.
+
+### Where everything lives
+A short reference: the plan link, the mockup, the docs, the task board, and who to contact.
+
+## 3. Deliver it in the form they will actually read
+
+Ask, or use what you know about them. The document is the same; the wrapper differs:
+
+- **A rendered page** they can open and share — usually the best default, and it keeps the screenshots inline.
+- **A markdown file** in the repo if they are comfortable there.
+- **An email or message body**, if the pack is short and they are more likely to read it in their inbox than to click a link.
+
+Whatever the form, **put the screenshots in it.** A plan without pictures reads as an invoice; a plan with pictures reads as a product.
+
+## 4. Record it in CodeSpring
+
+So the next session knows what the client has already been told:
+
+- Set the project description to the plain-English "what we're building" paragraph, so the canvas opens with something they recognise.
+- Put the handover date and what was sent in the project info or a note.
+- If assumptions or open questions were listed, make sure they also exist in the relevant feature's note — otherwise they live only in a document nobody reads again.
+
+```bash
+codespring mindmap set-info --title "..." --description "<the plain-English paragraph>"
+```
+
+## 5. Say what you sent
+
+Tell the person who commissioned it — usually not the same person as the client — in three lines: what went out, what you are waiting on from the client, and what happens when it arrives.
+
+---
+
+## What good looks like
+
+- The client could read the whole pack and **explain their own app back to someone else.**
+- **No jargon, no file paths, no task IDs, no framework names** anywhere in the prose.
+- The mockup screenshots are in it, beside the features they show.
+- Build order is **phases with what-it-unlocks**, not sixty rows.
+- **Assumptions are stated**, each with a reason.
+- **What they owe is named**, specifically, with what it unblocks.
+- Cuts are named as *later*, not left silent.
+- The next steps are numbered, with real links and the real first task.
+- The plain-English summary is on the CodeSpring project, so the canvas opens with something they recognise.

--- a/.agents/skills/cs-build-import-codebase/SKILL.md
+++ b/.agents/skills/cs-build-import-codebase/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: cs-build-import-codebase
+description: >
+  Get an existing app into CodeSpring as a visual feature map — a small set of
+  core features (sidebar-level) with nested sub-features and a "how it works"
+  note each — then PRDs (via cs-build-create-prd) and Kanban tasks. Takes an
+  OPTIONAL audit + verdict: with no audit it documents what exists; with an audit
+  it builds the corrected target map (what the app should be) and generates fix or
+  rebuild tasks from the findings. Detects an existing map, judges whether it is
+  any good, and keeps or repairs it instead of duplicating it — and offers to
+  audit first if the codebase looks broken.
+  Triggers, "import my codebase into CodeSpring", "map my existing app", "reverse
+  engineer my app into features", "bring this project into CodeSpring",
+  "visualize my code in CodeSpring".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(git:*) Bash(node:*) Bash(curl:*) Bash(grep:*) Bash(rg:*)
+metadata:
+  author: codespring
+  version: "0.5"
+---
+
+# Import a codebase into CodeSpring
+
+Turn a real repo into an accurate CodeSpring model: **core features → sub-features → notes → PRDs → tasks**. Reads code and git; writes only to CodeSpring — never modifies the codebase.
+
+Shared knowledge, read it: `codespring` skill `references/project-state.md` (enter-from-anywhere, the five questions), `references/auditing-and-fixing.md` (audit → verdict → map → tasks, and why the map shows the target), `references/analyze-codebase.md`, `references/mindmap-structure.md` (the exact node/edge schema), `references/prd-management.md`, `references/pitfalls.md`. Then this skill's `references/target-map.md` (**the map rules — the node model, the corrected target, and how to keep it small**).
+
+**Language- and stack-agnostic.** Any named specific here or in the references is a **labelled worked example**, never an assumption about the repo in front of you.
+
+**Script paths are relative to this skill's own folder**; the skills install side by side, so `../codespring/scripts/…` reaches the core skill's scripts. Resolve them to absolute paths once at the start — your working directory will be the user's repo.
+
+## 0. Detect where the project already is
+Run the state-detection **scripts** rather than counting by hand (the `codespring` skill's `scripts/`, installed alongside this one):
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state   # read-only snapshot; prints the projectId
+node ../codespring/scripts/state.mjs       /tmp/cs-state          # summary line + booleans and counts
+node ../codespring/scripts/check-map.mjs   /tmp/cs-state          # machine-checkable map faults, before you add to them
+```
+
+Read `projectId` from the **local** `.codespring/config.json` and print it before any write.
+
+**Branch on what exists — do not assume you are starting from nothing:**
+- **A map already exists** → you are **updating**, not importing. Print the existing core features and ids, then **run the map-quality ladder** (below). Match on title; never re-create; re-parent strays. Skip straight to whatever is actually missing (notes → PRDs → tasks).
+- Not linked → link. If the project must live in a team workspace, the user creates it in the **web app** first (there is no CLI way to place or move a project — `pitfalls.md`).
+- Tasks exist → note the highest number and continue the sequence.
+- **Two projects already exist for this one app** → establish **which is authoritative** before writing anything, and say so to the user.
+
+### 0a. The map-quality ladder — an existing map is not automatically a good map
+*"A map exists → keep it"* is too blunt; an unusable map poisons every note, PRD and task built on it. Full version with the CLI commands and the two-projects warning: `references/target-map.md`.
+
+1. **Does a map exist?** No → build it (§2–§4).
+2. **Is it good?** `check-map.mjs` settles the count, duplicate titles, flattened sub-features and missing notes. **You** judge the rest: core features **4–8**, each one something a user would recognise as a **sidebar item**; sub-features are things a user **does**, not sections of an output document or groups of form fields; card descriptions one sentence with the depth in the note card. A map can pass every check and still be incomprehensible.
+3. **Good → keep it.** Update notes, add tasks. **Never recreate it.**
+4. **Fixable** (mostly right, a few strays) → **fix in place and say what you changed:** `codespring feature update <subId> --parent <coreId>`, `codespring feature delete <dupId> --yes`, `codespring feature update <id> --title "..."`.
+5. **Not fixable** (wildly too many core features, output sections standing in as features, no coherent structure) → **do not salvage it.** Explain why plainly, recommend a **new CodeSpring project** with a clean map, and say the old one **stays as history**. **Get explicit confirmation before creating a second project — never silently.** Two projects for one app is confusing later, so it must be a deliberate, explained choice, and the user must be told **which project is now authoritative**. (Real case: a 13-core-feature import was unusable; a second project with a clean 6-feature map replaced it; both still exist, and there is no `project delete`.)
+
+## 1. Do you have an audit?
+This is the one input that changes the output.
+
+| | Behaviour |
+|---|---|
+| **No audit** | Document **what exists** — the app as it is today. |
+| **Audit + verdict** | Build the **corrected target map** — what the app *should* look like, simplified into core features a non-expert recognises. |
+
+**If there's no audit, ask the five questions** (`project-state.md`) before importing — does the app do what it needs to do; is it getting things wrong or presenting unverifiable figures as fact; does the architecture allow what it needs to do; can it be built on scalably; can users use it without it breaking. **Any no → offer the audit first.** Do not ask "do you trust the code", and do not accept "it works" as five yeses — **"the code runs" is not the same as "the code does the job."**
+
+**Then run the quick health smell test** (`project-state.md`), because the user often cannot answer questions 2, 4 and 5 from knowledge. Six smells: no tests/CI, ungated deploy, local clone behind the remote, swallowed errors, credentials in shipped source, browser-only records or hardcoded reference data. **Two or more → stop and offer the audit**, plainly: *"I found 4 of the 6 things that usually mean an app needs diagnosing before mapping. Want me to run `cs-build-audit-codebase` first?"* Do not silently import a mess — a map of a broken app is a map nobody should trust. If they decline, import what exists and say the map documents today's behaviour, faults included.
+
+## 2. Analyse the code
+Follow `analyze-codebase.md`: frontend map (routes, components, what the user sees, navigation) and backend map (API routes and which features share them, data model, security, shared systems — payments/credits, jobs/cron, storage, auth, env vars — and infra). Set the real tech stack. Read files; don't guess. On the audit path you already have most of this — reuse the findings rather than re-deriving them.
+
+## 3. Decide the features — smallest recognisable set
+Rules and the worked failure in `references/target-map.md`. The short version:
+
+- **Core feature** = a sidebar/nav-level thing the user would point at. **Aim for 4–8.** The first real run produced **13 confusing** core features; after redirection, **6 clean** ones. Push hard toward the smallest set.
+- **Sub-feature** = something the user **does**. A verb. *Save a client. Compare two properties. Export the PDF.*
+- **The mistake not to repeat: do not turn report/page sections or form field-groups into sub-features.** A report section is part of one feature's output; a form field-group is part of one feature's input. Twelve report sections are one feature plus a good note, not twelve features.
+- **Card descriptions stay to one short sentence. ALL detailed information goes into the note card attached to that feature via its bridge — never into the card description.** The node model (features node → card → bridge → note card, and bridge → PRD bridge → PRDs) is in `references/target-map.md`; the exact schema is in `mindmap-structure.md`. The first real run failed on exactly this: long descriptions on the cards *and* output sections promoted to sub-features, giving 13 unusable core features.
+- **Notes are root-feature-only** via the CLI, so sub-feature detail goes in the parent core feature's note (`pitfalls.md` §5).
+
+On the audit path, add a feature the current app lacks **only** where a bucket-1 fix has nowhere else to live (durable storage for records that exist only in a browser; sign-in where there is none). A bucket-2 "could add later" idea never becomes a feature (`auditing-and-fixing.md` §4a).
+
+**Ask whether the app is feature-complete or still being built.** If it is still being built, **ask what is planned but not yet built before finalising the list** — missing code is not proof a feature is missing, and pages nothing links to may be unfinished modules rather than dead ends or a separate product.
+
+**Read the list back to the user and ask them to cut it before you write anything.**
+
+## 4. Write the map (CLI)
+```bash
+codespring mindmap set-info --title "..." --description "..." --github "<repo url>"
+codespring mindmap tech-stack --replace --add '[{"id":"tech-...","title":"...","description":"Frontend"}, ...]'
+codespring mindmap features --add '[{"title":"Dashboard","description":"..."}, ...]'   # CORE features; keep the returned ids
+codespring feature create --parent <coreId> --title "..." --description "..."           # sub-features
+codespring mindmap note <coreId> --title "How it works — X" --text "$(cat note.txt)"    # one per core feature; redirect output to /dev/null
+```
+
+**Idempotency (`auditing-and-fixing.md` §8):** diff by title first and only add what is missing. **`codespring mindmap features --replace` does NOT replace — it appends and creates duplicates.** If duplicates happen, recover with `codespring feature delete <id> --yes`, which does work and cascades.
+
+**The note per core feature** carries the depth from `analyze-codebase.md` §8–9 and, on the audit path, three things: what the feature *should* do, how it works today, and what is wrong with it today (severity + file reference; on a rebuild, the "do not reintroduce this" constraints). The PRD generator reads this note as its context, so a thin note produces a thin PRD. When updating an existing note, read it first and keep what is still true.
+
+## 5. Say what the map is
+One sentence to the user, because it prevents a real misunderstanding: **the map shows the corrected target, not the current structure — so it won't mirror the repo until the tasks are done, and the Kanban is the gap between the two.** Rationale in `references/target-map.md`; this is deliberate and applies on both verdicts.
+
+## 6. PRDs — via `cs-build-create-prd`
+Do not re-implement PRD mechanics. For each core feature use **`cs-build-create-prd`** (Both frontend + backend); it captures the shared backend contracts and attaches the PRD bridge nodes correctly. Mind its ≥120s timeout and dedupe rules. **Never regenerate a PRD that already exists** unless asked — read it, say it exists, offer to refresh it. And never generate a PRD for a feature with no note.
+
+## 7. Tasks — the two paths differ, and this is the important part
+Only **bucket 1 (real problems)** becomes tasks. Every task: linked to exactly one core feature, carrying a severity (Critical → `urgent`, High → `high`, Medium → `medium`, Low → `low`), one-sentence title, detail in the description, continuing the existing numbering.
+
+**Future ideas have nowhere to live in CodeSpring, and they must not become tasks** — a task list implies committed work. Buckets 2 and 3 go in `FINDINGS.md` in the repo, in two explicitly titled sections with a one-line reason each: *"Could add later — deliberately not doing now"* and *"Not worth adding"*. Never on the map, never in Kanban, never as a PRD (`auditing-and-fixing.md` §4a — it is a known product gap for FERB).
+
+**Verdict = REBUILD → two distinct sets.**
+1. **Build-to-spec tasks** — one per feature/sub-feature, foundations first.
+2. **"Mistakes to avoid" tasks** — one per significant defect found in the original, carried forward as an explicit do-not-reintroduce constraint with the concrete example. **This second set is the entire reason for auditing before importing** — without it a rebuild recreates the same silent failures, the same hardcoded tables and the same duplicated logic, because nothing in the new plan says not to. Write them as verifiable constraints:
+   - *"Reference data lives in dated records, not as values typed into the code. It must be impossible to change a rate by editing the app."*
+   - *"When a lookup finds nothing, say so. No code path may put a zero or a blank where an error happened."*
+   - *"There is exactly one copy of the calculation logic, and everything imports that copy."*
+   - *"When a report is published, save the inputs, the results, and which year's rates produced them — so fixing a rate later doesn't change what a client was already shown."*
+   - *"Who someone is never comes from the request body. Identifiers in a request are targets, and ownership is checked before use."*
+
+**Verdict = FIX IN PLACE → one set.** One task per defect, at the place it lives, **with the file reference in the description** (the user-facing findings have no paths; the task needs one because an agent has to act on it). Sequence: silent failures first, then wrong outputs, then structural work, then polish — or the audit's own suggested fix order.
+
+**No audit** → tasks come from the PRDs, not from findings. Hand off to **`cs-build-create-tasks`** for that; it owns PRD-derived task lists. This skill only writes the findings-derived tasks, because it is the only place the findings exist.
+
+An **UNVERIFIED** finding becomes an investigation task keeping its label — never a confident fix task.
+
+## 8. Verify (`pitfalls.md`, `auditing-and-fixing.md` §9)
+**Run the check, don't eyeball it:**
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-verify
+node ../codespring/scripts/check-map.mjs   /tmp/cs-verify --expect-core <the count you intended>
+```
+
+- `node-features.items.length` equals the intended core-feature count — **and no sub-features have been flattened to top level.** Re-parent any stray with `codespring feature update <subId> --parent <coreId>`; keep a sub→core map so re-runs are one command.
+- No duplicate features (by title) and no duplicate PRDs (by feature + type).
+- One note per core feature. Every task linked to a feature with a severity.
+- A non-zero exit is a real failure: fix it before reporting. Then report the diff: created N, updated N, skipped N. Give the project link `https://v2.codespring.app/project/<projectId>`.
+
+## 9. Optional independent audit of the map (no-audit path only)
+On the audit path, skip this — you already have one. Otherwise spawn a **background sub-agent** with a FULLY SELF-CONTAINED brief and **no context from the import work**, so the comparison is unbiased:
+
+> You are an independent auditor. Read-only: do not modify the codebase or the CodeSpring map.
+> 1. **Inventory the whole codebase** — every route, page, table + enum, external provider, webhook, cron/job, and the shared backend contracts (payments/credits/refunds, job pipelines, storage conventions, auth, env vars).
+> 2. **Read everything documented in CodeSpring** — every feature's notes and PRDs (via the `codespring` CLI).
+> 3. **Compare critically and report**, prioritising **shared backend gaps and conflict risks** (the riskiest part of adding a new feature). Flag anything in the code that's undocumented, anything that could break or duplicate a shared system, and anything documented but missing critical backend detail — each **rated by severity** with exact file/route/table references, plus a shortlist of what to add to CodeSpring.
+
+Report when it finishes and offer to fold the shortlist into the notes/PRDs, or hand off to `cs-build-resync-codebase`.
+
+## What good looks like
+- The map holds the **smallest** set of core features a non-expert would recognise — not report sections, not form field-groups.
+- With an audit, the map is the **corrected target** and the user has been told so in one sentence; without one, it honestly documents what exists.
+- Nothing was duplicated: an existing map was judged against the ladder and then kept or repaired in place, features were matched on title, strays were re-parented, existing PRDs were left alone.
+- A second CodeSpring project was only ever created with **explicit confirmation**, with the reason explained and the authoritative project named.
+- Future ideas are in the two named `FINDINGS.md` sections, not on the map and not in Kanban.
+- Every core feature has a real "how it works" note, and every PRD was generated from one.
+- On a rebuild, a distinct set of "mistakes to avoid" tasks exists so the original's defects cannot come back. On a fix in place, every defect has a task where it actually lives.

--- a/.agents/skills/cs-build-import-codebase/references/target-map.md
+++ b/.agents/skills/cs-build-import-codebase/references/target-map.md
@@ -1,0 +1,159 @@
+# Building the map — the node model, the corrected target, and how to keep it small
+
+Applies to any codebase in any language. The named examples (a report's sections, a form's field-groups, a 13-feature first attempt) are **labelled worked examples** from real runs, not assumptions about the repo in front of you.
+
+Two inputs, one output shape.
+
+| Input | What the map shows |
+|---|---|
+| **No audit** | What exists — the app documented as it is today |
+| **An audit + a verdict** | **The corrected target** — what the app *should* look like, simplified into core features a non-expert recognises |
+
+## The settled decision
+
+**The mindmap always shows the corrected target. It never shows the messy current structure annotated with warnings.** True on a rebuild verdict and true on a fix-in-place verdict.
+
+Recorded rationale:
+
+- **The map means one thing.** Nobody reading a CodeSpring map — user or agent — has to ask "is this the real structure or the intended one?" It is always the intended one.
+- **The Kanban always means the same thing:** the gap between here and there. Every task closes a distance between the map and reality, whether that task builds a feature or fixes one.
+- **One drawing model.** No second node type for "broken", no warning badges, no annotation layer, and nothing extra to unwind when a task is finished.
+
+Accepted cost: **the map does not mirror the repository until the tasks are done.** Disclose that to the user in one sentence. It is arguably a feature — the map shows people where they are going, which is what a non-expert needs to see — and `cs-build-resync-codebase` is what brings the two back into agreement afterwards.
+
+**A fix-in-place target map looks almost identical to the current app.** The difference lives in the notes (what each feature *should* do, including the corrections) and in the tasks (what is wrong today). Do not skip the corrected-target step just because the verdict was fix in place.
+
+Where a finding has no home in the target map — dead code being deleted, a page being removed — it becomes a task without a new feature. Attach it to the nearest core feature, or to a core feature named for the cleanup. **Never invent a feature just to host a defect.**
+
+---
+
+## Is the existing map any good? — the ladder
+
+*"A map already exists → keep it"* is too blunt. An import can produce a map that is genuinely unusable, and keeping it means every note, PRD and task afterwards inherits the confusion. Walk the ladder, in order, and say out loud which rung you landed on.
+
+**1. Does a map exist?** No → build it (the rest of this file).
+
+**2. Is it good?** Judge it against these tests, not against your own taste:
+
+- **Core features are 4–8**, and each one is something a user would recognise as a **sidebar item**.
+- **Sub-features are things a user *does*** — verbs — not sections of an output document and not groups of form fields.
+- **Every core feature has a note**, and the **card descriptions are one sentence** with the depth in the note (below).
+- **No duplicates** — no two features share a title.
+- **No sub-features flattened to top level** (`pitfalls.md` §2).
+
+Run the machine-checkable half rather than counting by hand — it is identical every time:
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state
+node ../codespring/scripts/check-map.mjs /tmp/cs-state            # add --expect-core N once you know the number
+```
+
+It settles the count, duplicate titles, flattened sub-features, missing notes, duplicate PRDs and unlinked tasks. **The judgement calls stay yours:** whether a core feature is really a sidebar item, whether a sub-feature is a verb, and whether the whole thing is comprehensible. A map can pass every check and still be wrong.
+
+**3. Good → keep it.** Update the notes, add the tasks. **Never recreate it.** Print the core features and their ids and move on.
+
+**4. Fixable** — mostly right, a few strays → **fix it in place, and say what you changed:**
+
+```bash
+codespring feature update <subId> --parent <coreId>     # re-parent a stray sub-feature
+codespring feature delete <dupId> --yes                 # remove a duplicate (cascades)
+codespring feature update <id> --title "..."            # rename to something a user would recognise
+```
+
+**5. Not fixable** — so wrong that it is confusing: wildly too many core features, sections of an output document standing in as features, no coherent structure → **do not try to salvage it.** Explain plainly *why* it cannot be fixed (say which tests it fails and how many features would have to change), and recommend a **new CodeSpring project with a clean map**, telling the user the old project **stays as history**. **Get explicit confirmation before creating a second project — never silently.**
+
+### Warning: two projects for one app
+
+This is a real case, not a hypothetical. An import produced a **13-core-feature** map that the owner could not use; the fix was a **second** CodeSpring project with a clean **6-feature** map. **Both still exist.**
+
+- **Two projects for one app gets confusing later** — links, notes, PRDs and tasks split across two places, and nobody remembers which is current.
+- So it must be a **deliberate, explained choice**, never a quiet workaround for a map you did not want to fix.
+- **Tell the user which project is now authoritative**, in those words, and record it in the new project's info/description so the next session does not have to guess.
+- On entry, if you find two projects for one app, establish which is authoritative **before writing anything** (`project-state.md`).
+- There is no `project delete` and no way to move a project between workspaces, so a second project is permanent. Name it so the difference is obvious.
+
+---
+
+## How a map is stored — the node model
+
+The same shape for every project, whatever the codebase. Exact node ids, edge handles and JSON live in `mindmap-structure.md`; this is the model you need in your head before you write anything.
+
+- **Core features are items on one node.** The features node holds an array of items, and each item **is** a core feature card — a `title` and a one-sentence `description`. There is no separate node per core feature.
+- **Each core feature gets a sub-feature group node.** One node per core feature, holding that feature's sub-feature cards and pointing back at its core feature (`parentFeatureId`). That parent link is the whole difference between a sub-feature and an extra core feature, and it is the thing that breaks (`pitfalls.md` §2).
+- **Detail attaches through a bridge.** A feature card connects to a **bridge node**; the bridge connects to the detail cards — the **note card** (one per core feature) and, later, a PRD bridge carrying the Frontend and Backend PRD cards. Nothing detailed hangs off a feature card directly.
+
+```
+features node ──(card)──► bridge ──► note card
+                             └────► PRD bridge ──► Frontend PRD / Backend PRD
+```
+
+### Where detail goes — the rule
+
+> **Card descriptions stay to one short sentence. ALL detailed information goes into a note card attached to that feature via a bridge — never into the card description.**
+
+Cards are read at a glance on a canvas, so a paragraph on a card hides the structure the map exists to show. The note card has no practical length limit, and it is the **note** — not the card — that the PRD generator reads as its context (`project-state.md`).
+
+**Notes are root-feature-only through the CLI** (`pitfalls.md` §5): `codespring mindmap note <coreFeatureId>` overwrites that core feature's single note, and a sub-feature cannot have one. So **sub-feature detail belongs in the parent core feature's note** — which is one more reason not to invent sub-features to hold detail.
+
+### The real failure this prevents
+
+First attempt on a real app: long descriptions written onto the cards **and** the report's own sections and the form's field-groups promoted into sub-features → **13 core features, unusable**, and the owner said so plainly. Second attempt: **6 core features**, one-sentence descriptions, every piece of depth in the notes → usable. Same codebase, same information, different placement.
+
+---
+
+## The smallest set of core features that a user would recognise
+
+The first run on the real app produced **13 core features** and the user found them confusing. After redirection it produced **6**, which were right. Push hard toward the smallest set.
+
+**Test for a core feature:** would this be a sidebar item? Would the user point at it and say "that's a thing my app does"? If the answer needs explaining, it is not a core feature.
+
+**Test for a sub-feature:** is it something the user **does**? A verb. *Save a client. Compare two properties. Export the PDF. Enrol someone.*
+
+### The specific mistake that was made — do not repeat it
+
+**Sub-features are not sections of an output document, and they are not groups of form fields.**
+
+The first run turned the report's own sections into sub-features ("Government costs", "Tax benefits", "Market intelligence", "Glossary", "How to read these figures") and turned form field-groups into sub-features ("Location", "Loan details", "Property details"). Both are wrong:
+
+- **A report section is not a feature.** It is part of the output of one feature. Twelve report sections do not make twelve features — they make one feature called "the report", and the sections are detail that belongs in that feature's note.
+- **A form field-group is not a feature.** It is part of the input to one feature. "Location" is not something a user does; *analysing a property* is, and Location is one panel of it.
+
+Symptoms you have made this mistake: core features that read like a table of contents; sub-features that are nouns rather than verbs; more than about 8 core features on an app with 6 screens; two sub-features that a user could not tell apart.
+
+### Practical shape
+
+- **Core features: aim for 4–8.** Above 8, argue for each one. Above 10, you have almost certainly split an output document or a form.
+- **Sub-features: the actions inside that feature.** A handful each, not twenty.
+- Depth goes in the **note**, not in more features. If detail is being lost, the note is too thin — enrich it rather than adding features.
+- **Card descriptions stay one sentence.** Always.
+
+### Building the target list from an audit
+
+1. Start from what the app is *for* — the two or three jobs a user comes to do.
+2. Take the real navigation as the candidate list (`analyze-codebase.md` §6), then **collapse**: merge screens that are one job split across pages, and drop pages that the target does not have (dead ends, orphans, internal galleries shipping to production).
+3. Add features the target genuinely needs and the current app lacks **only where the audit put them in bucket 1** — a *fix* that has no home in the current structure (durable storage for records that currently live in one browser, an accounts/sign-in feature where there is none). A bucket-2 "could add later" idea **never** becomes a feature on the map; it lives in the *"Could add later — deliberately not doing now"* section of `FINDINGS.md` (`auditing-and-fixing.md` §4a).
+   **On an app that is still being built, ask what is planned but not yet built before you finalise the list.** Code that is missing is not proof a feature is missing, and pages nothing links to may be unfinished modules rather than dead ends.
+4. Name them the way the user talks, not the way the code is organised.
+5. Read the list back to the user and ask them to cut it before you write anything.
+
+---
+
+## Writing the notes
+
+One "how it works" note per core feature. On the audit path each note says three things:
+
+1. **What this feature should do** — the target behaviour, plainly.
+2. **How it works today** — the real structure, files, routes and data, at the depth in `analyze-codebase.md` §8–9. The PRD generator reads this note as its context, so thin notes produce thin PRDs (`project-state.md`).
+3. **What is wrong with it today** — the audit findings that belong to this feature, each with its severity and its file reference, and, on a rebuild, the "do not reintroduce this" constraints.
+
+Notes are **root-feature only** and there is one per feature, which the CLI overwrites (`pitfalls.md` §5). Put sub-feature detail and cross-feature links inside the parent's note. When updating an existing note, **read it first and preserve what is still true.**
+
+---
+
+## CLI reality check before you write
+
+- `codespring mindmap features --replace` **does not replace — it appends**, creating duplicates. Treat feature creation as add-only, diff by title first. Recovery is `codespring feature delete <id> --yes`, which does work and cascades.
+- There is **no `project delete`**, and no way to move a project between workspaces or organisations from the CLI — `project create` ignores `--org` and stamps `organizationId: null`. If the project must live in a team workspace, the user creates it **in the web app first**, then you link to it.
+- Always read `projectId` from the **local** `.codespring/config.json` and print it before any write.
+
+Full details and the rest of the failure modes: `pitfalls.md`.

--- a/.agents/skills/cs-build-plan-app/SKILL.md
+++ b/.agents/skills/cs-build-plan-app/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: cs-build-plan-app
+description: >
+  Turn an idea into a CodeSpring plan — from a sales-call recording, a transcript,
+  a voice note, or someone just talking at you about what they want. Interviews
+  the person (or mines the recording) for the job the app does, walks the screens
+  with them, picks the platform from what the app actually needs to do, finds the
+  one technically hard part and names a real solution for it (including existing
+  open-source prior art), cuts to a v1 that can be sold, then writes the map —
+  core features, sub-features, notes — and hands off to cs-build-create-prd and
+  cs-build-create-tasks. The no-code-yet counterpart to cs-build-import-codebase.
+  Triggers, "plan my app", "generate a plan", "turn this recording into a plan",
+  "I have an idea for an app", "design my app in CodeSpring", "map out this idea",
+  "I've got a client call recording, make the plan", "plan from scratch".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(node:*) Bash(git:*) Bash(grep:*) Bash(rg:*) WebSearch WebFetch
+metadata:
+  author: codespring
+  version: "0.7"
+---
+
+# Plan an app from an idea
+
+There is no code yet. Produce the same artefact `cs-build-import-codebase` produces — **core features → sub-features → notes → PRDs → tasks** — but derived from a person instead of a repo.
+
+**Two phases with a gate between them:**
+
+| | | |
+|---|---|---|
+| **A. Think** (§1–§6) | Conversational, nothing is written | the job, the journey, every kind of user, the platform call, the hard part and what solves it, the systems checks, the v1 cut |
+| **GATE** | **Read the plan back and get an explicit yes** | §6a |
+| **B. Write** (§7) | CodeSpring gets touched | the map and the notes |
+| **C. Show** (§7a) | Hand off to `cs-build-ui-mockup` | the cheapest possible disagreement — corrections come back into the notes |
+| **D. Instruct** (§8–§9) | Only once the mockup is agreed | PRDs, then tasks |
+
+**Never write to CodeSpring during phase A.** A map is expensive to unpick and it makes people feel committed to a plan they were still arguing with. Phase A is meant to be argued with.
+
+This is the **no-code-yet counterpart to `cs-build-import-codebase`** and it deliberately does its own writing rather than handing over — that skill's engine is *reading a repo*, and there is no repo. What the two share is the destination, and that is already factored out: the node model and map rules in `cs-build-import-codebase/references/target-map.md`, the schema in `mindmap-structure.md`, the CLI in `commands.md`. Use those; do not re-derive them and do not fork them.
+
+Shared knowledge, read it: `codespring` skill `references/project-state.md` (enter-from-anywhere, the three stages), `references/mindmap-structure.md` (the exact node/edge schema), `references/prd-management.md`, `references/pitfalls.md`. **And `cs-build-import-codebase/references/target-map.md` — the node model, the one-sentence-card rule and the 4–8 core feature ceiling are identical here; do not restate or re-derive them.**
+
+Then this skill's own references, which cover what is different about planning from nothing:
+
+| Reference | Read it when |
+|---|---|
+| `references/elicitation.md` | Always. Getting the real app out of a person's head, and out of a recording. |
+| `references/platform-choice.md` | Before you name a stack. Mac vs web vs iOS decided by capability — **and the constraint that can overrule it: what the owner can actually build in and maintain.** Plus what each choice costs. |
+| `references/hard-part-first.md` | Always. Every app has one genuinely hard bit; find it, find the prior art, prove it. |
+| `references/data-and-shape.md` | Always, and the actor question **before the feature list is final**. The five systems checks nobody asks for: figures someone else publishes and how they get updated, logic shared across products, every kind of user and the owner's admin surface, whose database this lives in, and showing how current the data is. |
+| `references/v1-scope.md` | Before you write the map. Cutting to one loop, and the revenue gate. |
+
+---
+
+## The difference that governs everything
+
+**Importing a codebase has ground truth. Planning an idea does not.**
+
+With a repo you can be wrong and find out — you read the file. With an idea, a confident plan that does not match what is in the person's head reads exactly like a good one, right up until they see it built. Every rule below exists to fight that.
+
+The second thing, and it is the harder one:
+
+> **They do not know what they don't know, and they do not know what they need.**
+
+Non-technical people describe apps in terms of what they have seen. They will ask for the thing they saw on Instagram. Your job is not to transcribe their request and it is not to substitute your own product taste for theirs — it is to get at **the job they are trying to do**, then bring the technical judgement they cannot bring: what is possible, what is expensive, what already exists, and what the hard part really is. They own the *what*. You own the *how*, and you own telling them when the *what* is going to cost more than they think.
+
+**Never let a planning session end with only their words in it.** If the plan contains nothing they could not have written themselves, you have taken dictation, not planned.
+
+---
+
+## 0. Detect where the project already is
+
+Same entry as every other skill in the pack — you may not be starting from nothing even when the *code* is nothing.
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state   # read-only snapshot; prints the projectId
+node ../codespring/scripts/state.mjs       /tmp/cs-state          # summary line + booleans and counts
+node ../codespring/scripts/check-map.mjs   /tmp/cs-state          # map faults, before you add to them
+```
+
+Read `projectId` from the **local** `.codespring/config.json` and print it before any write.
+
+- **A map already exists** → you are extending a plan, not starting one. Run the map-quality ladder in `target-map.md`, match on title, never re-create.
+- **Code exists after all** → wrong skill. Route to `cs-build-import-codebase` (or `cs-build-audit-codebase` if it fails any of the five questions in `project-state.md`). A half-built prototype from Lovable/Base44/v0 **is** code, even if the user calls it "just a mockup" — go and look before you accept "there's nothing there yet."
+- Not linked → link. Team workspace projects must be created in the **web app** first (`pitfalls.md`).
+
+### ⚠️ Give the new project its own directory — the trap unique to this skill
+
+Every other skill in the pack runs inside the repo it is mapping. **You have no repo**, so there is no natural home — and the directory you happen to be standing in is very often the parent folder of the user's *other* projects, which already has a `.codespring/config.json` pointing at one of them.
+
+**Running `codespring init` there silently repoints that config at your new project**, and the next session on the sibling project writes into the wrong place. Real case: a planning run started in a folder whose config pointed at a live Mac app project; creating the new project in a fresh subfolder was the only thing that prevented hijacking it.
+
+```bash
+codespring status                       # ALWAYS run first — whose project is this directory linked to?
+mkdir -p "<AppName>" && cd "<AppName>"  # a new directory for the new project, even with no code in it
+codespring project create --name "..." --description "..."
+codespring init --project <newId> --force
+codespring status                       # confirm the new id
+cat ../.codespring/config.json          # confirm the PARENT's link is untouched
+```
+
+That folder becomes the repo later, so this is not throwaway scaffolding. **Never `init` into a directory that is already linked to something else**, and never assume an empty-looking folder is unlinked — check.
+
+## 1. Get the raw material in
+
+The input is whatever exists: a call recording or transcript, a voice note, a Loom, screenshots of apps they like, a rambling paragraph, or a live conversation.
+
+**Read all of it before asking a single question.** Turning up to an interview with questions the recording already answered is the fastest way to lose a non-technical person's confidence.
+
+**Extract, do not summarise.** Pull out, in their own words:
+- who it is for and what that person is trying to get done
+- every screen, button, moment or behaviour they described
+- every constraint they stated (platform, offline, price, deadline, audience age, accessibility)
+- every reference app or screenshot, and specifically **what they liked about it**
+- anything they said twice — repetition marks what actually matters to them
+- anything they rejected, and why
+
+**Keep their phrasing.** *"Five minutes is the floor, anything less isn't worth the time"* survives into the note and eventually into the PRD; *"configurable session duration"* does not. Their words carry constraints and reasons that yours will quietly drop.
+
+Full method, including how to mine a sales call and what to do when the only input is a rambling voice note: `references/elicitation.md`.
+
+## 1a. Ask what they are set on building it in — before anything else
+
+One question, asked early, because the answer can invalidate the whole plan:
+
+> **"Are you set on building this in a particular tool? Base44, Lovable, v0, Replit, Bubble, something else?"**
+
+Non-technical people frequently already have a subscription and a half-learned tool, and they will not mention it unless asked — it does not feel like a requirement to them, it feels like a detail. **It is a hard constraint.** AI web-app builders emit web apps and cannot produce a native desktop or mobile app at all, so a plan that says "Mac app" is a plan they cannot execute.
+
+Ask it here, in §1, not at §4 when the platform is being chosen — by then you have already reasoned toward an answer their tool may not be able to reach.
+
+Follow-ups: *are you committed to it or just already paying for it?*, *who maintains this in a year?* Then carry the answer into §4 and resolve any conflict openly (`references/platform-choice.md` — *"the constraint that overrules capability"*).
+
+## 2. Find the job before you find the features
+
+One paragraph, agreed out loud, before anything else:
+
+> **Who** opens this, **what** are they trying to get done, **what happens today** without it, and **how do we know it worked?**
+
+If you cannot write that paragraph, you do not have enough to plan and more feature discussion will not help. Go back to §1.
+
+The last part is not decoration. *"She does her three sessions a week"* is a testable outcome; *"she feels supported"* is not, and an app cannot be aimed at it.
+
+## 3. Walk the screens with them
+
+This is the elicitation engine and it works on people who cannot describe software:
+
+> *Close your eyes and imagine you're using it. It's open in front of you. What's the first thing you see? What do you click? What happens then?*
+
+Walk it as **a journey, not a feature list**: open → first screen → first click → the main thing they came to do → done → what brings them back tomorrow. Non-technical people are excellent at this and hopeless at "what are your core features."
+
+**Sidebar-first.** For a desktop or web app, the question *"what's in the sidebar?"* produces the core feature list almost directly, and it produces one a user would recognise. Ask it in those words.
+
+**Treat the sidebar as a prompt for finding core features, not as the definition of one.** A core feature is **a big thing the user does**. The sidebar is simply where most of them are listed, which is why the question works — but some apps have a major screen you reach by pressing a button rather than by clicking the nav, and it is still a core feature. *How* the user gets to it is a navigation detail for the note, not the thing that decides whether it goes on the map.
+
+The test that actually matters: **is this a big thing the user does, and would leaving it off hide a large part of the build?** Both yes → it is a core feature, sidebar or not.
+
+Still aim for 4–8 (`target-map.md`). If applying this puts you at ten, the list is too granular, not too honest.
+
+**Then walk the *second* user — the one who puts the content in.** People describe the app from the point of view of the person using it and never mention who fills it with exercises, lessons, templates or programmes. An authoring tool is a second application and is routinely 30–50% of a build while appearing nowhere in the feature list. Ask where the content comes from on day one, who adds more, whether it differs per user, who decides the order, and **what happens on day two** — the most-skipped question in app planning. `references/elicitation.md`.
+
+Script, follow-up questions, and what never to ask: `references/elicitation.md`.
+
+### 3a. Name every kind of user — including the owner
+
+Ask this **before the feature list is final**, because the answer adds features to it:
+
+> **"Who are all the different kinds of people who use this, what can each of them see and do, and who administers it?"**
+
+They will describe one user. There are usually four or five: the end customer; **their** customers, who often receive an output without ever logging in; staff; partners; and **the owner of the business running the app**.
+
+**Almost every app needs an admin surface for the owner** — see who has signed up, manage plans and access, and edit the data the app depends on. It is missed at planning time on nearly every project and it is expensive to retrofit, because it changes the permission model rather than adding a screen. Ask what **plans or tiers** exist and what each unlocks, because that decides whether entitlement is one column or a whole subsystem. And state the security rule plainly: **permissions are enforced at the database and on the server, never only in the interface** — hiding a button is not access control.
+
+Full list of actors people forget, and the owner-only data problem: `references/data-and-shape.md` §3.
+
+## 4. Pick the platform from what the app must do
+
+Do this **before** the feature list is final, because it changes what is buildable.
+
+Decide on **capability**, never on preference or fashion:
+
+| Needs | Points to |
+|---|---|
+| Camera + real-time local ML, filesystem access, background/menubar, true offline, heavy local compute | **Desktop (Mac)** |
+| Shared by link, signup funnel, SEO, "just send it to them", cross-platform from day one | **Web** |
+| Genuinely mobile-first — in a gym, in a field, out of the house | **Mobile** |
+
+**iOS is almost never right for a v1**: review latency, Apple's cut, and an older audience that mostly prefers a larger screen. Say so plainly and say why.
+
+Then state the consequences of the choice out loud, because they are what bite later: signing and notarization, how the thing gets distributed, how payment works, whether "offline" is real. Full decision table and the consequences of each: `references/platform-choice.md`.
+
+**Then ask the question that can overrule all of it: *what will they actually build it in, and who maintains it after you leave?*** Capability says what the app *needs*. This says what the person can *keep*. If they are committed to a tool that cannot produce the platform capability points at — an AI web-app builder cannot emit a native desktop app — you have a genuine conflict, and the resolution is a conversation, not a silent override in either direction. Do not quietly plan a platform they cannot build in, and do not quietly drop a capability because their tool is easier. Put both costs on the table and let them choose. `references/platform-choice.md` — *"the constraint that overrules capability"*.
+
+### 4a. Inherit the stack from an app they already own
+
+Once the platform is chosen, **ask whether they already have a working app on that platform** — theirs, or one you built for them. **Ask; do not go looking.** A codebase sitting in a neighbouring folder is not automatically a reference — it may be internal, abandoned, or on a platform this project has just ruled out. Confirm it is a deliberate template before reading a line of it, and drop it the moment the platform decision moves.
+
+If it is confirmed, read its manifest and mirror it: same language version, same dependencies, same database layer, same design-system target, same build and release scripts.
+
+This is not laziness, it is the single cheapest quality decision available:
+
+- The stack is **already proven to ship** on that platform, including the tedious parts — signing, notarization, auto-update, crash reporting.
+- The **design system already exists**, so the visual language is consistent and free.
+- **Components you were about to spec may already be built.** In a real run, a client wanted a glass-blurred panel with an inset white card; the reference app's design-system target already contained exactly those two components. That is a whole task that evaporated because someone looked.
+- The person maintaining both apps only has to know one stack.
+
+So: read the reference app's `Package.swift` / `package.json` / equivalent, its design-system folder, and its `scripts/`. Record the inherited stack on the map's tech-stack node, and **name the reference app in the notes** so the builder knows where to copy patterns from rather than inventing them.
+
+If there is no reference app, choose a boring, well-trodden stack and say why.
+
+## 5. Find the hard part, and find who already solved it
+
+**Every app has exactly one genuinely hard thing.** The rest is screens, forms and lists. A plan that has not named the hard thing is not a plan — it is a wish, and the build will discover it in week three.
+
+Say which part it is, out loud, then:
+
+1. **Search for prior art before designing anything custom.** Someone has almost certainly solved this. Use WebSearch/WebFetch; look for maintained libraries, platform-native frameworks (often the best answer and the most overlooked), and open-source repos.
+2. **Check the licence, every time.** The most googlable library in a field is frequently the one that cannot be used commercially. This kills projects late and expensively.
+3. **Prefer the platform-native framework** where one exists — no dependency, no licence question, better performance, and it survives OS updates.
+4. **The hard part becomes task #1**, as a throwaway spike that proves it works on real input before a single screen is designed.
+
+Method, the licence trap with worked examples, and how to write the spike: `references/hard-part-first.md`.
+
+## 5a. Run the systems checks — the questions nobody asks for
+
+Four more questions, asked out loud in the Think phase, before the v1 cut and before the gate. Nobody requests any of this and no user can describe it, but each one is **cheap as a decision and expensive as a retrofit**. The fifth — who the users are — was §3a, because it changes the feature list.
+
+1. **"What figures does this app rely on that somebody else publishes — and what happens on the day they change?"**
+   Tax and duty rates, statutory thresholds, interest or benefit rates, tariffs, postage, currency, compliance limits, licence fees, minimum wage. If there are any: **they belong in the database, not in the code**, as rows carrying **the dates they apply between**; the app resolves the value that applied **at the date of the thing being modelled** — including across a change already announced for a future date; anything saved **records which version produced it**; the app **knows when its data has expired** and says so. **Do not assume an API exists** — for many public datasets there is none, and scraping the publisher's site is more fragile than a maintained table because it fails by shipping wrong numbers rather than by stopping. Plan the honest version: a table, an import script, a dated review, and a written record of sources. And **give the owner a screen to edit it**, because they will need to model an announced-but-not-yet-legislated change before you can ship an update.
+2. **"Is this app one of several that will share the same core logic?"**
+   If yes, the shared part is **one package every product imports** — never copied, never reimplemented. It must be **pure**: no database, no network, no framework, no clock, no randomness; everything it needs is passed in. Give it a **version number**, and split it into **small files by topic**, because one huge file is what makes people copy a function out instead of importing it. Two copies always diverge, silently, until two parts of the business quote different numbers for the same thing.
+3. **"Does the organisation already have a database, and is another product — or another person — already working in it?"**
+   **Default to a separate database per product**, with the same ownership boundary in both so they can be merged later. Merging two well-shaped databases is a migration; unpicking one tangled database is a rebuild.
+4. **"Does the user need to know how current the data is, or prove where a figure came from?"**
+   If an output drives a financial, legal or medical decision it must show **what data it used and as at when**. Never assert currency the app cannot verify. Label estimates and assumptions **where they appear**, and let the user override them.
+
+Reasoning, the rules in full, and a worked example for each: `references/data-and-shape.md`.
+
+## 6. Cut it to a v1 that can actually ship
+
+They will describe the finished product. Your job is the **first version that delivers the job in §2 end to end** — one complete loop, working, sellable.
+
+- **One loop, whole.** A user opens it, does the main thing, and gets the outcome. Nothing half-present.
+- **Cut breadth, never depth.** Five features at 60% is a broken app. One feature at 100% is a product.
+- **Tracking features are not v1 features.** Anything whose value is "the user types in what they did" has near-zero pull and dies in week two. Features where the app *does something for them* are what people come back to. See `references/v1-scope.md` — this is the most common way an idea-plan goes wrong.
+- **The revenue gate:** if the person needs this to make money, ask *"how does someone pay for this?"* and make sure the answer exists in v1. A v1 with no way to take money cannot produce revenue no matter how good it is, and this gets missed on nearly every plan because it is not a feature anyone is excited about.
+- **Ask what the real cost is — it is often content, not code.** Apps that need a media library, a data set, an exercise catalogue or a document corpus are usually 20% software and 80% acquiring the content. If so, say it now and plan the pipeline, because it is the schedule risk. `references/v1-scope.md`.
+
+Name what is *not* in v1 as explicitly as what is — an unspoken cut is heard as a broken promise later.
+
+## 6a. THE GATE — read it back, get a yes
+
+**Nothing has been written yet. Do not proceed without an explicit go-ahead.**
+
+Narrate the plan back the way they described it in §3 — *"they open it, they see X, they click Y, then Z happens"* — then add the things they could not have supplied themselves:
+
+1. **The platform call and why** (one sentence, repeatable).
+2. **The hard part, and the named thing that solves it** — including its licence.
+3. **Every kind of user, and what the owner gets** — the admin surface, the plans, and what only the owner can edit (§3a).
+4. **Any figures somebody else publishes**, where they will live, who updates them and how often (§5a) — plus the database call, if there was one to make.
+5. **What v1 is, and explicitly what it is not.**
+6. **How someone pays**, if money is needed.
+
+Then ask, in these words: **"What did I get wrong, and what's missing?"**
+
+People correct a story. They rubber-stamp a feature list. This is the last cheap moment to be wrong — after §7 the plan exists as a map, notes and tasks, and changing it costs real work.
+
+Iterate here as many times as it takes. **Only when they say yes, continue.**
+
+## 7. Write the map
+
+Identical mechanics to `cs-build-import-codebase` §4 — the node model, the one-sentence card rule and the notes-are-root-only constraint all come from `target-map.md`. Do not re-derive them.
+
+```bash
+codespring mindmap set-info --title "..." --description "..."
+codespring mindmap tech-stack --replace --add '[{"id":"tech-...","title":"...","description":"Frontend"}, ...]'
+codespring mindmap features --add '[{"title":"Today","description":"..."}, ...]'   # CORE features; keep the returned ids
+codespring feature create --parent <coreId> --title "..." --description "..."       # sub-features
+codespring mindmap note <coreId> --title "How it works — X" --text "$(cat note.txt)"
+```
+
+**`codespring mindmap features --replace` does NOT replace — it appends and duplicates** (`pitfalls.md`). Diff by title and add only what is missing. Recovery: `codespring feature delete <id> --yes`.
+
+**The note is the whole deliverable on this path.** With no code to read, the note is the *only* context the PRD generator gets — a thin note here produces a thin PRD, and there is no repo to fall back on. Each core feature's note carries:
+
+1. **What this feature does**, in the user's own words wherever possible.
+2. **The screens and the journey** — what the user sees, clicks, and gets.
+3. **The decisions and why** — platform, chosen library and its licence, the data model in plain terms, and anything deliberately deferred with the reason.
+4. **The §5a answers that belong to this feature** — which published figures it uses and where they live, what it shares with another product, who is allowed to see and edit each thing, and what the interface has to show about how current the data is. These are invisible in a feature list and they are what the PRD and the tasks need in order to build the right shape.
+5. **What is explicitly not in v1**, so it does not get quietly built.
+
+Write the notes **before** generating any PRD.
+
+## 7a. Hand off to `cs-build-ui-mockup` — BEFORE the PRDs
+
+**Do not generate PRDs from a plan nobody has seen.** The map and notes are agreed in words, and words are not enough: a person will sign off a written plan they have not actually understood, because prose lets both sides fill the gaps differently and neither notices.
+
+**Run `cs-build-ui-mockup`.** It builds a throwaway clickable mockup from these notes, runs the review that surfaces what the plan could not express — screen order, hierarchy, position, and choices that turn out to be incomplete — and writes every correction back into the notes and tasks.
+
+A real run produced **eleven corrections in ten minutes** from a plan that had already passed the gate and looked complete. None had surfaced in written review.
+
+Come back here only if the review changes the feature set. Otherwise the chain continues: mockup → `cs-build-create-prd` → `cs-build-create-tasks`.
+
+## 8. Verify
+
+Run the check, don't eyeball it:
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-verify
+node ../codespring/scripts/check-map.mjs   /tmp/cs-verify --expect-core <the count you intended>
+```
+
+Core count matches; no sub-features flattened to top level (re-parent with `codespring feature update <subId> --parent <coreId>`); no duplicate titles; one note per core feature. A non-zero exit is a real failure — fix it before reporting. Then give the project link `https://v2.codespring.app/project/<projectId>`.
+
+## 9. Hand off
+
+**PRDs → `cs-build-create-prd`** (Both, per core feature). Never generate a PRD for a feature with no note.
+**Tasks → `cs-build-create-tasks`**, with the §5 spike as task #1.
+**Then → `cs-build-feature`.**
+
+## 10. Report what now exists
+
+One short close, because the person needs to know what they own: the project link, the core features by name, that every one has a note, and **the single next action** — normally *"task #1 is the spike that proves the hard part; do that before anything else."*
+
+---
+
+## What good looks like
+
+- The **job paragraph** exists and was agreed before any feature was named.
+- The feature list came out of a **walked journey**, not a brainstorm, and lands at 4–8 core features a user would recognise as sidebar items.
+- The **platform was chosen on capability** and the consequences were stated, not chosen by default or by fashion.
+- The **hard part is named**, has real prior art with a **checked licence** whose obligation was stated in one line, and is task #1 as a spike.
+- **Every kind of user was enumerated before the feature list closed**, the owner has an admin surface, and permissions are stated as enforced on the server and in the database.
+- **Every figure somebody else publishes was named**, lives in dated rows rather than in code, resolves by the date being modelled, and has a real plan for staying updated — with no assumption that an API exists.
+- Where the same logic runs in more than one place, it is **one pure, versioned package** rather than a second copy, and the database decision was **deliberate** rather than inherited.
+- The new project got **its own directory**, and no sibling project's link was clobbered.
+- Where a proven app on the same platform already existed, its **stack and design system were inherited** rather than reinvented.
+- **v1 is one complete loop**, and if the person needs money from it, there is a way to pay in v1.
+- If the real cost is **content rather than code**, that was said out loud and a pipeline exists.
+- The **notes are thick** — they are the only context a PRD will get on this path.
+- **Nothing was written to CodeSpring before the gate**, and the plan was read back as a story with *"what did I get wrong?"* asked out loud.
+- The plan contains **technical judgement they could not have supplied themselves.** If it is only their words tidied up, it is dictation.

--- a/.agents/skills/cs-build-plan-app/references/data-and-shape.md
+++ b/.agents/skills/cs-build-plan-app/references/data-and-shape.md
@@ -1,0 +1,139 @@
+# The systems questions — data that goes stale, and the shape the app has to be
+
+Five checks that decide whether the app survives its second year. The named examples are **labelled worked examples** from real runs, not assumptions about the app in front of you.
+
+## Why these belong in planning and nowhere else
+
+Nobody asks for any of this. They are not features, they never appear in a walked journey (`elicitation.md`), and a user cannot describe them because they are invisible until the day they go wrong. But each one is **cheap as a decision and expensive as a retrofit** — changing where a number lives, who is allowed to edit it, or which database it sits in means touching every screen that reads it, and in one case it means changing the permission model of the whole app.
+
+So they are asked **during the Think phase, before the plan is read back at the gate.** The actor question (§3 below) has to come earliest of all, because it adds features to the list.
+
+The five, in the words to ask them in:
+
+| # | The question to ask |
+|---|---|
+| 1 | **"What figures does this app rely on that somebody else publishes — and what happens on the day they change?"** |
+| 2 | **"Is this app one of several that will share the same core logic? Is the same calculation, ruleset or model going to run in more than one place?"** |
+| 3 | **"Who are all the different kinds of people who use this, what can each of them see and do, and who administers it?"** |
+| 4 | **"Does the organisation already have a database, and is another product — or another person — already working in it?"** |
+| 5 | **"Does the user need to know how current the data is? Would they ever need to prove where a figure came from?"** |
+
+---
+
+## 1. Reference data that goes stale
+
+> **"What figures does this app rely on that somebody else publishes — and what happens on the day they change?"**
+
+Follow-ups: *how often do they change, who publishes them, and does anything tell us when they have?*
+
+**Reference data** here means any number the app uses but does not own — someone else decides it, publishes it on a schedule, and it is wrong for everyone from the moment it changes until the moment the app is updated. It is far more common than people expect: tax and duty rates, statutory thresholds, interest or benefit rates, shipping tariffs, postage prices, currency conversions, compliance limits, licence fees, minimum wage, contribution caps, mileage allowances.
+
+If the answer to the question is "none", say so and move on. If it is anything else, these rules apply.
+
+### The rules
+
+- **Reference data belongs in the database, not in the code.** This is the whole decision, and it is one sentence long. If a rate is typed into the code, updating it is a developer editing a file and shipping a new version of the app. If it is a row in a table, updating it is a data change — someone edits a value and every user has the new number immediately. Same number, completely different cost, forever.
+- **Every row carries the dates it applies between, not just a current value.** Two extra columns — *applies from* and *applies until* — turn a single figure into a history. Without them the app can only ever answer "what is it now", and it silently forgets that it ever said anything different.
+- **The app resolves which value applied at the date of the thing being modelled, not "the current one".** This is the rule people skip, and it matters in both directions. Looking backward: a document produced for last year must use last year's figures. Looking forward: **a projection that crosses a known future change must use the new value after that date** — an app modelling ten years ahead, with a rate change already announced for next April, is wrong from year two onward if it uses today's number all the way through.
+- **Anything the app saves that used those figures records which version produced it.** Store the inputs, the result, and the identifier of the reference data set behind it. Otherwise correcting a figure later silently changes a document a customer has already received, printed, or sent to their accountant — and nobody can reconstruct what the app said at the time or explain the difference.
+- **The app knows when its own data has expired, and says so.** If today is past the end date of every row, the app must show that it can no longer verify these figures, rather than continuing to present them as current. Software asserting currency it cannot check is the thing that costs trust (§5).
+- **Do not assume an API exists.** For a great many public datasets there is no feed at all, free or paid, and there never has been. Scraping the publisher's website is *more* fragile than a maintained table, not less: it breaks silently whenever a page is redesigned, and it fails by shipping a wrong number rather than by stopping. The realistic pattern, and the one to plan for, is unglamorous and reliable: **a table, a small import script, a dated annual review, and a written record of where each figure came from and when it was last checked.** Say this out loud at plan time, because "can't it just fetch them automatically?" comes up in every one of these conversations and deserves a settled answer rather than a repeated one.
+- **Give the owner a way to edit it.** They will need to model a change that has been announced but not yet legislated, or to correct something you got wrong, before you can realistically ship an update. That is an editing screen for the owner and nobody else, which is §3's job — and it is the most common reason the admin surface gets discovered too late.
+
+### Where it lands in the plan
+
+The reference table is part of the data model in the note; the annual review is a real, recurring job that belongs in the plan rather than in someone's memory; the owner's editing screen is a feature on the map. None of the three appears unless the question is asked.
+
+> **Worked example.** A property-investment calculator covering eight jurisdictions. Every jurisdiction's tax and duty tables were typed directly into a web page — and the same tables existed in **five places across two repositories**, two of which had already drifted, so the same property produced different figures depending on which page the user opened. **No government API exists for any of it**, in any of the eight jurisdictions, so the automatic-fetch idea that everybody proposes was never available. The correct shape was one dated table per jurisdiction in the database, a resolver that picks the rows applying at the date being modelled, a stamped version on every saved report, an expiry warning, and a screen where the owner can enter next year's rates the week they are announced.
+
+---
+
+## 2. Shared logic across more than one product
+
+> **"Is this app one of several that will share the same core logic? Is the same calculation, ruleset or model going to run in more than one place?"**
+
+Ask it even when the answer looks obviously "no" — a web app plus its own admin tool is already two places, and "we'll do a mobile version later" is the same answer arriving a year late.
+
+If it is genuinely one product with one place the logic runs, skip the rest of this section.
+
+### The rules
+
+- **The shared part becomes one package that every product imports.** A *package* here just means a self-contained folder of code with a name, which other projects depend on the way they depend on any other library. Never copy-pasted between projects, never reimplemented in a second language because it was easier at the time.
+- **The shared part is pure.** *Pure* means: given the same inputs it always returns the same answer, and it touches nothing else. No database access, no network calls, no framework imports, no reading the clock, no randomness. Anything it needs — including today's date and the reference data from §1 — is **passed in as an argument.** That constraint is not tidiness; it is the only thing that makes the same code usable in a browser, on a server, in a background job, and in a second product, and it is what makes it testable without any of them.
+- **Give it a version number**, and let anything it produces record which version produced it. Paired with the reference-data version from §1, that means any saved output can be explained: these inputs, that data set, this version of the rules.
+- **Structure it as several small files by topic, not one large one.** A single enormous file is precisely what makes the next person copy one function out of it instead of importing the package — and that copy is where the divergence starts.
+
+### The failure this prevents
+
+**Two copies of the same logic always diverge, and the divergence is invisible.** Nobody edits both. There is no error, no crash and no failing test — just two parts of the business quoting different numbers for the same thing, usually discovered by a customer, and usually long after both numbers have been sent to people.
+
+> **Worked example.** The same property calculator had its calculation engine in two places. The copy the secondary pages used sat a full financial year behind for nine days, so the identical property produced different government charges depending on which page it was opened from. Nothing failed and nothing was logged; there were no tests to notice. One imported package, pure, with a version stamped onto every saved report, removes the entire class of problem.
+
+---
+
+## 3. Who uses it, and what each of them can reach
+
+> **"Who are all the different kinds of people who use this, what can each of them see and do, and who administers it?"**
+
+**Ask this before the feature list is final**, because the answer adds features to it. It belongs next to the walked journey in `elicitation.md` — that section finds the second user who *puts the content in*; this one finds every remaining actor and what each is allowed to reach.
+
+### The rules
+
+- **Enumerate every actor, including the ones people forget.** They will describe one. There are usually four or five: the end customer; **their** customers or clients, who often receive an output without ever logging in; staff or team members; partners, resellers or referrers; and **the owner of the business running the app**. Write the list down, and for each one write what they can see and what they can do.
+- **Almost every app needs an admin surface for the owner.** A place to see who has signed up, manage plans and access, and edit the data the app depends on. It is missed at planning time on nearly every project, and it is expensive to retrofit for a specific reason: **it changes the permission model**, so it is not a screen bolted on at the end but a distinction that has to run through the data from the first day.
+- **Some data must be editable by the owner and by nobody else.** The reference data in §1 is the classic case: every user reads it, exactly one person changes it. That is a different kind of ownership from "this row belongs to this user", and both have to exist in the data design from the start.
+- **Ask what plans or tiers exist and what each one unlocks.** The answer decides whether entitlement — what this account is allowed to do — is a single column on an account, or a whole subsystem with limits, counters and upgrade paths. Those are very different builds and the difference is settled by one question.
+- **Permissions are enforced at the database and on the server, never only in the interface.** Hiding a button is not access control. The rule to state plainly: every request re-checks who is asking and what they own, on the server, and the database itself refuses to return rows that belong to somebody else — regardless of what the screen showed.
+
+> **Worked example.** The same property calculator was described as a tool for financial advisers, and the plan on the table had exactly one kind of user. There were four. The adviser used it; **the adviser's client** received the report as a document and was the person whose trust the whole thing depended on; the adviser's **firm** wanted to see what its people were producing; and **the owner of the business selling the app** needed to see who had signed up, manage their plans, and update eight jurisdictions of tax tables himself the week the budgets landed. Only the first was in the plan. The fourth is the one that changes the permission model.
+
+---
+
+## 4. Where the data lives, and who else is in it
+
+> **"Does the organisation already have a database, and is another product — or another person — already working in it?"**
+
+The tempting answer is "we already have one, put it in there." It is almost always wrong.
+
+### The rules
+
+- **Sharing a database between two products is the fastest route to confusion.** Three predictable costs: a table count where most of the tables belong to something else, so nobody can see the shape of either product; **name collisions** between them, where both want a table or a column called the obvious thing and one of them has to be renamed into something misleading; and permission mistakes, where a rule written for one product exposes its data through the other.
+- **Default to a separate database per product.** Same shape in both — in particular the same **tenant boundary**, meaning every row carries which account or organisation owns it, expressed the same way in both places. That is what keeps a later merge possible.
+- **Merging two well-shaped databases is a migration. Unpicking one tangled database is a rebuild.** That asymmetry is the whole argument: separate is reversible, shared is not.
+- **The argument is strongest when a non-technical owner is actively working in the existing database.** Two people with different tooling in one database — one editing rows through a dashboard by hand, one shipping schema changes from code — will collide, and the collision usually destroys someone's work rather than raising an error.
+
+> **Worked example.** An owner had a database already in daily use by another product, and was editing rows in it himself through the provider's dashboard. Adding the new app's tables there would have put both products' tables in one list, put a hand-editing human and an automated migration in the same place, and made every permission rule twice as hard to reason about. Separate database, identical ownership column in both, merge later if it is ever actually wanted.
+
+---
+
+## 5. Freshness and provenance in the interface
+
+> **"Does the user need to know how current the data is? Would they ever need to prove where a figure came from?"**
+
+Checks 1 and 2 decide what the app *knows*. This one decides what it *says*, and it is the half that customers actually see.
+
+### The rules
+
+- **If an output is used to make a financial, legal or medical decision, show what data it used and as at when.** A line saying which figures were applied and the date they were current to, on the screen and on anything exported or printed. This is what makes an output defensible months later, when the numbers have moved and somebody asks why the document says what it says.
+- **Never present a figure as authoritative when the app cannot verify it is current.** A printed claim like *"rates current for this financial year"* sitting next to numbers that nothing checks is worse than printing no claim at all: it converts an ordinary staleness problem into a false statement the business has made in writing.
+- **If a value is an estimate or an assumption, say so where it appears, and let the user override it.** Not in a footnote, not in a help page — next to the number. The nastiest version of this failure is a field that is honestly labelled as estimated in one mode and loses the label in another, so the same guess is presented as a precise result.
+- Assumptions presented as precise results are **a trust problem, not a cosmetic one.** A user who catches one number that was quietly invented stops believing all the others, including the correct ones, and does not come back to check.
+
+> **Worked example.** A generated property report named its government source and financial year beside figures that nothing validated — including for an unrecognised location, where every government charge came out as zero and the report presented the zeros with the same confidence as everything else. The fix was not a bigger disclaimer: it was the app knowing which dated data set it used, printing that data set and its as-at date on the report, refusing to produce charges at all for a location it does not recognise, and labelling every estimated input as estimated at the point it is shown.
+
+---
+
+## What good looks like
+
+- [ ] Every figure the app relies on that **somebody else publishes** is named, with how often it changes and who publishes it.
+- [ ] That data lives in **dated rows in the database**, never in code, and the app resolves the value that applied **at the date being modelled** — including across a known future change.
+- [ ] Saved outputs record **which version of the data and which version of the logic** produced them.
+- [ ] The app can tell when its data has **expired**, and says so instead of asserting currency.
+- [ ] There is a plan for **keeping it updated** — a table, an import script, a dated review, a record of sources — and no assumption that an API exists.
+- [ ] If the same logic runs in more than one place, it is **one imported package, pure and versioned**, split into small files by topic.
+- [ ] **Every actor is listed** with what they can see and do — including the customer's customer, and the owner of the business.
+- [ ] There is an **admin surface for the owner**, including editing the reference data, and it was in the plan rather than added later.
+- [ ] **Plans and tiers** are settled, so entitlement is scoped as either a column or a subsystem deliberately.
+- [ ] Permissions are **enforced on the server and in the database**, and the plan says so in those words.
+- [ ] The database decision is **deliberate** — separate per product by default, with the same ownership boundary in both.
+- [ ] Anything used for a real decision shows **what data it used, as at when**, and every estimate is **labelled and overridable** where it appears.

--- a/.agents/skills/cs-build-plan-app/references/elicitation.md
+++ b/.agents/skills/cs-build-plan-app/references/elicitation.md
@@ -1,0 +1,156 @@
+# Getting the real app out of someone's head
+
+Applies whether the input is a live conversation, a sales-call recording, a voice note, or three screenshots and a paragraph. The named examples are **labelled worked examples** from real runs, not assumptions about the person in front of you.
+
+## The problem this solves
+
+> **They do not know what they don't know, and they do not know what they need.**
+
+A non-technical person describes an app in terms of things they have already seen. They will ask for the thing from the Instagram reel. That request is **evidence**, not a specification — it tells you what appealed to them, and your job is to find out *why* it appealed, because the why is the actual requirement.
+
+Two failure modes, and they are opposites:
+
+- **Dictation.** You write down what they said, tidied up. The plan contains no technical judgement, no platform reasoning, no prior art, and no cut list. It reads well and it is worthless — they could have written it themselves.
+- **Substitution.** You decide what the app should be, because you can see a better product. They nod along in the call and then never recognise the thing that gets built.
+
+The line: **they own the *what*, you own the *how*** — and you own telling them when the *what* costs more than they think.
+
+---
+
+## Mining a recording
+
+**Read or listen to all of it before you ask a single question.** Turning up with questions the recording already answered is the fastest way to lose a non-technical person's confidence — they told you, and now they think you weren't listening.
+
+Pull out, verbatim where you can:
+
+| Look for | Why it matters |
+|---|---|
+| Who it is for, in their words | The audience constrains everything — a 78-year-old beginner is a different app from a 30-year-old gym-goer |
+| Every screen, button, moment they described | This is the journey; you will replay it in the walkthrough |
+| Every **number** they said | Numbers are hard requirements in disguise: *"five minutes is the floor"*, *"up to twenty"*, *"three times a week"* |
+| Every constraint | Platform, offline, price, deadline, audience age, accessibility |
+| Every reference app or screenshot, **and what they liked about it** | The *what they liked* is the requirement; the app itself is just where they saw it |
+| **Anything they said twice** | Repetition marks what actually matters to them. This is the single highest-signal thing in a transcript |
+| Anything they rejected, and why | Prevents you proposing it back to them in an hour |
+| Their **own domain expertise** | Often the most valuable asset in the whole project and almost always under-used |
+
+**Extract, do not summarise.** Summarising is lossy in exactly the wrong direction — it keeps the features and drops the reasons.
+
+**Keep their phrasing all the way into the note.** *"Anything lower than five minutes is not worth the time"* survives into the note and eventually into the PRD, carrying its own justification. *"Configurable session duration"* is the same fact with the reason amputated, and the reason is what stops someone building a slider from 1 to 90.
+
+### What a transcript will not give you
+
+Recordings are full of *what* and empty of *why*. They also systematically miss:
+- what happens when it goes wrong
+- what brings someone back tomorrow
+- how anyone pays
+- what happens the very first time someone opens it, before there is any data
+
+Those are your questions.
+
+---
+
+## The walkthrough — the elicitation engine
+
+This works on people who cannot describe software:
+
+> *Close your eyes and imagine you're using it. It's open in front of you. What's the first thing you see? What do you click? What happens then?*
+
+Walk it as **a journey, not a feature list**:
+
+1. They open it. What is on screen?
+2. What do they click first?
+3. Now they are doing the main thing they came for — describe it, moment by moment.
+4. They finish. What do they see?
+5. What brings them back tomorrow?
+6. What happens the **first** time they ever open it, when there is nothing in there yet?
+
+Step 6 is the one everyone forgets, and it is where non-technical apps most often feel broken — an empty dashboard with no data reads as "this doesn't work."
+
+**Sidebar-first.** For desktop or web, ask literally: *"if there's a sidebar down the left, what's in it?"* This produces the core feature list almost directly, and it produces one the user recognises — which is exactly the 4–8 sidebar-item test in `target-map.md`. It is a much better question than *"what are your core features"*, which produces a wish list.
+
+### Questions that work
+
+- *"What happens today, without the app?"* — finds the real job and the real competitor, which is usually a notebook, a spreadsheet, or nothing.
+- *"Who is the person opening this, and what kind of day are they having?"* — surfaces the audience constraints they would never think to state.
+- *"What would make them close it and not come back?"* — finds the trust-breakers. Extremely high yield.
+- *"Show me the thing you saw that you liked. What specifically about it?"*
+- *"If it only did one thing brilliantly, which one?"* — the v1 cut, asked in a way they can answer.
+- *"How does somebody pay for this?"* — see `v1-scope.md`. Nearly always missing.
+- *"What do you already have that we should use?"* — audience, content, an email list, professional credibility, a domain. Usually under-used.
+
+### Questions that do not work
+
+- *"What are your core features?"* → a wish list, not a product.
+- *"Do you want it to be simple or powerful?"* → everyone says both.
+- *"Should it be a web app or a native app?"* → not their decision, and they will answer on vibes. Decide it on capability (`platform-choice.md`) and then **tell them the call and the reason**.
+- *"What's your tech stack preference?"* → they do not have one, and asking makes them feel stupid.
+- Anything with an acronym in it.
+
+---
+
+## Handling "I saw this on Instagram"
+
+Reference material is good — take it. Then interrogate it once:
+
+1. **What specifically did you like?** Usually one mechanic, not the whole app.
+2. **Would your person like it, or do you like it?** Not the same, especially across an age gap.
+3. **What does it do that yours must not do?**
+
+Then say plainly whether the thing is cheap or expensive to build. A reference that is one afternoon of work should be taken wholesale; one that is the entire product should be discussed now, not discovered in week three.
+
+**Worked example.** A client wanted a streak display copied from a cycling app — flame, day-of-week dots, the lot. Cheap to build, so take it. But the reference counted *consecutive days*, and the app was strength training for beginners over 50, where **rest days are physiologically required**. A daily streak would have punished correct behaviour and broken on week one. The fix was to keep the exact visual and change the unit to *weeks hitting a target* — which the reference screenshot was already showing anyway ("1 Weeks"). Same design, opposite behaviour. **Copy the look; re-derive the rule.**
+
+---
+
+## The second user nobody mentions — who puts the content in?
+
+People describe the app from the point of view of the person *using* it. They almost never describe the person who **fills it with content**, even when that person is themselves.
+
+If the app shows exercises, lessons, templates, recipes, programmes, questions, or any other catalogue, ask all of these:
+
+- **Where does the content come from on day one?** Shipped inside the app, or entered by someone?
+- **Who adds more later, and how?** Them, in a tool you have to build? You, by hand? Nobody?
+- **Does it differ per user?** A coach assigning different programmes to different clients is a **completely different app** from a fixed catalogue everyone gets — accounts, assignment, roles, a second interface.
+- **Who decides the order?** The app, on a rule? The user, freely? The coach, in advance?
+- **What happens on day two?** The single most-skipped question. *Is it the same as day one?* If not, something has to decide — and that decision rule is a feature nobody has mentioned yet.
+
+**Why this matters more than it sounds:** an authoring tool is a second application. It has its own screens, its own validation and its own testing, and it is routinely 30–50% of the build while appearing nowhere in the feature list. It is also the most common cause of *"I thought we were nearly done."*
+
+**The cheap answer is almost always the right v1 answer:** ship a fixed catalogue inside the app, authored by hand as data before release. No authoring UI, no accounts, no assignment. Add the tool later, once anyone has proved they want to change the content.
+
+**Worked example.** A coach's exercise app: the assumption was that she would need an admin app to record and add exercises. The v1 answer was a hand-authored catalogue file shipped in the bundle — nothing to build, nothing to film, nothing for her to learn. The admin tool became a v2 question to be answered by whether she ever actually asks for it.
+
+**Watch for the ordering rule specifically.** *"They shouldn't do the same thing every day"* sounds like a preference and is actually a scheduling feature with real edge cases — what if they skip a day, do half a session, or do it twice? Get the rule stated in one sentence at plan time (*"a cursor through the unlocked list that advances only on completion"*), because otherwise it gets invented during the build.
+
+---
+
+## When the input is one long ramble
+
+Common, and fine. Do this in order:
+
+1. **Separate ideas from the app.** People bring three or four ideas to a planning session. Get them listed and get one chosen before planning anything. The others are recorded and parked, not discussed.
+2. **Separate the app from the business.** *"I need money by September"* is a real constraint that shapes v1 scope, but it is not a feature. Note it under the job (§2 of the skill), where it belongs.
+3. **Separate what they want from what they have seen.**
+4. **Find the thing they said twice.** That is the centre of the app.
+
+---
+
+## Before you leave the interview
+
+You need all of these. If any is missing, ask now — it is cheap here and expensive later.
+
+- [ ] The job paragraph: **who**, **what they're trying to get done**, **what happens today without it**, **how we know it worked**.
+- [ ] The journey, walked start to finish, including the very first launch.
+- [ ] Every number they stated.
+- [ ] The audience's real constraints — age, ability, device, environment, how much patience they have.
+- [ ] What would make someone close it and never come back.
+- [ ] How money changes hands, if it needs to.
+- [ ] What they already have that the plan should use.
+- [ ] What they have explicitly rejected.
+
+## The test
+
+**Would they recognise this as their app, and does it contain at least one thing they could not have told you?**
+
+Both halves are required. The first alone is dictation. The second alone is substitution.

--- a/.agents/skills/cs-build-plan-app/references/hard-part-first.md
+++ b/.agents/skills/cs-build-plan-app/references/hard-part-first.md
@@ -1,0 +1,143 @@
+# Find the hard part, and find who already solved it
+
+## Every app has exactly one genuinely hard thing
+
+The rest is screens, forms, lists and buttons — well-understood work that an AI agent does quickly and reliably. One part is not, and it decides whether the app is possible at the quality the person imagines.
+
+**A plan that has not named the hard part is not a plan.** It is a wish with a feature list attached, and the build discovers the hard part in week three, which is the worst possible moment: after the screens are built around an assumption that turns out to be false.
+
+### Finding it
+
+Walk the journey from `elicitation.md` and ask at each step: *if I had to build only this, would I know how?*
+
+The hard part is usually one of:
+
+| Kind | Examples |
+|---|---|
+| **Real-time perception** | camera, pose, audio, video processing |
+| **Getting data out of a mess** | receipts, PDFs, faxes, handwriting, scraping |
+| **A domain rule nobody has written down** | tax logic, clinical scheduling, compliance |
+| **Sync, offline-first, or multi-user state** | conflict resolution is always harder than it looks |
+| **A content or data corpus that must exist** | see `v1-scope.md` — often the real cost, and it is not a coding problem at all |
+| **An integration you do not control** | a system with no API, or a hostile one |
+
+If you genuinely cannot find a hard part, the app is a CRUD app. Say so — that is **good news**, it means fast and cheap, and the person should hear it.
+
+---
+
+## Search for prior art before designing anything custom
+
+Somebody has solved this. Use WebSearch/WebFetch and look, in this order:
+
+1. **The platform's own framework.** The most overlooked answer and frequently the best one — no dependency, no licence question, better performance, maintained by the OS vendor, survives OS updates.
+2. **A maintained cross-platform library** with real adoption and recent commits.
+3. **An API** you can pay for — sometimes correct for v1, but check the per-user cost against the price of the app before committing.
+4. **A research repo.** Usually the worst option: unmaintained, undocumented, and see the licence trap below.
+
+Judge each candidate on: **licence**, **maintenance** (last commit, open issues), **platform fit**, **whether it runs locally or needs a server**, and **whether a non-expert can install it** — a dependency that needs Python, CUDA and a compiler is not viable for the audience these apps are built for.
+
+---
+
+## The licence trap — check it, every time
+
+**The most googlable library in a field is very often the one that cannot be used commercially.** This kills projects late, after the app is built around it, and the person planning has no idea it is a risk.
+
+Two patterns to recognise:
+
+- **Academic / non-commercial licences.** Free to try, illegal to sell. The author will license commercially for a fee, sometimes a large one.
+- **AGPL and other strong copyleft.** Legally usable, but the reciprocity obligations are usually incompatible with shipping a closed commercial app. Many popular ML repos are AGPL specifically to sell commercial exemptions.
+
+**Permissive (MIT, Apache-2.0, BSD) is what you want**, and a platform-native framework has no licence question at all.
+
+### Say the permissive part out loud — the fear is usually misplaced
+
+Non-technical people hear "open source" and assume selling is forbidden, then rule out a perfectly good library. A real client asked *"can I really sell using Apache-2.0?"* and was about to reject the correct answer over it. Three sentences fix it, so say them:
+
+| Licence | Can you sell a closed-source app with it? | What you must do |
+|---|---|---|
+| **MIT / BSD / Apache-2.0** | **Yes.** Commercial use and closed source are explicitly permitted | Include the licence text (an acknowledgements screen). Apache-2.0 also asks you to pass on any `NOTICE` file |
+| **LGPL** | Usually, if dynamically linked | Get advice if you are static-linking |
+| **GPL / AGPL** | **No**, not closed-source. AGPL extends this to network use | Buy a commercial exemption, or do not use it |
+| **Non-commercial / academic** | **No**, at any price without a negotiated deal | Contact the owner; expect real money |
+| **Platform framework** (Apple, Microsoft, Android) | **Yes** | Nothing — it is part of the OS |
+
+**The distinction that matters is permissive vs copyleft vs non-commercial, not open vs closed.** Say which bucket the chosen library is in and what the obligation is, in one line, in the note. It removes a blocker that has nothing to do with engineering.
+
+### Permissive still has obligations — make them a task
+
+"You can sell it" is not "you can ignore it". Every permissive licence asks for something small, and because it is small it gets skipped and then discovered at launch. **Write it as a real task on the board**, not as a line in a note nobody opens:
+
+- **Ship the licence text.** MIT, BSD and Apache-2.0 all require the copyright notice and licence text to travel with the distributed software. In an app that means an **Acknowledgements / Open Source Licences screen** — normally under Settings or About — listing each dependency, its copyright line and its full licence text.
+- **Apache-2.0 additionally requires passing on any `NOTICE` file** the project ships, and flagging files you modified.
+- **Keep a `LICENSES/` or `THIRD-PARTY-NOTICES` file in the repo** as the source of truth, generated from the dependency list rather than maintained by hand, so a new dependency cannot silently arrive without its notice.
+- **Model weights can carry a different licence from the code that loads them.** Check both. A permissively-licensed inference library shipping restrictively-licensed weights is a real and easy trap.
+- **Trademarks are not licensed by any of these.** You may use the code; you may not imply the project endorses your product.
+
+None of this is onerous — it is one screen and one generated file — but it belongs in the plan, because the moment to add it is while the app is being built and not the week it ships.
+
+### Worked example — human pose estimation
+
+Real research done for a follow-along exercise app. **The two most searchable options were both unusable.**
+
+| Option | Licence | Verdict |
+|---|---|---|
+| **Apple Vision** (`VNDetectHumanBodyPoseRequest`) | System framework, no separate licence | **Chosen.** On-device, no dependency, no install burden, ~19 joints, fast on Apple silicon |
+| **MediaPipe / BlazePose** (Google) | Apache-2.0 | Good fallback. More landmarks, cross-platform, has a browser build |
+| **MoveNet** (TensorFlow) | Apache-2.0 | Viable, very fast, fewer keypoints |
+| **OpenPose** (CMU) | **Non-commercial / academic** | **Cannot ship.** Commercial licence costs real money |
+| **Ultralytics YOLO-pose** | **AGPL-3.0** | **Cannot ship closed-source** without buying the commercial licence |
+
+The lesson generalises: **the top two search results were the two that would have ended the project**, and the right answer was the platform framework nobody searches for because it is not a GitHub repo.
+
+**Verify licences yourself at plan time.** The table above is a starting point and a demonstration of the risk, not a warranty — projects relicense, and a v1 answer can be wrong a year later.
+
+---
+
+## Make the hard part task #1
+
+**The spike comes before any screen.** It is a throwaway whose only job is to answer *does this actually work, on real input, at the quality we need?*
+
+A good spike:
+
+- runs on **realistic input**, not the library's demo video — the actual camera, the actual lighting, the actual crumpled receipt, the actual 70-year-old partly out of frame
+- measures the thing that matters — accuracy, latency, frame rate, error rate
+- has a **written pass/fail threshold decided in advance**, so the result cannot be argued with afterwards
+- is **thrown away**. It is not the foundation of the app.
+
+Write it as the first task with the threshold in the description, e.g. *"Prove pose tracking holds 15fps and correctly identifies elbow angle within 15° on a MacBook webcam, standing 2m back, in a normally lit living room."*
+
+**If the spike fails, the plan changes — and that is the spike doing its job**, cheaply, in week one, before the screens exist.
+
+## Design a fallback before you need one
+
+For anything perception- or AI-based, decide now what happens when it does not work: bad light, unusual body, occlusion, an old machine.
+
+**There must be a path where the user still gets the outcome.** An exercise app whose camera cannot see the user should still run the session with a timer and a manual rep count. A receipt scanner that cannot read the total should ask.
+
+The failure mode to design out is **the app confidently telling the user they are wrong when the app is the thing that is wrong** — that is the fastest way to lose trust permanently, and it is much worse than the app admitting it cannot see.
+
+### Make the feedback signal progress, not judgement
+
+The design move that removes this whole class of failure: **have the interface show how far through the action the user is, rather than whether they are doing it correctly.** Progress cannot be insulting when the sensor is wrong; a verdict can.
+
+**Worked example.** An exercise app was going to draw the tracked skeleton **red until the movement was correct, then green**. Red means *you are doing this wrong* — and on a 78-year-old, partly out of frame, in a dim living room, the app would say it constantly while being wrong itself. The fix kept the identical visual and changed its meaning: neutral while tracking, filling toward green through the range of motion, green flash on a completed rep, **and never red**. Same satisfying feedback loop, structurally incapable of shaming the user.
+
+**And when detection genuinely fails, the app blames itself in plain words** — *"I can't see you clearly, try stepping back"* — never the user. Pair this with the fallback path above so the user still gets the outcome.
+
+### When the client is a licensed professional
+
+If the person commissioning the app is a doctor, lawyer, accountant, therapist or similar, two rules apply and both belong in the notes:
+
+1. **The app must not appear to give professional advice.** Anything that reads as a prescription, a dose, a load, a diagnosis or a legal position is a liability the software should not carry. Have the app *remember and display what the user did last time* instead of *recommending what they should do next*, and put any real guidance in the expert's own words, attributed to them.
+2. **Expert review of the content is a required build step, not a formality.** They are the authority on every entry in the catalogue. Schedule it, name it as a task, and do not ship generated domain content they have not read.
+
+---
+
+## What good looks like
+
+- The hard part is **named in one sentence** the person understands.
+- Real prior art was **searched for**, with two or three candidates compared.
+- The **licence of the chosen option was checked and recorded in the note.**
+- The platform-native option was considered before any third-party dependency.
+- The hard part is **task #1 as a spike with a written pass/fail threshold**.
+- A **fallback path** exists for when it does not work.

--- a/.agents/skills/cs-build-plan-app/references/platform-choice.md
+++ b/.agents/skills/cs-build-plan-app/references/platform-choice.md
@@ -1,0 +1,114 @@
+# Choosing the platform — decide on capability, then state what it costs
+
+Decide this **before** the feature list is final, because it changes what is buildable and what a feature even means. Do not decide it on preference, on fashion, or by asking the user — they will answer on vibes, and it is not their call. Make the call, then **tell them the call and the reason** in one sentence they can repeat.
+
+## The decision
+
+Start from **what the app must physically be able to do**, not from what is trendy.
+
+| If it must | Platform | Why |
+|---|---|---|
+| Use the camera with **real-time local ML** | **Desktop (Mac)** | Native frameworks, real compute, no upload, believable privacy story |
+| Read/write real files, watch folders, run at login, live in the menubar | **Desktop** | The browser cannot, by design |
+| Work **genuinely offline** | **Desktop** | "Offline web app" is a service worker and a cache, and it is a lie in most cases (below) |
+| Be **shared by a link**, found by search, signed up for in one click | **Web** | Distribution is the product |
+| Be sold with a self-serve funnel from day one | **Web** | Payment, accounts and onboarding are solved and expected |
+| Be used **away from a desk** — in a gym, a field, a warehouse | **Mobile** | Nothing else is in their pocket |
+| Be usable on any machine the user happens to be at | **Web** | No install |
+
+**When both fit, pick web** — it is cheaper to distribute, cheaper to update, and easier to sell. Desktop must be *earned* by a capability the browser genuinely cannot provide.
+
+## iOS is almost never the right v1
+
+Say this plainly and say why:
+
+- **Review latency.** Every release, including the fix for the bug you shipped on Friday.
+- **Apple's cut** on in-app purchase.
+- **A developer account and the whole signing apparatus** before anyone can install anything.
+- **Small screen.** For an older audience or anything with a lot on screen at once, this is a real usability loss, not a preference.
+- **The hardest place to iterate**, which is the one thing a v1 must do well.
+
+Exception: the app is genuinely useless anywhere but in someone's hand.
+
+## The constraint that overrules capability — what will they actually build it in?
+
+Capability decides what the app *needs*. It does not decide what the person in front of you can **build and keep running after you leave**, and that second question can legitimately overrule the first.
+
+Ask it explicitly, before the platform is written down:
+
+> **"What are you going to build this in, and who maintains it after I'm gone?"**
+
+The common collision: someone is committed to an AI web-app builder (Base44, Lovable, v0, Replit) — it is what they have paid for, what they half-understand, and the only tool they can imagine still using in six months. **Those tools emit web apps. They cannot produce a native desktop or mobile app at all.** So a plan that says "Mac app" is a plan they cannot execute, however correct the capability argument was.
+
+### How to resolve it — a conversation, not a silent override
+
+Do not quietly plan a platform they cannot build in, and do not quietly drop a capability because their tool is easier. Both failures look like agreement in the room and surface weeks later. Instead, put the real trade on the table:
+
+1. **Name what is lost** by moving to the platform their tool supports. Be specific and technical: *"in a browser this runs at roughly half the frame rate and the privacy claim is harder to make credible."*
+2. **Check whether the loss is actually fatal**, by researching it rather than assuming. Browser capability moves fast and the intuition that "the browser can't do that" is often several years out of date. This is worth a real investigation, not a guess.
+3. **Name what is gained** — usually distribution, cross-platform reach, no signing or notarization, no install friction, payment already solved, and instant updates. These are not consolation prizes; for a v1 that has to be sold quickly they frequently outweigh the capability.
+4. **If the capability is genuinely load-bearing and their tool cannot reach it, say so plainly** and offer the two honest options: build it outside their tool, or change the product so it no longer needs that capability.
+
+### The maintenance question is the real one
+
+A technically better app the owner cannot touch is worse than a slightly worse app they can. Weight this heavily for non-technical owners — the platform they can still ship a fix to in a year usually wins, and that is a legitimate engineering judgement rather than a compromise.
+
+**Record the decision and the reason in the note**, including what was given up. Otherwise the next person reads "web app" and assumes nobody considered the alternative.
+
+---
+
+## "Offline" almost never means offline
+
+When someone says the app should work offline, find out which they mean:
+
+1. **"It shouldn't break on bad wifi"** — a web app with sensible caching is fine.
+2. **"It works on a plane"** — real offline. Desktop, or a serious PWA investment.
+3. **"My data doesn't go to a server"** — that is **privacy**, not offline, and it is a much stronger requirement. It usually forces desktop and it is usually worth a lot in the marketing.
+
+They are three different requirements and people use one phrase for all of them. **Video, in particular, kills naive offline claims** — a follow-along app that streams its content is online whatever the shell is built in.
+
+---
+
+## What each choice actually costs — state these out loud
+
+The platform decision is cheap. Its consequences are not, and they surface in week four.
+
+### Desktop (Mac)
+
+- **Signing and notarization.** Distributing outside the App Store still needs an Apple Developer account, a **Developer ID certificate**, and notarization on every build. Without it users get "cannot be opened because the developer cannot be verified" and they will not proceed. **This is a hard, calendar-time dependency — start it on day one, not at launch.**
+- **Distribution is manual by default** — a signed, notarized DMG on a download page. That is genuinely fine for the first few dozen customers and much faster than it sounds.
+- **Updates** need a mechanism (Sparkle or equivalent). If you defer it, you cannot ship a fix to anyone who already installed. Decide deliberately.
+- **Payment is not solved for you.** No store, no billing. A payment link plus a licence key checked at launch is the cheap answer, and **the licence check must exist from the first build** — it cannot be retrofitted onto customers who already have an unlocked copy.
+- **Mac-only excludes Windows users.** Fine for a design-led or Apple-heavy audience; check it is not half the market.
+
+### Web
+
+- **Accounts, hosting and a database from day one** — there is no local-only web app worth selling.
+- **Payment is solved** (Stripe Checkout, an afternoon).
+- **Updates are free** — everyone is on the latest version always.
+- **Capability ceiling.** Camera works; sustained real-time ML is harder, heavier and less believable on privacy; filesystem is limited; background work is limited.
+- **Distribution is the win.** A link. This is worth more than most capability arguments.
+
+### Mobile
+
+- Everything in iOS above, plus a second platform if Android matters.
+- The only correct answer when the use is genuinely away from a desk.
+
+---
+
+## The privacy angle can decide it
+
+If the app handles **camera video of the user, health data, or anything they'd be uncomfortable uploading**, desktop wins on credibility even where the browser is technically capable.
+
+*"This never leaves your computer"* is true, provable, and worth saying loudly in the UI of a native app. The same claim from a web page is technically achievable and **nobody believes it**. For an older, less technical audience — one that already suspects it is being watched — this is not a footnote, it is a selling point and possibly the deciding factor.
+
+---
+
+## Worked example — a follow-along exercise app for women over 50
+
+- **Camera + real-time pose estimation, every frame** → real compute, and Apple's Vision framework is on-device and free (`hard-part-first.md`).
+- **Video of a woman exercising in her living room** → the "this never leaves your computer" claim is the whole trust story, and it is only credible in a native app.
+- **Audience is 50–78 on laptops** → big screen wins, phone loses.
+- **She wants to sell within weeks** → App Store review is a schedule risk; a DMG on a page is not.
+- **Verdict: Mac app.** Not because Mac is nicer — because pose estimation and the privacy claim both need it.
+- **Consequences stated up front:** Developer ID certificate needed *now*; DMG distribution; payment via link + licence key, **with the licence check in the first build**; no Windows users in v1, accepted deliberately.

--- a/.agents/skills/cs-build-plan-app/references/v1-scope.md
+++ b/.agents/skills/cs-build-plan-app/references/v1-scope.md
@@ -1,0 +1,88 @@
+# Cutting to a v1 that can actually ship
+
+They will describe the finished product. You are planning **the first version that delivers the job end to end** — one complete loop, working, and sellable if it needs to be sold.
+
+## One loop, whole
+
+> A user opens it, does the main thing, gets the outcome, and has a reason to come back.
+
+Everything in v1 serves that sentence. Everything else is later, and *later* is a real place — it goes in the note as "explicitly not in v1", not on the map and not in Kanban.
+
+**Cut breadth, never depth.** Five features at 60% is a broken app that cannot be shown to anyone. One feature at 100% is a product. When the list is too long, remove whole features rather than shipping all of them half-done — this is the single most valuable instinct in scoping and the one people resist hardest.
+
+---
+
+## Tracking features are not v1 features
+
+The most common way an idea-plan goes wrong. It is worth being blunt about.
+
+Sort every proposed feature into two piles:
+
+| | The app does something **for** them | The user does something **for** the app |
+|---|---|---|
+| **Called** | a doing feature | a tracking feature |
+| **Examples** | runs the session, corrects the form, reads the receipt, makes the decision | log your sleep, type in your meals, rate your mood, tick the box |
+| **Pull** | high — they come back because it gives them something | near zero — it is a chore with a delayed, abstract payoff |
+| **Week-two retention** | good | close to nil |
+
+**Manual logging dies.** It dies fastest with older, busier and less technical audiences — exactly the people these apps are usually for. Every "and it'll track their X" feature should be challenged, and the challenge is: *what does the user get back, in the next ten seconds, for typing that in?* If the answer is "a chart, eventually", cut it.
+
+This matters most when someone has a **framework with several parts** and wants all of them in the app. Usually one part is a doing feature and the rest are tracking features wearing a costume.
+
+**Worked example.** A menopause coach with a five-pillar method — sleep, nutrition, movement, brain health, stress — wanted all five in the app. Four of the five would have been manual logging screens. **Only movement was a doing feature**: the app runs the session and corrects the form. Correct v1: build movement properly, alone. The other four are her *coaching*, and the plan says so, so nobody builds four dead screens.
+
+If the other parts genuinely must appear, the cheap shape is **one short daily check-in feeding one number**, not one tracker screen each.
+
+---
+
+## The revenue gate
+
+If the person needs this to make money — and they will have said so, usually early and emotionally — then ask, in these words:
+
+> **"How does somebody pay for this?"**
+
+Then confirm the answer exists in v1. This is missed on nearly every plan because it is not a feature anyone is excited about, and it is the difference between a product and a demo.
+
+Minimum viable answers, in order of cost:
+
+1. **Manual.** A payment link, then send the download or an invite by hand. Perfectly fine for the first few dozen customers, and it can be live tomorrow.
+2. **Payment link + licence key** checked on launch (desktop). Cheap, and **the check must be in the first build** — you cannot retrofit it onto people who already have an unlocked copy.
+3. **Stripe Checkout + accounts** (web). An afternoon, and the right answer if it is a web app.
+
+Also settle: **free trial or not**, and **what a paying user gets that a non-paying one does not.** These are product decisions that change the build, so they belong in the plan and not in a conversation three weeks later.
+
+---
+
+## Ask what the real cost is — it is often content, not code
+
+Some apps are 20% software and 80% acquiring the thing the software shows. If that is true here, **say it now**, because it is the schedule risk and it is invisible on a feature list.
+
+Signals: the app needs an exercise library, a media catalogue, a document corpus, a template set, a curriculum, a reference data set, or anything "we'll generate with AI."
+
+**Beware AI-generated content standing in for a real corpus.** For anything a domain expert or an experienced user will look at, current generation is often not good enough, and being *nearly* right is worse than being obviously wrong — it destroys trust in one glance and it does not come back.
+
+**Worked example.** An exercise app where AI generated an illustration of a bicep curl that was not a bicep curl. The client — a physician — immediately said *"anybody would say this is not a bicep curl, and you lose trust doing those kind of things."* The right plan filmed the expert doing each movement once, which was cheaper, correct by construction, and turned her credibility into the product's.
+
+**The best content pipelines fall out of the architecture.** If the exercise is stored as a sequence of joint positions, then recording the expert once produces the demonstration, the correction targets and the rep counting from a single capture — one artefact, three features. Look for that collapse before planning a content operation.
+
+Plan the pipeline explicitly: **who makes it, how much is needed for v1, how long it takes, and what the quality bar is.** Then cut the v1 content set to the smallest that still delivers the loop — a dozen items done properly beats sixty done badly, and nobody has ever churned because a library was too small at launch.
+
+---
+
+## Say what is not in v1
+
+Name the cuts as explicitly as the inclusions, and write them into the note. An unspoken cut is heard as a broken promise the moment they see the build.
+
+Say it as a sentence they can repeat: *"v1 is one thing done properly — the session, with the camera. Sleep, nutrition and the community come after we know people are using this one."*
+
+---
+
+## The v1 test
+
+- [ ] One complete loop — open, do the thing, get the outcome, reason to return.
+- [ ] Every feature is a **doing** feature.
+- [ ] If money is needed, there is a way to pay **in v1**.
+- [ ] The hard part (`hard-part-first.md`) is proven by a spike before screens are built.
+- [ ] If the real cost is content, there is a pipeline and a minimum viable set.
+- [ ] The **not-in-v1 list is written down** and was said out loud.
+- [ ] It can be shown to a real user in weeks, not months.

--- a/.agents/skills/cs-build-resync-codebase/SKILL.md
+++ b/.agents/skills/cs-build-resync-codebase/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: cs-build-resync-codebase
+description: >
+  Re-sync CodeSpring with the real code after building. Independently checks
+  whether the features, notes, and PRDs in CodeSpring still match what the code
+  actually does now (features drift from their plan once built), then updates
+  CodeSpring to match. Read-only on the codebase — it only reads code/git and
+  writes to CodeSpring. Use after a feature is finished, or periodically, to
+  keep the map from going stale. Triggers, "resync my codebase", "is CodeSpring
+  up to date", "check for stale PRDs", "update CodeSpring from the code", "my
+  plan drifted from the code".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(git:*) Bash(node:*) Bash(curl:*)
+metadata:
+  author: codespring
+  version: "0.1"
+---
+
+# Re-sync CodeSpring with the codebase
+
+Once a feature is built, it rarely matches the original plan exactly. This skill checks CodeSpring against the current code and brings the map/notes/PRDs back into line.
+
+**Guardrail: this is read-only on the codebase.** It reads code and git history and writes ONLY to CodeSpring (features, notes, PRDs). Never modify application code from this skill.
+
+Uses: `codespring` skill references (`analyze-codebase.md`, `mindmap-structure.md`, `prd-management.md`, `pitfalls.md`).
+
+## 0. Connect first
+`codespring auth status` + `codespring status` (LOCAL project; print it).
+
+## 1. Establish what changed
+- Read recent changes: `git log`, `git diff` since the last sync point (or a branch/tag the user names), and the current state of the relevant files. If a GitHub remote is set, the mindmap's `githubUrl` and the repo are the reference.
+- Focus on the feature(s) the user built, but scan for new routes, tables, jobs, env vars, and shared systems anywhere.
+
+## 2. Compare code ↔ CodeSpring
+For each affected feature, diff reality against what's documented:
+- **Features / sub-features** — any new capability in the code not represented as a feature/sub-feature? Any documented one that no longer exists?
+- **Notes** — does the "how it works" note still describe the real flow, files, and routes?
+- **PRDs** — do the Frontend/Backend PRDs still match? Especially the shared backend contracts (routes, data model, auth/RLS, jobs/cron, storage/buckets, payments/credits, env vars) and the dependency map.
+- **Tech stack** — any new dependency/service to add.
+
+## 3. Report first
+Summarize as: **up to date / minor tweaks / stale**, with a short list of concrete diffs (each with file/route/table references and a severity). Let the user confirm before large rewrites.
+
+## 4. Update CodeSpring (writes go here, not to code)
+- Add/adjust features & sub-features (`codespring feature create --parent ...`, `feature update ...`), keeping the `node-features` count correct (re-parent if flattened — see `pitfalls.md`).
+- Refresh notes (`codespring mindmap note ...`).
+- Refresh PRDs: regenerate via `cs-build-create-prd` where a PRD is materially stale, or `codespring prd sync <id> --file` for targeted content updates.
+- Update tech stack / project info if needed.
+
+## 5. Confirm
+List what was updated in CodeSpring and give the project link. Note anything you intentionally left (e.g. a planned-but-not-built task).
+
+## What good looks like
+- CodeSpring reflects what the code actually does now, not just the original plan.
+- Drift is reported by severity with exact references before anything is rewritten.
+- The codebase was never modified — only CodeSpring was updated.

--- a/.agents/skills/cs-build-ui-mockup/SKILL.md
+++ b/.agents/skills/cs-build-ui-mockup/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: cs-build-ui-mockup
+description: >
+  Turn a CodeSpring plan into a clickable local mockup the client can actually
+  look at — one screen per core feature, real copy, plausible data, a proper
+  token-driven design system with light and dark mode, and a style guide page
+  showing the branding. Then run the review that surfaces what the written plan
+  could not: screen order, hierarchy, position, and choices that turn out to be
+  incomplete. Feeds every correction back into the CodeSpring notes and tasks.
+  Runs AFTER the map and notes exist and BEFORE the PRDs are generated.
+  Triggers, "make a mockup", "mock up the UI", "show me what it looks like",
+  "build a prototype", "design the screens", "what would this app look like",
+  "create a UI mockup for this plan", "I want to show the client something".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(node:*) Bash(npm:*) Bash(npx:*) Bash(git:*) Bash(grep:*) Bash(rg:*) WebSearch WebFetch
+metadata:
+  author: codespring
+  version: "0.1"
+---
+
+# Build a clickable mockup from the plan
+
+**A written plan cannot express a focal point.** It cannot express screen order, position, hierarchy, or whether a set of choices is complete. Those are exactly the things that go wrong, and no amount of re-reading the notes will find them — the client agrees to the words and then sees the screens and says something quite different.
+
+This skill turns the plan into something they can look at, runs the review that surfaces the gap, and writes what it finds back into CodeSpring.
+
+**Where it sits in the chain:**
+
+```
+cs-build-plan-app  or  cs-build-import-codebase        (map + notes exist)
+        │
+        ▼
+   cs-build-ui-mockup   ← you are here
+        │            build it, show it, feed corrections back
+        ▼
+  cs-build-create-prd → cs-build-create-tasks → cs-build-feature
+```
+
+**Run it before the PRDs.** A PRD generated from a plan nobody has seen just encodes the misunderstanding in more detail and makes it more expensive to undo.
+
+Read: `codespring` skill `references/project-state.md`, `references/pitfalls.md`, and this skill's own references —
+
+| Reference | Read it when |
+|---|---|
+| `references/design-system.md` | **Before writing any CSS.** The token architecture, the scales, the radius relationships, brand-swapping, and light/dark. |
+| `references/review-method.md` | Before showing it to anyone. How to run the review without contaminating it, what mockups reliably catch, and how corrections get written back. |
+
+**Also load Anthropic's `frontend-design` skill if the runtime supports it** (`https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md`). It is the method for making the thing distinctive rather than templated; `design-system.md` here is the structure it hangs on. If skills cannot be installed in this environment, read that URL and follow it directly.
+
+---
+
+## 0. Check the plan is ready
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state
+node ../codespring/scripts/state.mjs       /tmp/cs-state
+```
+
+You need **core features with notes**. Without notes there is nothing to draw — the note is where the screen's content, states and rules live.
+
+- **No map** → wrong skill. `cs-build-plan-app` (no code) or `cs-build-import-codebase` (existing code) first.
+- **Map but thin or missing notes** → say so and fix the notes first. A mockup built from card titles alone invents everything and tests nothing.
+- **PRDs already generated** → still worth doing, but say plainly that corrections will mean regenerating them.
+
+## 1. Get the brief straight before drawing anything
+
+From the notes and from the person, settle these. They are the inputs to every visual decision:
+
+- **Who uses it**, and what that constrains — age, ability, environment, device, how much patience they have.
+- **The single job of the main screen.**
+- **The one moment the product will be remembered by.** This is where the boldness gets spent; everything else stays quiet.
+- **Any brand that already exists** — colours, type, logo, an existing product to match.
+- **Any reference the client has supplied.** If they have pinned a direction, **follow it exactly** — their words win over any default you would otherwise reach for.
+- **Light or dark or both**, and which is the default.
+
+**If a reference image was supplied, extract from it explicitly** and write the extraction down: palette as named hex values, radius scale, type pairing, spacing rhythm, and the two or three structural patterns worth stealing. Then say what you are deliberately *not* taking from it, and why. A reference is evidence of what they liked, not a specification to copy wholesale — the reference's audience is often not their audience.
+
+## 2. Choose the smallest stack that throws away cleanly
+
+This is a **communication device with a lifespan of days**. It is not the app and it must never become the app by accident.
+
+Default: whatever gets a styled, routed, clickable page up fastest in the target platform's own idiom — usually a scaffolded web app with a utility CSS layer. Match the eventual stack where that is free, but **never let stack fidelity slow the mockup down.** A web mockup for a native app is fine and normal; the point is the screens.
+
+**No backend. No database. No auth. No real API calls.** Hardcoded sample data throughout.
+
+Put it in its own directory, clearly named `mockup/`, and say in one line that it is throwaway.
+
+## 3. Build the design system FIRST
+
+Do not write a screen before the tokens exist. `references/design-system.md` is the spec; the short version:
+
+- **Every value lives in one place.** No hex, no pixel value, no radius, no font stack appears in a component. Ever. A whole rebrand must be one file.
+- **Light and dark are both built from day one**, not retrofitted. Retrofitting dark mode means revisiting every screen.
+- **One spacing scale, one type scale, one radius scale.** Radii are chosen as a deliberate relationship — see the reference; the common failure is a card at 28, a button at 6 and an input at 12 for no reason anyone can state.
+- **Colour is semantic, not literal.** `--surface`, `--ink`, `--accent` — never `--blue`. Semantic names are what make a brand swap possible.
+
+Then run the **two-pass process** from Anthropic's frontend-design skill: plan the token set (4–6 named colours, display + body faces, a layout concept, and the one signature element), **critique that plan against the brief**, revise anything that reads as a generic default, and only then write code.
+
+## 4. Build the screens
+
+**One screen per core feature, plus the single most important flow.** Do not build every sub-feature — build enough that the shape of the product is legible.
+
+Non-negotiables, because each one has cost a real review:
+
+- **Real copy.** Never lorem ipsum. Wrong wording is one of the things you are trying to surface, and placeholder text hides it completely.
+- **Plausible sample data.** Real-looking names, real-looking numbers. "Sit-to-Stand Strength · 10 minutes · Level 2" surfaces problems that "Item 1" never will.
+- **Controls must visibly respond.** A chip that does nothing when clicked reads as **broken**, not as static, and you will lose review time to it. Hardcoded state that moves on click is enough.
+- **Draw the empty and first-run states.** They are the most-skipped screens and the ones that most often read as "this is broken" to a non-technical user.
+- **Every list item that has detail behind it must open.** A list you cannot open is a list nobody can trust, and "you'd click into it" is exactly the kind of assumption a mockup exists to expose.
+- **Every enumerated choice needs its escape hatch** — an "Other" or "Custom" option — unless the set is genuinely closed. Fixed lists die on contact with real users.
+
+## 5. Add a style guide page
+
+A `/styleguide` route showing the design system as an artefact the client can react to: the palette with names and values, the type scale in use, the spacing and radius scales, buttons and inputs in every state, cards, and the light/dark toggle.
+
+This does real work. It gives the client something concrete to approve or reject **at the token level**, which is a far cheaper conversation than arguing about it one screen at a time. It also documents the system for whoever builds the real thing.
+
+## 6. Check it yourself before showing anyone
+
+- The build passes and every route loads.
+- **Look at it.** Screenshot each screen and actually read them. Do not ship a mockup you have only verified with HTTP 200s.
+- Light and dark both work on every screen.
+- Nothing framework-branded is visible — dev badges, error overlays, placeholder favicons. A non-technical client reads any of that as "broken".
+- The quality floor: keyboard focus visible, sensible heading order, reduced motion respected, no horizontal scroll.
+- **Chanel's rule: find the one thing to remove.**
+
+## 7. Run the review
+
+Full method in `references/review-method.md`. The core of it:
+
+**Put it in front of them and shut up.** Do not narrate, do not explain your reasoning, do not pre-defend a choice. The moment you explain a screen you are measuring whether your explanation is convincing, not whether the screen is.
+
+Ask only open questions: *show me what you'd do first*, *what's confusing*, *what's missing*, *where would you look for X*.
+
+**Take the feedback literally and work out separately what it means.** "This looks blobby" is not actionable but the thing they are pointing at is real. "I don't know what that's showing" means a chart has no title. "Is that something I click?" means one screen is doing two jobs with no signposting.
+
+**Expect two rounds.** Stop when the feedback moves from "this is wrong" to "I'd prefer" — at that point you have the understanding you came for and the rest is taste that can be settled during the build.
+
+## 8. Write the corrections back into CodeSpring
+
+**This is the step that makes the skill worth running.** The review output is not a UI to-do list — it is plan corrections, and they belong where the build will read them.
+
+1. **The reason goes in the feature's note.** Not just the decision — the reason. *"The workout goes first, because asking two questions before showing anything is two decisions before she has seen anything."* The reason is what stops the next person reverting it.
+2. **A `DESIGN REVIEW` block goes on every affected task**, so whoever builds that screen sees the correction rather than rediscovering the original mistake.
+3. **Anything the review revealed as missing becomes a new task**, and a new sub-feature if it is genuinely a new thing the user does.
+4. **Name the mockup in the notes as the agreed UI reference**, with how to run it. It is now worth more than any written description of the same screens.
+
+```bash
+codespring mindmap note <coreFeatureId> --title "How it works — X" --text "$(cat note.txt)"
+codespring task update <taskId> --description "$(cat task.txt)"
+codespring task create --title "0.x.y — ..." --description "..." --feature <id> --priority high
+```
+
+## 9. Hand off
+
+**→ `cs-build-create-prd`**, now that the plan reflects something the client has actually seen.
+Then `cs-build-create-tasks`, then `cs-build-feature`.
+
+Tell them plainly what they have: the mockup and how to run it, the style guide, what changed in the plan because of the review, and what happens next.
+
+---
+
+## What good looks like
+
+- The mockup existed **before** the PRDs.
+- **The design system was built first**, all values live in one place, and light and dark both work.
+- A `/styleguide` route exists, so branding is a token-level conversation.
+- Real copy, plausible data, controls that respond, and empty states drawn.
+- Every list with detail behind it opens; every enumerated choice has an escape hatch.
+- It was shown **without narration**, with open questions.
+- **Every correction became a note reason and a task block** — not a private to-do list.
+- The mockup is named in the notes as the agreed UI reference.
+- **At least one thing surfaced that no amount of reading the plan had found.** If nothing did, the mockup was too vague to be useful.

--- a/.agents/skills/cs-build-ui-mockup/references/design-system.md
+++ b/.agents/skills/cs-build-ui-mockup/references/design-system.md
@@ -1,0 +1,233 @@
+# The design system — build this before any screen
+
+The single rule everything else follows from:
+
+> **No colour, size, radius, spacing value or font stack ever appears inside a component.** Every one of them is a named token defined in one file. A complete rebrand is one file changed.
+
+If a component contains `#DC5B42` or `padding: 18px`, the system has already failed — because the rebrand, the dark mode and the accessibility pass all become a hunt through every screen.
+
+---
+
+## Colour
+
+### Name colours by ROLE, never by appearance
+
+The most common failure in a mockup that later needs to change: `--blue-500`. When the brand becomes green, every name is a lie and every usage has to be re-read to work out what it meant.
+
+```
+--surface          the page behind everything
+--surface-raised   cards and panels sitting on it
+--surface-sunken   wells, inputs, chart tracks
+--ink              primary text
+--ink-soft         labels and secondary text
+--ink-faint        disabled, placeholder
+--accent           the brand colour — the ONE thing that changes on rebrand
+--accent-hover     pressed and hover states
+--accent-wash      tint behind icons and soft badges
+--rule             hairlines and borders
+--positive         success and confirmation
+--caution          warnings
+--critical         destructive and error
+```
+
+**Semantic names survive a rebrand; literal names do not.** With this set, changing `--accent` changes the product.
+
+### Keep the palette small
+
+**4–6 named values plus neutrals.** More than that and the mockup stops looking designed and starts looking assembled. If a seventh colour seems necessary, it is usually a job for a shade of an existing one.
+
+### Light and dark from day one
+
+Not a later pass. Retrofitting dark mode means revisiting every screen, and every hard-coded value you got away with becomes visible at once.
+
+```css
+:root { --surface: #FAF7F5; --ink: #1C1A19; --accent: #DC5B42; }
+
+@media (prefers-color-scheme: dark) {
+  :root { --surface: #171513; --ink: #F4F0ED; --accent: #E87059; }
+}
+
+:root[data-theme="dark"]  { /* explicit override wins over the media query */ }
+:root[data-theme="light"] { }
+```
+
+Support both the system preference **and** an explicit toggle, and let the explicit one win in both directions.
+
+**Dark is not inverted light.** Three things that always need adjusting:
+- **Lift the accent's lightness.** A colour that reads well on white is usually muddy on near-black.
+- **Never use pure black or pure white.** `#000` on `#FFF` is harsh; near-black and near-white are calmer and look intentional.
+- **Shadows barely work in dark.** Separate surfaces with a lighter raised colour and a subtle border instead of a drop shadow.
+
+### Contrast is a functional requirement
+
+WCAG AA — 4.5:1 for body text, 3:1 for large text and UI boundaries. **Check both themes.** For an older or low-vision audience, treat AA as the floor and aim higher on anything read at distance.
+
+---
+
+## Spacing
+
+**One scale, and everything snaps to it.** A 4px base is the standard choice:
+
+```
+--space-1: 4px    --space-4: 16px   --space-7: 40px
+--space-2: 8px    --space-5: 24px   --space-8: 64px
+--space-3: 12px   --space-6: 32px   --space-9: 96px
+```
+
+**No value outside the scale.** The moment `padding: 18px` appears, the rhythm is gone and nobody can tell why the page feels slightly wrong.
+
+**Space communicates grouping.** Related things sit closer than unrelated things, and that difference should be at least two steps of the scale or the eye will not read it. Most cramped-looking interfaces are not short of space overall — they use the *same* gap between related and unrelated elements.
+
+---
+
+## Radius — pick relationships, not numbers
+
+The failure this prevents: a card at 28px, a button at 6px, an input at 12px, chosen separately at different times. Nothing is wrong individually and the whole thing looks incoherent.
+
+**Define a scale and state the relationships:**
+
+```
+--radius-sm    6px    inputs, small controls, table cells
+--radius-md   12px    buttons, chips, badges
+--radius-lg   20px    cards nested inside other cards
+--radius-xl   28px    top-level cards, panels, modals
+--radius-full 999px   pills, avatars, circular buttons
+```
+
+**The two rules that keep it coherent:**
+
+1. **Nested corners get smaller, not bigger.** A card inside a card steps *down* the scale. A large radius inside a small one reads as a mistake even to people who cannot say why.
+2. **Concentric radii should relate**: an inner radius of roughly `outer − padding` keeps the curves parallel. A 28px card with 16px padding wants an inner radius near 12px.
+
+**Commit to a personality and hold it.** Fully round pills with 6px cards is a mixed message. Either the product is soft (large radii, pills everywhere) or it is precise (small radii, square-ish) — pick one and be consistent. If buttons are pills, chips should be pills too.
+
+---
+
+## Type
+
+**Two faces, three at most:**
+- **Display** — carries the personality. Used with restraint, at large sizes only.
+- **Body / UI** — chosen for legibility, not character. This is most of the product.
+- Optionally a **mono** for code, data, or timers where digit alignment matters.
+
+**One scale, and every size comes from it:**
+
+```
+--text-xs   13px    --text-lg    20px    --text-3xl  44px
+--text-sm   15px    --text-xl    24px    --text-4xl  56px
+--text-base 17px    --text-2xl   32px    --text-hero 96px+
+```
+
+**Set the base from the audience, not from habit.** 16px is a floor, not a default. An older or low-vision audience wants 17–19px body and everything else scaling from it.
+
+**Always set line height with size.** Tight for display (1.1–1.2), comfortable for body (1.5–1.6). Long body text at 1.2 is unreadable and it is the single most common type mistake.
+
+**Numbers that update need `font-variant-numeric: tabular-nums`** — otherwise a running timer visibly jitters as digit widths change.
+
+---
+
+## Elevation
+
+Pick **one** way to separate surfaces and use it consistently: shadow, border, or a background shift. Mixing all three is what makes a UI look assembled by different people.
+
+Three levels is plenty — flat, raised, floating (modals, menus). If a fourth seems necessary, the layout is probably too deep.
+
+Remember shadows barely read in dark mode; plan the border or surface-shift equivalent at the same time.
+
+---
+
+## Components — define once, use everywhere
+
+Build these before the screens, from tokens only:
+
+**Button** — primary, secondary, ghost, destructive; default, hover, active, focus, disabled, loading. **A button with no focus state is not finished.**
+**Input** — label, field, helper text, error state, disabled. Errors say what to do next.
+**Card** — the container everything sits in.
+**Chip / pill** — selected and unselected. Selected must be distinguishable **without relying on colour alone**.
+**Modal** — backdrop, panel, close, scrollable body, Escape to dismiss, focus trapped.
+**Table row** — including the hover and clickable states, if rows open.
+**Empty state** — an illustration or glyph, a line explaining what goes here, and the action that fills it. Design it once and reuse it.
+
+**Minimum target size 44×44px**, and larger for an audience with reduced dexterity.
+
+---
+
+## Navigation
+
+Pick the pattern from the shape of the product, not from fashion:
+
+- **Sidebar** — 4–8 top-level destinations, desktop-first, and the user moves between them often. Most tools.
+- **Top bar** — few destinations, or content-led and marketing-adjacent.
+- **Bottom bar** — mobile, 3–5 destinations, thumb reach matters.
+
+Whatever the pattern: **the current location must be unmistakable** (not a faint tint), destinations are named for what the user does there rather than how the system is built, and **full-screen modes are entered from a destination rather than being one.** A workout session, a video player, a canvas — these take over the screen but do not appear in the nav.
+
+---
+
+## Motion
+
+**Default to less.** Extra animation is one of the strongest signals that an interface was generated rather than designed.
+
+```
+--motion-fast   120ms   hover, focus, small state changes
+--motion-base   200ms   most transitions
+--motion-slow   320ms   modals, page-level changes
+```
+
+Ease-out for things entering, ease-in for things leaving. **Respect `prefers-reduced-motion` and mean it** — not a shorter animation, no animation.
+
+One orchestrated moment lands harder than movement scattered everywhere. And during any task where the user is concentrating, motion should stop entirely.
+
+---
+
+## Making the brand swappable
+
+The client will change their mind, or the same mockup will be shown to a second client. Build for it from the start:
+
+1. **Every visual value is a token**, no exceptions.
+2. **Colour tokens are semantic**, so `--accent` means "the brand colour" regardless of what colour it is.
+3. **Font families are two tokens**, `--font-display` and `--font-body`, referenced nowhere else.
+4. **The radius scale is one block** — softening or sharpening the whole product is five numbers.
+5. **Keep a themes block**, so an alternative brand is a set of overrides rather than an edit:
+
+```css
+:root[data-brand="alt"] {
+  --accent: #2F6F5E;
+  --font-display: "Some Other Face", serif;
+  --radius-xl: 8px;
+}
+```
+
+**Test it before you finish.** Change `--accent`, reload, and look at every screen. Anything that did not change is a hard-coded value you missed — and that is exactly the bug you are trying to prevent.
+
+---
+
+## The style guide page
+
+A `/styleguide` route rendering the system from the same tokens the app uses:
+
+- Palette swatches with token names and values, in both themes
+- The type scale, each size labelled and shown in use
+- The spacing and radius scales, drawn
+- Every component in every state
+- A light/dark toggle
+
+Two reasons it earns its place: the client can approve or reject the **branding at token level**, which is a much cheaper conversation than arguing screen by screen — and it documents the system for whoever builds the real thing.
+
+---
+
+## The checklist
+
+- [ ] No hex, px, or font stack in any component.
+- [ ] Colour tokens are **semantic**, not literal.
+- [ ] **Light and dark both work**, on every screen, and the toggle beats the system preference.
+- [ ] Contrast meets AA in **both** themes.
+- [ ] One spacing scale, and nothing off it.
+- [ ] Radius scale with **stated relationships**; nested corners step down.
+- [ ] Type scale with line heights; base size set from the audience.
+- [ ] Tabular numerals anywhere numbers change.
+- [ ] Every component has hover, focus, active and disabled.
+- [ ] Empty states designed.
+- [ ] Targets ≥ 44px.
+- [ ] Reduced motion respected.
+- [ ] **Changing `--accent` visibly rebrands every screen.**

--- a/.agents/skills/cs-build-ui-mockup/references/review-method.md
+++ b/.agents/skills/cs-build-ui-mockup/references/review-method.md
@@ -1,0 +1,88 @@
+# Building it, showing it, and feeding it back
+
+The method behind `cs-build-ui-mockup`. Learned the expensive way on a real client.
+
+## The problem it solves
+
+`elicitation.md` warns that a confident plan which does not match what is in the person's head **reads exactly like a good one**. Everything else in this skill fights that with words — read it back, ask what is wrong, get a yes at the gate.
+
+**Words are not enough.** A person will agree to a written plan they have not actually understood, because prose lets both sides fill the gaps differently and neither notices. The gap only becomes visible when someone can *look* at it.
+
+Real run: a plan was written, agreed at the gate, expanded into PRDs and sixty tasks. It looked complete. A clickable mockup was then built from it, and within ten minutes of the owner looking at the screens it produced **eleven corrections** — including a whole screen in the wrong order, a feature nobody could find, a control that had no source for its numbers, and a list nobody could open. None of those had surfaced in any amount of written review, and several would have been expensive to fix after the build.
+
+> **A mockup is the cheapest possible disagreement.**
+
+## When to build one
+
+**After the map and notes, before the PRDs.** That is the moment the plan is complete enough to draw and cheap enough to be wrong.
+
+Skip it only when there is genuinely no interface — a CLI, a library, a background job.
+
+The design system that the mockup is built from is a separate concern with its own rules: `design-system.md`. Build that first.
+
+## What to build
+
+**A static, clickable, throwaway front end.** Not the app. No backend, no real data, no auth, no camera, no API calls. Hardcoded sample values everywhere.
+
+- **One screen per core feature**, plus the single most important flow.
+- **Real copy**, not lorem ipsum. Wrong copy is one of the things you are trying to surface, and placeholder text hides it.
+- **Plausible sample data.** Numbers that could be real. "Sit-to-Stand Strength · 10 minutes · Level 2" surfaces problems that "Item 1" never will.
+- Enough interactivity that clicking a thing visibly does something. **A control that does not respond reads as broken, not as static**, and you will waste review time on it.
+
+Build it in whatever is fastest to throw away. It is a communication device with a lifespan of days.
+
+## How to run the review
+
+Put it in front of them and **shut up**. Do not narrate, do not explain the reasoning, do not pre-defend a choice. The moment you explain a screen you have contaminated the test — you are now measuring whether your explanation is convincing, not whether the screen is.
+
+Ask only:
+- *"Show me what you'd do first."*
+- *"What's confusing?"*
+- *"What's missing?"*
+- *"Where would you look for X?"*
+
+**Then take the feedback literally, and separately work out what it means.** "This looks blobby" is not actionable, but the thing they are pointing at is real. "I don't know what that's showing" means a chart has no title. "Is that something I click?" means one screen is doing two jobs with no signposting.
+
+## What a mockup reliably catches that prose does not
+
+Every one of these came from a real review, and every one had been invisible in a written plan that both parties had signed off:
+
+| What surfaced | The general lesson |
+|---|---|
+| The screen asked two questions before showing anything useful | **Screen ORDER is a decision, and prose does not encode it.** A note listing features says nothing about what is at the top. |
+| A summary line duplicated what the graphic already said | Redundancy is invisible in a list and obvious on a screen. |
+| A control had no source for its numbers | **"The user picks a level" hides the question of where the level's VALUES come from.** Prose accepts an unfinished thought; a form has to be filled in. |
+| A list of items could not be opened | **A list nobody can open is a list nobody can trust.** Detail views get planned as "obviously"; obviously never gets built. |
+| A fixed set of options had no escape hatch | **Every enumerated choice needs an "other".** A list of five equipment types dies on contact with a real user. |
+| An important secondary action was at the bottom of a long page | Position IS priority, and a note cannot express position. |
+| A screen in the nav had nothing behind it | Prose lists it as a feature; the mockup shows it is empty. |
+| Status was scattered across five floating elements | **"Show the round, the reps and the timer" reads fine as a sentence and fails as a screen.** |
+| Everything on a bar had equal weight | **A written plan cannot express a focal point.** Prose has no hierarchy; a screen is nothing but hierarchy. |
+| A real feature read as invented | If a feature's purpose is not legible on screen, it will be cut by whoever reviews it — including the person who asked for it. |
+
+Notice the pattern: **almost all of it is about hierarchy, order, position, and the completeness of a choice.** Those are exactly the properties a bulleted list cannot represent, which is why no amount of re-reading the plan finds them.
+
+## Feed it straight back into the plan
+
+The review output is not a UI to-do list — it is **plan corrections**, and they belong in CodeSpring where the build will read them:
+
+1. Write each decision into the relevant feature's **note**, with the reason. *"Order changed: the workout goes first because asking two questions before showing anything is two decisions before she has seen anything."* The reason is what stops it being reverted by the next person.
+2. Add a **DESIGN REVIEW** block to every affected **task**, so whoever builds that screen sees the correction and does not rediscover the original mistake.
+3. **Add tasks for what the review revealed was missing.** A detail view, a defaults table, an empty screen that was only ever a nav item.
+4. Add sub-features for anything genuinely new.
+5. Keep the mockup and **name it in the notes as the agreed UI reference.** It is now worth more than any written description of the same screens.
+
+## Expect more than one round
+
+The first revision will not be right either. The second review is cheaper and sharper because the obvious problems are gone and the person is now looking at hierarchy rather than content.
+
+**Two rounds is normal. Three is fine.** It is still radically cheaper than discovering any of it after the build. Stop when the feedback moves from "this is wrong" to "I'd prefer" — at that point you have the understanding you came for, and the rest is taste that can be settled during the build.
+
+## What good looks like
+
+- A clickable mockup existed **before** the PRDs were generated.
+- It used real copy and plausible data, and its controls visibly responded.
+- It was shown **without narration**, and the questions asked were open.
+- Every piece of feedback became a **note correction with its reason**, a **task addition**, or both — not a private to-do list.
+- The mockup is named in the notes as the agreed UI reference.
+- At least one thing surfaced that no amount of reading the plan had found. **If nothing did, the mockup was too vague to be useful.**

--- a/.agents/skills/cs-marketing-offer-creation/SKILL.md
+++ b/.agents/skills/cs-marketing-offer-creation/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: cs-marketing-offer-creation
+description: >
+  Design a paid-ads offer from evidence rather than opinion. Tears down what
+  competitors are already running in the Meta Ad Library, ranks offers by
+  survival and creative duplication, scrapes the landing pages behind the
+  winning ads, then writes the offer, its price ladder, its order bumps and its
+  back end into a durable teardown document. Use when designing or rewriting a
+  front-end offer, a webinar or event registration page, an order bump, or an
+  upsell. Triggers, "research offers", "what offers are working right now",
+  "tear down this funnel", "scrape the ad library", "design a front-end offer",
+  "what should our webinar promise be", "competitor ad research", "why is our
+  CPC so high".
+---
+
+# Offer creation from ad-library evidence
+
+## Overview
+
+Produce an offer backed by what the market is already paying to run. The output
+is a teardown document plus a specified offer, not a hunch. Consumes market
+context from `cs-marketing-research`; hands its offer to `cs-marketing-website`
+for the page build.
+
+**Approval boundaries.** This skill reads public data and writes documents. It
+must not launch ads, spend budget, publish pages, or contact competitors. It
+must not copy competitor copy into production — quote it as evidence only.
+Apify runs cost credits, so ask before using the paid route when a free one
+exists.
+
+## 1. Frame the decision
+
+State before researching: the product being sold, the avatar, the traffic
+source, the price the back end needs to support, and the CPC or cost-per-lead
+target. An offer designed without a back-end price is a guess.
+
+If any of these are missing, ask. Do not research generically.
+
+## 2. Pull the ads
+
+### Free route — the browser. Default to this.
+
+Drive `facebook.com/ads/library` directly. No credits, no API.
+
+```text
+active_status=active|inactive|all
+ad_type=all
+country=US|GB|ALL
+media_type=all
+q=<terms>
+search_type=keyword_exact_phrase | keyword_unordered
+```
+
+- `keyword_exact_phrase` — the literal phrase. Use for brand names, signature hooks, and measuring an angle's size.
+- `keyword_unordered` — **AND across all terms.** The workhorse for finding offers. Four to five terms; six or more returns zero.
+
+Parse by splitting `document.body.innerText` on `Library ID: `. Each chunk gives
+the start date, the advertiser (the line before `Sponsored`), the
+`N ads use this creative` count, `0:00 / 0:00` when the creative is video, and
+the display domain.
+
+Destination URLs are not in the text. Pull them from the DOM:
+
+```js
+[...document.querySelectorAll('a[href*="l.php"], a[href*="l.facebook.com"]')]
+  .map(a => decodeURIComponent(new URL(a.href).searchParams.get('u') || ''))
+```
+
+Pagination is a **"See more"** button, not infinite scroll. Click it in a loop.
+
+### Paid route — Apify MCP. Ask first; it spends credits.
+
+Server `apify` at `https://mcp.apify.com/`, header `Authorization: Bearer <APIFY_TOKEN>`.
+
+```text
+search-actors        find a Facebook Ad Library actor
+fetch-actor-details  read its input schema BEFORE calling
+call-actor           run it (waitSecs 0-45; 0 returns a runId immediately)
+```
+
+Results return storage IDs, not rows. Build the URL from the ID and read it as
+an MCP resource, paging with `limit`/`offset` because reads inline only to
+about 256 KB:
+
+```text
+http://api.apify.internal:3333/v2/datasets/{datasetId}/items?clean=true&format=json&limit=100
+```
+
+Use this route for volume, scheduled monitoring, or when the browser is
+unavailable.
+
+## 3. Read the numbers
+
+Five rules decide everything downstream.
+
+1. **A duplicated creative is a winner.** `N ads use this creative` means one creative across N ad sets. Nobody duplicates twenty-four times to test; they duplicate because it already won. This is the only free profitability signal that exists.
+2. **Many creatives with no duplication means still testing.** Judge nothing until it survives.
+3. **Mass inactivity kills an angle.** If an angle sits entirely in `active_status=inactive`, it was tried at volume and abandoned. Do not re-run it as though it were undiscovered.
+4. **Age beats volume.** One ad alive 150 days outranks ninety ads alive three weeks. Spend fakes volume; it cannot fake survival.
+5. **Durations are floors.** Meta resets the start date on material edits.
+
+Also compute `active ÷ (active + inactive)` per keyword for the survival rate of
+the space, and cross-check each operator's brand keyword against their personal
+name — the oldest ad is often a different, older offer.
+
+## 4. Scrape the pages behind the winners
+
+Fetch the destination URLs from step 2. Funnel pages are usually JS-rendered; if
+a fetch returns only the footer or a 403, load it in a browser instead.
+
+Capture verbatim, never paraphrased: headline, sub-headline, every bullet, form
+fields, CTA button text, countdown or date language, price, guarantee, and proof
+claims. Paraphrase destroys the evidence.
+
+**Evergreen tell:** a CTA reading "See The Next Workshop Time" or "STARTING 8PM
+TONIGHT" with a rolling countdown, rather than a fixed calendar date.
+
+**Also record the mechanics, not just the copy** — social-proof counters,
+incentivised phone capture, attendance bribes, and how many separate
+application pages sit behind one registration.
+
+## 5. Write the teardown
+
+One entry per offer. Name the offer so it can be argued about.
+
+| Field | Why it matters |
+|---|---|
+| Front-end format | webinar, evergreen, challenge, VSL, sales page |
+| Promise, verbatim | the words that actually buy the click |
+| Product sold | SaaS, agent, marketplace, course, community, coaching, DFY |
+| Price ladder | front end, order bumps, OTO, high-ticket |
+| Operators running it | one company, or a licensee/affiliate network |
+| Ads and duplication | total ads, and unique creatives |
+| Days live | from the oldest still-active ad |
+| Format mix | video versus static |
+
+## 6. Specify the offer
+
+Test the draft against what the teardown shows.
+
+- **Does the promise end at money?** Offers that stop at a capability die young. Offers that close the loop to revenue survive.
+- **Is the number in the first line?** Winning pages lead with a specific figure and make it the reader's future, not the founder's past.
+- **Is the front end in the proven band?** Free registration, or roughly $7–$97. Anything above needs a free front door in front of it.
+- **Is there an order bump?** A single front-end price rarely liquidates ad spend. Bumps should sell the half the core product does not deliver.
+- **Is the back end an outcome rather than more software?** Winning back ends sell the result; the software is the delivery mechanism.
+- **Is there one door per avatar?** Separate registration pages feeding one event beat one page trying to address everyone.
+- **Is the proof aggregate?** Customer averages travel further, and survive scrutiny better, than founder claims.
+
+## 7. Artifacts
+
+- A dated teardown document in the project's research folder.
+- A specified offer: promise, avatar, format, price ladder, bumps, back end.
+- A concise ingest into Atlas so later work inherits the decision.
+
+## 8. Verification
+
+Do not report completion without: the query strings used, ad and duplication
+counts per operator, at least one verbatim landing page per shortlisted offer,
+and an explicit statement of what was not covered.
+
+## 9. Status language
+
+Use `draft`, `dogfooding`, `proven`, `deprecated` exactly as defined in
+`docs/skill-governance-sop.md`. An offer that has not run traffic is `draft`,
+however good the research is.
+
+## Pitfalls
+
+- **Benchmarking against a dead funnel.** Confirm which of your own campaigns are actually live before comparing. A paused offer's creative is not your current positioning.
+- **Reading raw ad counts as spend.** Ad count without the duplication breakdown misreads eight winning creatives as eighty tests.
+- **Treating an empty lane as opportunity.** Usually it means unproven demand, not undiscovered demand. Say which you believe and why.
+- **Copying competitor copy.** Quote it as evidence; never ship it.
+- **Claiming conversion insight.** Longevity and duplication are profitability proxies. Nothing in the Ad Library measures conversion, and no spend data exists for US-targeted ads.
+- **Sampling silently.** Every sweep is impressions-sorted and sampled from the top. State what was left uncovered.
+
+## Handoff
+
+Feeds `cs-marketing-website` for the page build, and the offer's back-end
+definition into the relevant build or release planning.

--- a/.agents/skills/cs-marketing-research/SKILL.md
+++ b/.agents/skills/cs-marketing-research/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: cs-marketing-research
+description: >
+  Research a product idea before committing it to a CodeSpring build plan. Finds
+  direct competitors, open-source projects, substitutes, and relevant platform
+  capabilities; separates commodity features from a defensible wedge; then
+  records an evidence-backed recommendation and creates only the scoped feature
+  and tasks worth building. Use when the user asks whether an idea already
+  exists, requests market or competitor research, asks what would make a
+  product unique, or wants to validate an idea before creating a PRD or tasks.
+---
+
+# Market research for CodeSpring ideas
+
+## Overview
+
+Turn a vague product idea into a decision: do not build, use or integrate an
+existing solution, or pursue a focused wedge. Treat research as a planning
+gate, not as a way to justify building a duplicate.
+
+## 1. Frame the job to be done
+
+- Restate the desired outcome, target user, platform, and constraints.
+- Identify the smallest complete workflow, including the moment the user gets
+  value. Do not research a feature list before identifying that workflow.
+- Name the unproven assumptions that change the decision, such as whether an
+  API exists, whether an existing tool automates the workflow, and whether the
+  requested platform matters.
+
+## 2. Research the market and technical reality
+
+- Search for direct products, open-source repositories, platform-native
+  features, and adjacent substitutes. Prefer primary sources: product docs,
+  source repositories, release notes, and source code.
+- For each serious alternative, record: intended user, exact overlapping
+  workflow, interaction model, maturity signals, license or pricing, and
+  meaningful gaps. Verify claimed capabilities from the source; do not rely on
+  search snippets alone.
+- Check relevant platform and API documentation before proposing automation.
+  Flag unsupported, brittle, credential-scraping, or GUI-injection approaches.
+- Do not call an idea unique merely because its UI, programming language, or
+  name differs. It is only a wedge when it changes the outcome, audience,
+  distribution, or integration surface.
+
+## 3. Make a recommendation
+
+Choose one outcome and state it plainly:
+
+- **Do not build:** an existing solution directly satisfies the job.
+- **Adopt or integrate:** use an existing tool and build only the missing
+  integration or workflow layer.
+- **Build a wedge:** define one narrow user, outcome, and capability that the
+  alternatives do not offer.
+
+For a build recommendation, give a one-sentence positioning statement, MVP
+boundary, non-goals, risks, and the evidence behind the choice. Avoid a generic
+feature comparison dump.
+
+## 4. Sync the decision to CodeSpring
+
+- Read project context, relevant features, mindmap, PRDs, and existing tasks
+  before changing CodeSpring. Reuse a suitable existing feature where possible.
+- Add an evidence-backed mindmap note with research date, sources, decision,
+  alternatives considered, and explicitly rejected scope.
+- Create or update a feature only when the recommendation is to build a wedge
+  or an integration. Do not create a feature for a commodity clone.
+- Create a small dependency-linked task list only after the MVP boundary is
+  clear. Each task must state what it may touch, what it must not touch, and
+  how to verify it. Use existing CodeSpring task conventions.
+- If the recommendation is adoption, create a single evaluation or integration
+  task rather than pretending a new application needs to be built.
+
+## Output
+
+Return a short research memo with:
+
+- Decision and confidence.
+- Direct alternatives and exact overlap.
+- Proposed wedge or reason not to build.
+- MVP, non-goals, and top risks.
+- CodeSpring changes made, including task order.

--- a/.agents/skills/cs-marketing-research/agents/openai.yaml
+++ b/.agents/skills/cs-marketing-research/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Market Research"
+  short_description: "Validate a product idea before planning"
+  default_prompt: "Use $cs-market-research to assess this idea before we plan it in CodeSpring."

--- a/.agents/skills/cs-marketing-website/SKILL.md
+++ b/.agents/skills/cs-marketing-website/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: cs-marketing-website
+description: Use when an app needs its marketing pages set up and organised. Builds the site architecture, page inventory, proof map, conversion paths, and a founder-facing NOW/NEXT/LATER workboard.
+metadata:
+  author: codespring
+  version: "0.1"
+---
+
+# Website foundation for an app
+
+Use this skill when a founder has a finished or credible product but cannot reliably remember what each website page is for, what to build next or which marketing work is blocked. This is the coordinating marketing skill. It turns a scattered site and a list of ideas into a maintained page inventory and a dependency-aware workboard.
+
+Do not use it to publish content, make a production change, spend on ads or claim a page is live. Those actions require the appropriate follow-on skill and approval.
+
+## Required inputs
+
+Collect or explicitly mark missing:
+
+- product, buyer and job to be done;
+- primary conversion action and destination;
+- current production URL and source repository, if available;
+- approved proof: customer outcomes, screenshots, product demos, reviews or source data;
+- analytics and Search Console access status;
+- founder availability, decision owner and review cadence.
+
+If the live site or repository is unavailable, create a **DRAFT** inventory from supplied information and record the blocker. Do not infer technical state.
+
+## Step 1: inspect, inventory, and organise the site
+
+Inspect the actual website, routes, navigation, sitemap and conversion paths. Use `templates/page-inventory.csv` to record each existing and needed page.
+
+For every page capture: URL, page home, parent route, navigation label, page type, audience, job to be done, primary CTA, proof, indexation state, owner, status, dependency, success metric, next action and review date.
+
+Use these page homes by default:
+
+| Page purpose | Home |
+| --- | --- |
+| Product/category or use-case conversion | product, solution or use-case page |
+| Evergreen how-to answer | `/resources/guides/[slug]` |
+| Tool/approach decision | `/resources/comparisons/[slug]` |
+| Useful template, checklist or generator | `/resources/tools/[slug]` |
+| Approved customer evidence | `/resources/stories/[slug]` |
+| Company updates and launches | `/blog/[slug]` |
+| Product help | `/docs/[slug]` |
+
+A page must have one primary job. If it has several, split it or state the priority.
+
+### Required page architecture
+
+Before adding pages, define a compact hierarchy. Start with only the lanes the product can genuinely support:
+
+```text
+/                         # home: category, buyer, promise, primary CTA
+/product or /solutions    # product/use-case conversion pages
+/pricing                  # packaging and purchase path, if public
+/resources                # resource hub; not a dumping ground
+  /guides                 # evergreen how-to answers
+  /comparisons            # decision pages
+  /tools                  # useful templates, checklists, or generators
+  /stories                # approved customer evidence
+/docs                     # product help, not acquisition content
+/blog                     # announcements and time-bound updates
+```
+
+- Keep navigation to a small set of buyer-relevant top-level destinations. A resource subtype belongs in its own hub and is linked from the relevant product page; do not make every article a top-nav item.
+- A planned page gets a parent/home before it gets a slug. Do not create duplicate guides, comparisons, blog posts, and docs pages that answer the same job.
+- A resource lane stays out of the sitemap and is `noindex` until it has a useful hub and at least one complete, original page. Retired or duplicate pages need an explicit redirect/noindex decision.
+- Use `templates/page-brief.md` for every new material page before writing or building it.
+
+**Done when:** the inventory covers every route that matters to a buyer, customer or crawler; every page has a page home and primary job; and missing pages are ordered on the workboard rather than created ad hoc.
+
+## Step 2: establish truth and proof
+
+Write the product truth in `templates/website-context.md`:
+
+- audience, problem and category;
+- promise that can actually be supported;
+- what the product does not do;
+- approved proof and evidence gaps;
+- conversion action and objection each page must address.
+
+Mark any unapproved customer name, quote, metric or screenshot as **BLOCKED/AWAITING APPROVAL**. Never turn an anecdote into public proof.
+
+**Done when:** every planned page can point to a source of truth or is explicitly marked as research-needed.
+
+## Step 3: create the workboard
+
+Sort the inventory into `templates/website-workboard.md`:
+
+- **NOW**: the smallest set of unblocked actions that improves a broken conversion path, missing essential product page or high-intent question.
+- **NEXT**: work that becomes useful once NOW is complete.
+- **LATER**: worthwhile but not currently limiting growth.
+- **BLOCKED/AWAITING APPROVAL**: work waiting on a founder, customer consent, access, copy approval, production deploy or evidence.
+
+Every item requires an owner, concrete next action, dependency and evidence of done. Do not add vague cards such as "improve SEO".
+
+**Done when:** the founder can ask "what should we do this week?" and receive one clear NOW item plus the blocker or approval needed.
+
+## Step 4: establish the durable marketing system
+
+Create or confirm these records in the client repository or operating workspace:
+
+1. page inventory;
+2. marketing context brief;
+3. NOW/NEXT/LATER/BLOCKED workboard;
+4. content register for planned Resources pages;
+5. customer-story pipeline with consent and approval tracking;
+6. weekly and monthly review cadence.
+
+Use `references/status-language.md` exactly. A committed or locally built page is not LIVE.
+
+## Handoffs
+
+- Technical crawlability, canonical, sitemap and Search Console setup → `cs-marketing-seo`.
+- Answer-led, source-backed Resources content → `cs-marketing-aeo-content`.
+- Recurring briefs, publishing, review and founder updates → `cs-marketing-content`.
+- Customer interviews and approved story production → `cs-marketing-content` until a dedicated story/video skill is proven.
+
+## Common mistakes
+
+1. **Treating the blog as the entire website.** Product, resource, story and docs pages serve different jobs.
+2. **Publishing empty resource lanes.** Keep them noindex until there is useful, complete material.
+3. **Planning without an owner or review date.** It becomes an archive, not an operating system.
+4. **Confusing local completion with live.** Require public URL verification after deployment.
+5. **Inventing proof.** Unapproved claims destroy the trust the system is meant to build.
+
+## Verification checklist
+
+- [ ] Page inventory has a row for every material route and needed page.
+- [ ] Every row has a page home, job, audience, CTA, owner, status and next action.
+- [ ] Every material new page has a page brief, parent route, indexation decision, and a place in the navigation/internal-link plan.
+- [ ] Product truth and approved proof are separated from research gaps.
+- [ ] Workboard has NOW, NEXT, LATER and BLOCKED sections.
+- [ ] The highest-priority NOW item has its dependencies and approval boundary stated.
+- [ ] Next weekly check-in and monthly review dates are recorded.

--- a/.agents/skills/cs-marketing-website/references/page-inventory.md
+++ b/.agents/skills/cs-marketing-website/references/page-inventory.md
@@ -1,0 +1,20 @@
+# Website page inventory
+
+Use one row per live, planned or retired page. Keep this in the client repository or operating workspace, not in chat.
+
+| URL | Page home | Parent route | Navigation label | Page type | Audience | Job to be done | Primary CTA | Proof/source | Indexation | Owner | Status | Dependency | Success metric | Next action | Review date |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/resources/guides/example` | resources/guides | `/resources/guides` | Guide title | guide | prospective builder | answer a real question | related product page | approved demo or source | noindex until complete, then index | owner | DRAFT | evidence review | qualified CTA clicks | write the brief | YYYY-MM-DD |
+
+## Status
+
+Use only: **DRAFT**, **READY**, **IN PROGRESS**, **AWAITING APPROVAL**, **QUEUED**, **SUBMITTED**, **LIVE / VERIFIED**, **BLOCKED**.
+
+Do not call a route live until its public URL is independently checked after deployment.
+
+## Page organisation rules
+
+- Give every page exactly one **page home** and one **parent route** before creating it.
+- Use product/solution pages for conversion, Resources for evergreen acquisition/helpful assets, Docs for product help, and Blog for announcements/time-bound updates.
+- Record an explicit `index`, `noindex`, `redirect`, or `retired` decision for every page. Do not add drafts or empty hubs to a sitemap.
+- A page that overlaps an existing page is an update, consolidation, redirect, or rejected idea — not a duplicate route.

--- a/.agents/skills/cs-marketing-website/references/status-language.md
+++ b/.agents/skills/cs-marketing-website/references/status-language.md
@@ -1,0 +1,10 @@
+# Status language
+
+- **DRAFT**: proposed but not approved or executed.
+- **READY**: prerequisites are present; work can begin.
+- **IN PROGRESS**: execution has started; required checks are incomplete.
+- **AWAITING APPROVAL**: blocked by a decision, credentials, spend, publication action, customer consent or production change.
+- **QUEUED**: scheduled for a future run; not live.
+- **SUBMITTED**: sent to a third party; not confirmed live.
+- **LIVE / VERIFIED**: public or production state independently checked with URL, ID, timestamp or test evidence.
+- **BLOCKED**: cannot proceed; state the dependency and owner.

--- a/.agents/skills/cs-marketing-website/templates/page-brief.md
+++ b/.agents/skills/cs-marketing-website/templates/page-brief.md
@@ -1,0 +1,37 @@
+# Page brief
+
+## Identity and placement
+- Proposed URL:
+- Page home:
+- Parent route / hub:
+- Navigation label (if any):
+- Page type:
+- Indexation decision: `index` / `noindex` / `redirect` / `retired`
+
+## Purpose
+- Primary audience:
+- Job to be done / search or product intent:
+- One-sentence page promise:
+- Primary CTA and destination:
+- Supporting CTA (optional):
+
+## Evidence and scope
+- Approved proof/source:
+- Claim requiring approval or source:
+- What this page does not cover:
+- Existing page to link from / avoid duplicating:
+
+## Structure
+- Proposed title and H1:
+- Required sections:
+- Internal links in:
+- Internal links out:
+- Schema decision, if any:
+
+## Delivery
+- Owner:
+- Status:
+- Dependency / approval:
+- Success metric:
+- Verification evidence:
+- Review date:

--- a/.agents/skills/cs-marketing-website/templates/page-inventory.csv
+++ b/.agents/skills/cs-marketing-website/templates/page-inventory.csv
@@ -1,0 +1,3 @@
+url,page_home,parent_route,navigation_label,page_type,audience,job_to_be_done,primary_cta,proof_or_source,indexation,owner,status,dependency,success_metric,next_action,review_date
+/,home,,Home,product,[buyer],[job],[CTA],[source],index,[owner],DRAFT,[dependency],[metric],[action],YYYY-MM-DD
+/resources/guides/[slug],resources/guides,/resources/guides,[guide title],guide,[reader],[question],[CTA],[source],noindex-until-complete,[owner],DRAFT,[dependency],[metric],[action],YYYY-MM-DD

--- a/.agents/skills/cs-marketing-website/templates/website-context.md
+++ b/.agents/skills/cs-marketing-website/templates/website-context.md
@@ -1,0 +1,21 @@
+# Website context
+
+## Product truth
+- Product:
+- Audience:
+- Job to be done:
+- Category and alternatives:
+- What it does not do:
+- Primary conversion action:
+
+## Approved proof
+- Product workflow or demo:
+- Customer-approved outcome:
+- Quote/metric and source:
+- Screenshot/video approved for use:
+
+## Evidence gaps and approvals
+- Claim needing source:
+- Customer permission needed:
+- Founder decision needed:
+- Analytics/Search Console access status:

--- a/.agents/skills/cs-marketing-website/templates/website-workboard.md
+++ b/.agents/skills/cs-marketing-website/templates/website-workboard.md
@@ -1,0 +1,18 @@
+# Website workboard
+
+## NOW
+- [ ] [Action] — owner: [name] — dependency: [none/what] — evidence of done: [URL/test/approval]
+
+## NEXT
+- [ ] [Action] — owner: [name] — dependency: [what must happen first]
+
+## LATER
+- [ ] [Action] — reason it is not currently limiting growth: [reason]
+
+## BLOCKED / AWAITING APPROVAL
+- [ ] [Action] — owner of blocker: [name] — needed decision/access/consent: [detail]
+
+## Cadence
+- Weekly website/content review:
+- Monthly performance and refresh review:
+- Next founder decision:

--- a/.agents/skills/cs-seo-website/SKILL.md
+++ b/.agents/skills/cs-seo-website/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: cs-seo-website
+description: "Use when growing CodeSpring site SEO, content, or listings."
+version: 0.5.0
+author: CodeSpring
+metadata:
+  tags: [codespring, seo, marketing-site, search-console, content, link-building]
+---
+
+# CodeSpring website SEO operator
+
+Use for CodeSpring marketing-site work: robots/sitemaps/canonicals, Search Console exports, docs/tutorials, the Vibe Code Library, product listings, referral links and organic-growth reporting.
+
+This skill covers **the CodeSpring website repo** (`VolkisAI/codespring-webinar`), not CodeSpring customer projects. Its goal is qualified organic traffic and conversions, not a vanity Domain Rating (DR) target.
+
+## Operating principle
+
+A third-party authority metric can be a diagnostic, but it does not itself make pages rank. Prioritise in this order:
+
+1. pages Google can crawl, index and understand;
+2. pages that satisfy a real search intent better than existing results;
+3. topical internal links and a clear conversion path;
+4. genuine mentions, reviews, integrations and editorial references;
+5. measurement of non-branded impressions, qualified visits and sign-ups.
+
+Never promise a DR/ranking result or buy/mass-submit links designed chiefly to manipulate rankings. A `nofollow` mention can still be valuable when it drives the right people.
+
+## Branch and release model
+
+Read the website repository `AGENTS.md` first. It is the operating contract and wins over this skill.
+
+- `main`: live branch and the only branch permitted to change shared SEO files such as `app/sitemap.ts`, `app/robots.ts`, `app/layout.tsx`, `lib/site-links.ts`, `templates/` and `docs/*.md`.
+- `blog`: only `app/blog/**`, `content/blog/**` and `public/blog/**`.
+- `library`: only Vibe Code Library-owned paths.
+- `docs`: only docs route/component paths.
+- `marketing`: only marketing-owned paths.
+
+Never recreate `dev`, never use an ad hoc `fix/seo-*` branch in the website repository, and never commit or push directly to `main`. Each area branch is cut from `origin/main`, keeps one draft PR into `main`, and begins every session by merging `origin/main` before any edits. A required shared SEO change is a separate, small main-only PR for human review.
+
+```bash
+git fetch origin --prune
+git switch blog  # or library, docs or marketing
+git merge origin/main
+git status --short --branch
+```
+
+For a new area branch that does not yet exist, create it from `origin/main` exactly as `AGENTS.md` instructs. Run `npx tsc --noEmit`, `rm -rf .next out && npm run build` and `node --test tests/*.mjs`; if an unchanged baseline test fails, report it exactly and do not claim the full suite passed. Push and verify the remote SHA before reporting completion.
+
+## 1. Technical SEO baseline
+
+Before creating content or seeking listings, inspect the live route **and** implementation on `origin/main`:
+
+- one canonical host, with the other host permanently redirected at CDN/hosting level;
+- valid `200 text/plain` `/robots.txt` with a sitemap declaration;
+- valid `200 XML` `/sitemap.xml` containing only canonical, intentionally indexable URLs;
+- server-rendered titles, meta descriptions, canonical URLs and meaningful body content;
+- intentional `noindex` for conversion-only, preview, account and duplicate routes;
+- internal links crawlers can follow without JavaScript;
+- accurate, visible-only structured data where applicable;
+- Search Console domain property, sitemap submitted, URL Inspection checked.
+
+For static Next.js exports, `app/robots.ts` and `app/sitemap.ts` generate the public files. A host redirect cannot be solved in Next.js source alone when S3/CloudFront serves static files; document and apply it at the delivery layer.
+
+Acceptance test after a production deployment:
+
+```bash
+curl -sSIL https://codespring.app/
+curl -sSIL https://www.codespring.app/     # expect 301 to the matching bare-host URL
+curl -sSI https://codespring.app/robots.txt
+curl -sSI https://codespring.app/sitemap.xml
+curl -sS https://codespring.app/robots.txt
+curl -sS https://codespring.app/sitemap.xml
+```
+
+## 2. Search Console → content loop
+
+Treat the Search Console query export as the backlog source. Do not choose page topics from generic keyword lists alone.
+
+1. Ingest the export and retain columns for query, page, clicks, impressions, CTR, average position, country and date range.
+2. Cluster queries by intent: brand, comparison, tutorial/problem, product/category, and support/docs.
+3. Prioritise terms with either:
+   - meaningful impressions and weak CTR/position; or
+   - clear commercial/problem intent matching CodeSpring’s product; or
+   - an existing page with a credible chance to be improved.
+4. For every page brief define: target intent, reader’s job, unique evidence/example, title, H1, outline, internal links, CTA, schema decision and success metric.
+5. Publish, request indexing only when the page is genuinely ready, then review at 14/28/56 days. Improve pages based on impressions, CTR and conversion—not publication count.
+
+Monthly scoreboard:
+
+`non-branded impressions | non-branded clicks | top-20 queries | indexed URLs | qualified organic sessions | organic sign-ups | referring domains | referral sign-ups`.
+
+## 3. Proactive daily content desk
+
+Run a founder-reviewable SEO desk at the start of each working day. The target output is **five distinct, fully written review pages**, not five briefs and never five automatically published URLs. Every page must independently have distinct intent, original value, demand evidence, no cannibalisation and a credible conversion path. If only three or four pages can honestly pass those gates, deliver those complete pages and explain why the remaining slots were withheld. This protects CodeSpring from scaled-content and doorway-page behavior while still creating a fast production rhythm.
+
+Use Search Console first, the cached monthly DataForSEO dataset second and live SERPs only for the short list. Treat Instagram, TikTok, YouTube and sales calls as qualitative sources for language, questions and objections—not as automatic one-video-per-landing-page instructions. Improve an existing canonical page whenever it already owns the intent.
+
+Each morning:
+
+1. rank five opportunities across commercial comparisons, problem-led guides, useful tools/templates, canonical-page refreshes and proof/docs/story work;
+2. build up to five complete, readable pages; withhold any slot that cannot pass the evidence and content gates;
+3. push a review branch and provide one verified, directly openable Vercel route per page—never localhost;
+4. send Sebastian a compact review packet with the target query, SERP gap, original value, CodeSpring position, CTA and one exact decision needed;
+5. select one or two pages where a founder YouTube video materially adds proof or teaching value;
+6. keep video demos simple by default: no authentication, database, backend, payments or deployment; use a single-screen utility, local-data interaction, one workflow or a current-interface comparison;
+7. create thumbnail candidates only after the page and video angle are approved;
+8. apply feedback, refresh previews and merge only with explicit approval; keep AWS production deployment separate.
+
+Track every opportunity and page through:
+
+`OPPORTUNITY → BRIEFED → REVIEW → REVISION → APPROVED → MERGED → AWAITING AWS DEPLOYMENT → LIVE / VERIFIED → 14/28/56-DAY REVIEW`.
+
+The morning run is incomplete without remote review URLs or explicit access blockers. Never call a Vercel preview published or live. Never let a page quota override distinct intent, usefulness, original evidence or quality.
+
+Use `references/daily-seo-content-desk.md` for the full selection, build, video, indexing and measurement workflow. Write the daily artifact with `templates/morning-seo-review.md`.
+
+## 4. Content systems
+
+### Tutorials and documentation
+
+Use tutorials for problems the product demonstrably solves: planning an AI-built app, turning requirements into PRDs, project/task sequencing, importing a codebase, and connecting coding agents. Lead with the reader’s outcome, give a real walkthrough/example, then use a direct CodeSpring CTA.
+
+Do not write generic AI filler or dozens of slight keyword variants. One high-quality tutorial with original examples and internal links beats a thin post farm.
+
+#### Write for beginners without flattening the meaning
+
+Plain English does not mean chopping every thought into the fewest possible words. Sentence length and reading-grade scores are checks, not quotas. Keep enough context for the reader to understand what changed, what broke and why the lesson matters.
+
+- Prefer ordinary language: say a feature is `done`, not that somebody can `call it finished`.
+- Keep the subject, action and result clear. Avoid compressed lines such as `The main screen worked. The blank form, failed save or next step did not.` Rewrite the full causal example.
+- Do not concatenate several states into one sentence merely to reduce word count. If three or more checks sit at the same level, introduce them and use bullets.
+- Use a real sequence: what was built, what initially worked, what changed later, what broke, and which acceptance check or test would catch the regression.
+- For example, explain that a CSV upload worked, a later data-processing change broke the upload, and the original upload tests should still pass after the new work.
+- Use paragraphs for explanation and bullets for parallel checks, edge cases, steps or outcomes. A long wall of prose is not beginner friendly.
+- Read the copy aloud. If a sentence is grammatically short but hard to understand without guessing the missing connection, rewrite it rather than shortening it further.
+- First-person founder lessons must come from Sebastian's feedback, first-party videos, call transcripts or recorded CodeSpring experience. Never invent the experience to make a page sound personal.
+
+### Editorial comparison and guide pages
+
+Treat a comparison page as an editorial article, not a landing-page feature grid.
+
+1. **Read the live SERP examples first.** Inspect the strongest ranking pages for structure, reader questions and missing evidence. Learn from them without copying text, images or unsupported claims.
+2. **Start with the reader.** Open with the situation, problem and decision they are trying to make. Do not introduce CodeSpring before answering the comparison intent.
+3. **Use article anatomy.** Include a visible founder byline/photo when Sebastian is the author, an updated date, reading time and linked chapter navigation for long pages.
+4. **Give each compared product its own section.** Explain what Claude Code, Codex, Cursor or another product does well, who it suits and what context it still needs. Put CodeSpring in its own later section, then summarise the choice in a fair table or decision path.
+5. **Use real visuals, not decorative substitutes.** For every third-party product, use a current screenshot captured from that product's first-party public product page or documentation. Store the optimised image locally, record the source URL/date, add meaningful alt text and link the caption to the official source. Never use search-result thumbnails, AI-redrawn interfaces or generic text-block diagrams when an authentic UI view is available.
+6. **Reuse real CodeSpring product assets.** Inspect the current homepage and `public/` library before inventing a diagram. Prefer the real mind map, generated PRD, journey/map or Kanban board screenshots already approved on the site. Replace placeholder architecture blocks with the relevant product UI.
+7. **Make comparison tables scannable.** Pair each product name with its official/approved logo at a consistent size. Keep supporting copy slightly smaller than article body copy and present each cell as a short bullet-style point rather than a dense paragraph. Logos identify products; they do not imply endorsement.
+8. **Build a visible internal-link map.** Link CodeSpring mentions to the homepage where the reader needs the product definition. Link topical phrases such as mind map, PRDs and Kanban board to their specific documentation pages. Links must look like links without requiring hover: use an accessible contrasting colour and underline, then verify every destination. Keep the final CTA direct. Link third-party screenshot captions and sources to their first-party pages.
+9. **Keep evidence honest.** Do not claim hands-on benchmark results unless the same task, environment and review method were documented. State when a page is a decision guide rather than a performance benchmark.
+10. **Verify the whole article.** Confirm screenshots load at natural dimensions, logos are legible, chapter anchors work, mobile/desktop layouts remain readable, metadata/canonical/schema are correct and every claim has visible support.
+
+For review, a Vercel PR preview is acceptable when it is actually accessible to the reviewer. Production remains the manual AWS workflow. Label the preview `REVIEW`, not `LIVE / VERIFIED`, and never imply that a Vercel preview changed AWS production.
+
+### Vibe Code Library
+
+Use the dedicated `feat/codespring-vibe-code-library` branch and strategy doc. An app page becomes indexable only when it has an original scoped verdict, realistic core loop, hard boundaries/exclusions, feature groups, original FAQs, sources/review date and meaningful related links. Draft pages stay out of the sitemap.
+
+The library’s conversion asset is not a generic directory listing: it is an honest plan/prompt/map for building a scoped substitute, with a real CTA destination.
+
+## 5. Listings and mentions
+
+Create one product-profile packet before using any directory:
+
+- product name and canonical URL;
+- 60-word and 160-character descriptions;
+- positioning/category;
+- logo, screenshots and approved demo link;
+- pricing/support/founder details that are true at submission time;
+- UTM-tagged referral URL;
+- owner, approval status and source evidence.
+
+### Qualification gate
+
+Use a listing only if at least one is true:
+
+- it reaches a relevant buyer/developer community;
+- it is a truthful review/integration/partner profile;
+- it can create editorial discovery or referral traffic;
+- it is a product launch with a real community response.
+
+Reject sites whose primary offer is selling “dofollow backlinks,” bulk link exchanges, spun descriptions or a large batch of low-quality submissions. Never create accounts, pay for placements, publish claims, or solicit reviews without approval and company-controlled credentials.
+
+Track every prospect in a ledger:
+
+`source | relevance | reason | proposed URL | rel | cost | owner | approval | submitted | live listing | referral sessions | sign-ups | review date`.
+
+Status labels are exact: **DRAFT**, **AWAITING APPROVAL**, **SUBMITTED**, **LIVE**, or **REJECTED**. Do not call a submission a live backlink until the public listing and outbound link are verified.
+
+## 6. Review and release checklist
+
+- [ ] Live and `origin/main` source inspected first.
+- [ ] Search intent and original evidence exist for each indexable page.
+- [ ] Daily desk targets five fully written review pages; every page independently passes the no-cannibalisation and original-value gates, and withheld slots have an explicit reason.
+- [ ] Every completed morning page has a directly openable, verified Vercel review route and one precise founder decision request.
+- [ ] Video briefs are limited to one or two high-value pages, use deliberately simple scope and do not block page review.
+- [ ] Canonical, title, description, server-rendered links and sitemap inclusion checked.
+- [ ] New Vibe Code pages pass the content gate.
+- [ ] Listing passes relevance/quality gate and has approval.
+- [ ] Editorial pages use article anatomy, first-party screenshots, approved logos, image provenance and real CodeSpring product assets.
+- [ ] Comparison tables are compact and scannable; internal links are visible without hover and point to the relevant homepage or documentation route.
+- [ ] Mobile/desktop and themes reviewed for UI changes.
+- [ ] `npx tsc --noEmit`, `npm run build` and `node --test tests/*.mjs` pass, or unchanged baseline failures are reported exactly.
+- [ ] Branch pushed, remote SHA verified and draft PR targets `main`.
+- [ ] Report review preview and AWS production status separately.
+- [ ] After approval and AWS verification, provide the sitemap/internal-link/Search Console indexing handoff; never imply a crawl request guarantees indexing.

--- a/.agents/skills/cs-seo-website/references/daily-seo-content-desk.md
+++ b/.agents/skills/cs-seo-website/references/daily-seo-content-desk.md
@@ -1,0 +1,153 @@
+# Daily SEO content desk
+
+Use this operating loop to prepare a founder-reviewable SEO packet each morning without turning volume into scaled-content spam.
+
+## Capacity rule
+
+The target is **five qualified opportunities and five fully written, review-ready page drafts** per working day.
+
+Five new indexable pages is a ceiling, not a quota. Build all five only when every page:
+
+- owns a distinct search intent and does not cannibalise an existing CodeSpring URL;
+- has current demand/SERP evidence and a credible CodeSpring conversion path;
+- contains original explanation, proof, product UI, example, tool or founder judgment;
+- passes the content, metadata, internal-link and visual verification gates independently.
+
+Five is a production target, not permission to lower the gate. If only three or four opportunities can become useful, non-overlapping pages, deliver those complete pages and state why the other slots were withheld. A slot may instead be an existing-page refresh, internal-link improvement, documentation expansion or customer-proof page when that is the better canonical answer. [Google defines scaled-content abuse](https://developers.google.com/search/docs/essentials/spam-policies#scaled-content) as generating many low-value or unoriginal pages primarily to manipulate rankings; speed never overrides usefulness.
+
+## Daily page mix
+
+Select from these lanes according to demand rather than forcing one of each every day:
+
+1. **Commercial comparison/category:** one substantial parent comparison or decision guide, not thin pairwise variants.
+2. **Problem-led guide:** answer a specific founder question with a real workflow, example or product proof.
+3. **Tool/template/checklist:** provide something immediately usable, with a truthful route into CodeSpring.
+4. **Refresh/internal-link slot:** improve an existing canonical page that already owns the intent.
+5. **Proof/docs/story slot:** deepen product documentation, customer evidence or a founder-led story only when the source material exists.
+
+Instagram, TikTok, YouTube and sales-call material are **inputs**, not automatic landing pages. Extract repeated questions, objections, language and hooks; then validate search demand and intent before choosing the correct canonical page. Consolidate overlapping clips into one strong resource instead of making one URL per clip.
+
+## Morning workflow
+
+### 1. Refresh the evidence backlog
+
+Use, in order:
+
+1. Search Console query/page performance and existing content gaps;
+2. the monthly cached DataForSEO demand/difficulty/SERP dataset;
+3. a live SERP check for only the shortlisted queries;
+4. recent sales-call objections and social-video topics as qualitative signals;
+5. the current Resources, Docs, Blog and Vibe Code inventories to detect cannibalisation.
+
+For every candidate record: query, country, intent, volume/date, difficulty signal, SERP composition, existing CodeSpring owner, product fit, original evidence, CTA and proposed lane.
+
+### 2. Rank five opportunities
+
+Score each opportunity on demand, commercial/problem intent, CodeSpring fit, ability to add original value, ranking feasibility, production effort and cannibalisation risk. Reject a candidate if its only distinction is a slight keyword variation.
+
+Attempt full production for all five in rank order. Withhold a candidate rather than turn it into a thin page when it fails a gate. The morning packet must say exactly which gate failed.
+
+### 3. Build complete review drafts
+
+For each selected page:
+
+- create or improve the canonical route in a review branch;
+- lead with the reader's answer, not a CodeSpring pitch;
+- include original examples, accurate product positioning and first-party proof;
+- add visible contextual links to the homepage and relevant documentation;
+- use authentic screenshots, meaningful alt text and source provenance;
+- set title, description, canonical, schema decision, sitemap/index state and CTA;
+- run contract tests and render the finished page.
+
+Before founder review, run a plain-language editing pass that protects meaning rather than chasing a low word count:
+
+- define the term with ordinary words such as `done`;
+- make each causal chain explicit: original feature → later change → regression → check or test;
+- replace compressed fragments or concatenated states with complete natural sentences;
+- use bullets for three or more parallel checks, edge cases, steps or outcomes;
+- break up dense prose with useful lists, examples, screenshots or diagrams, not decorative cards;
+- read the page aloud and rewrite any sentence whose subject, action or result is unclear;
+- verify every first-person experience against founder feedback or a first-party source.
+
+Do not publish filler, doorway pages, fake FAQs, fabricated benchmarks, copied SERP text or AI-redrawn product UI.
+
+### 4. Produce accessible review URLs
+
+Localhost is internal verification only. Push the review branch and create a Vercel PR preview for every page. Verify the latest deployment is ready and that the supplied route resolves. If Vercel authentication blocks the founder, label the packet **BLOCKED: REVIEW ACCESS** rather than pretending the page was reviewed.
+
+The morning packet must include one directly openable review URL per completed page. Label these **REVIEW**, never **LIVE / VERIFIED**. AWS remains production and is a separate approved deployment step.
+
+### 5. Send the founder review packet
+
+Use `templates/morning-seo-review.md`. The Telegram message itself stays within five short bullets and links to the durable packet when detail exceeds that limit.
+
+For each page show:
+
+- status and review URL;
+- target query, audience intent and why this page now;
+- what was written or changed;
+- CodeSpring positioning and CTA;
+- evidence/assets still needed;
+- the exact founder decision or correction requested.
+
+### 6. Assign one or two video briefs
+
+Choose the pages where a founder video adds proof, trust or demonstration value. A video is optional; it must not delay pages that stand on their own.
+
+Every video brief includes:
+
+- working YouTube title and thumbnail promise;
+- one-sentence hook;
+- three teaching beats;
+- exact screen/demo sequence;
+- CodeSpring positioning and CTA;
+- maximum build scope and estimated filming effort.
+
+Keep demonstrations intentionally small. Default to no authentication, database, backend, payments, deployment or multi-user state. Prefer a single-screen utility, static interaction, local-data example, one workflow or a screen-led comparison. For comparisons, demonstrate current interfaces and decision criteria without inventing a benchmark or winner.
+
+### 7. Produce thumbnails only after the angle is approved
+
+After the page and video angle are accepted, create one or more thumbnail candidates. Use a short promise, one focal idea and authentic CodeSpring/product evidence where the claim needs it. Never redraw readable product UI or fabricate results. Deliver the thumbnail as a review asset, not as a published YouTube asset.
+
+### 8. Publish only after approval
+
+Apply founder feedback, rerun tests and refresh previews. Merge only the approved pages. AWS deployment, sitemap verification, Search Console indexing request and public URL checks remain separate explicit actions.
+
+Track exact states:
+
+`OPPORTUNITY → BRIEFED → REVIEW → REVISION → APPROVED → MERGED → AWAITING AWS DEPLOYMENT → LIVE / VERIFIED → 14/28/56-DAY REVIEW`
+
+### 9. Hand off indexing after approval and production verification
+
+Google can discover pages automatically through crawlable internal links and the XML sitemap, but discovery and indexing are not guaranteed. Do not request indexing while a page is only on Vercel or merely merged.
+
+After Sebastian approves the page and the AWS production deployment is independently verified:
+
+1. verify the public URL returns `200`, renders the approved content, uses the intended self-canonical and is not `noindex`;
+2. verify the URL appears in `https://codespring.app/sitemap.xml` and has crawlable internal links from the relevant hub/related pages;
+3. verify the sitemap is already submitted in the correct Search Console property; submit or refresh the sitemap only when needed rather than repeatedly every day;
+4. for a small number of priority URLs, open URL Inspection in Search Console, test the live URL and use **Request indexing**;
+5. record the request date and monitor the Page indexing/URL Inspection status—do not repeatedly resubmit the same URL;
+6. report separately: `AWS LIVE / VERIFIED`, `SITEMAP VERIFIED`, `SEARCH CONSOLE REQUESTED`, and `INDEXED / VERIFIED`.
+
+[Google's recrawl guidance](https://developers.google.com/search/docs/crawling-indexing/ask-google-to-recrawl) says crawling can take from a few days to a few weeks, individual URL requests have quotas, repeated requests do not make crawling faster, and a crawl request does not guarantee inclusion. For many URLs, the sitemap is the discovery mechanism; URL Inspection is for a small priority set.
+
+The founder handoff must say exactly what happens next: approve revisions → merge → AWS deploy → production QA → sitemap/internal-link verification → Search Console request for priority URLs → monitor indexing and performance.
+
+## Durable daily register
+
+Keep one row per candidate/page with:
+
+`date | source signal | query | country | intent | volume/date | difficulty | SERP shape | existing owner | lane | route | original evidence | CTA | branch | PR | review URL | status | video priority | video URL | thumbnail path | AWS status | live URL | Search Console request | 14/28/56-day outcome`
+
+Use the register to prevent duplicate pages, lost review URLs and unmeasured publishing.
+
+## Completion criteria
+
+A morning run is complete only when:
+
+- five evidence-backed opportunities are ranked;
+- up to five complete pages have verified remote review URLs, with explicit reasons for every withheld slot;
+- one or two video briefs are selected when video materially helps;
+- no page is called published or live;
+- the durable register and founder review packet are updated.

--- a/.agents/skills/cs-seo-website/templates/morning-seo-review.md
+++ b/.agents/skills/cs-seo-website/templates/morning-seo-review.md
@@ -1,0 +1,72 @@
+# Morning SEO review — {{date}}
+
+**Packet status:** {{REVIEW | PARTIAL / BLOCKED}}
+**Production status:** AWS unchanged unless a separately verified deployment is recorded.
+
+## Today's ranked opportunities
+
+| Rank | Target query / intent | Lane | Existing owner | Evidence | Decision |
+|---|---|---|---|---|---|
+| 1 |  |  |  |  | BUILD / REFRESH / BRIEF |
+| 2 |  |  |  |  | BUILD / REFRESH / BRIEF |
+| 3 |  |  |  |  | BUILD / REFRESH / BRIEF |
+| 4 |  |  |  |  | BUILD / REFRESH / BRIEF |
+| 5 |  |  |  |  | BUILD / REFRESH / BRIEF |
+
+## Review pages
+
+### 1. {{page title}}
+
+- **Status:** REVIEW
+- **Review URL:** {{direct Vercel route}}
+- **Target query:** {{query, country, volume/date and intent}}
+- **Why this page:** {{SERP gap + CodeSpring fit}}
+- **What is original:** {{example, proof, screenshots, tool or founder judgment}}
+- **CodeSpring position:** {{truthful role in this topic}}
+- **Internal links:** {{homepage + relevant docs/resources}}
+- **CTA:** {{destination and user action}}
+- **Needs from Sebastian:** {{one precise decision/correction}}
+
+Repeat for each completed page.
+
+## Video assignments
+
+### Video 1 — {{working title}}
+
+- **Supports page:** {{review URL}}
+- **Thumbnail promise:** {{3–6 words}}
+- **Hook:** {{one sentence}}
+- **Three beats:**
+  1. {{beat}}
+  2. {{beat}}
+  3. {{beat}}
+- **Demo:** {{simple screen sequence}}
+- **Scope guard:** No authentication, database, backend, payments or deployment unless explicitly approved.
+- **CTA:** {{one next step}}
+- **Estimated filming effort:** {{minutes}}
+
+Repeat only when a second video materially improves the day's pages.
+
+## Blockers and approvals
+
+- {{missing proof, source, product claim approval, screenshot, review access or deployment dependency}}
+
+## Indexing handoff — after approval and AWS deployment
+
+- **Public URL:** {{production URL}}
+- **AWS production QA:** {{AWAITING DEPLOYMENT | LIVE / VERIFIED}}
+- **Canonical/noindex:** {{verified result}}
+- **Sitemap:** {{present / missing / submitted}}
+- **Internal discovery links:** {{verified hub/related URLs}}
+- **Search Console:** {{NOT REQUESTED | REQUESTED on date | INDEXED / VERIFIED}}
+- **Next action:** {{exact owner/action}}
+
+Do not request indexing for a Vercel preview or merged-but-undeployed page. For a few priority pages, use Search Console URL Inspection after production verification. Do not repeatedly request the same URL; Google states this does not make crawling faster and indexing is not guaranteed.
+
+## After feedback
+
+1. Apply requested revisions.
+2. Refresh each remote preview and verify it is ready.
+3. Request explicit approval to merge.
+4. Keep AWS deployment separate.
+5. Record live URL and Search Console request only after verification.

--- a/.claude/skills/codespring/SKILL.md
+++ b/.claude/skills/codespring/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: codespring
+description: >
+  Project planning and management with CodeSpring. Use when the user wants to
+  work with CodeSpring projects, tasks, PRDs, mindmaps, or analyze a codebase
+  for project planning. Handles workspace selection, project linking, task
+  management, and syncing findings to CodeSpring.
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(node:*)
+metadata:
+  author: codespring
+  version: "1.1"
+---
+
+# CodeSpring CLI
+
+Manage project planning: workspaces, projects, tasks, PRDs, and mindmaps.
+
+## Prerequisites
+
+- **CLI installed**: `npm i -g @codespring-app/cli` or use `npx @codespring-app/cli`
+- **Authenticated**: Run `codespring auth status` to check. Login with `codespring auth login`.
+- **Project linked**: Check for `.codespring/config.json` or run `codespring init`.
+
+## Quick Start
+
+```bash
+# 1. Check auth
+codespring auth status
+
+# 2. Link project (interactive — picks workspace → project → writes config)
+codespring init
+
+# 3. Start working
+codespring tasks --status todo
+```
+
+## Core Commands
+
+| Command | Purpose |
+|---------|---------|
+| `codespring workspaces` | List available workspaces |
+| `codespring projects [--org ID]` | List projects |
+| `codespring project create --name <n>` | Create a new project |
+| `codespring features` | List features for linked project |
+| `codespring feature create --title <t>` | Create a feature |
+| `codespring tasks [--status S] [--feature ID]` | List tasks with filters |
+| `codespring task create --title <t> [--priority P]` | Create a task |
+| `codespring task start <id>` | Mark task as in_progress |
+| `codespring task done <id>` | Mark task as done |
+| `codespring task update <id> --status <s>` | Update task fields |
+| `codespring prds` | List PRDs by feature |
+| `codespring prd <id>` | Get full PRD content |
+| `codespring prd sync <id> --file <path>` | Update PRD from file |
+| `codespring mindmap` | Get mindmap structure |
+| `codespring mindmap set-info --title <t>` | Update project info node |
+| `codespring mindmap tech-stack --add '<json>'` | Sync tech stack |
+| `codespring mindmap features --add '<json>'` | Sync features |
+| `codespring mindmap note <featureId> --text '...'` | Add feature notes |
+| `codespring schema` | Data schema reference |
+| `codespring node-types` | Mindmap node type reference |
+
+**Note:** Task IDs can be UUIDs or row numbers (e.g., `task start 1` picks the first task from the list).
+
+## Output
+
+All commands default to markdown in terminals, JSON when piped.
+Add `--json` to force JSON, `--pretty` for formatted JSON, `--md` for markdown.
+
+## Agentic Task Workflow
+
+```bash
+# 1. Find available work
+codespring tasks --status todo
+
+# 2. Claim a task (UUID or row number)
+codespring task start 1
+
+# 3. Do the work using your coding tools
+
+# 4. Mark done
+codespring task done 1
+
+# Or create a new task
+codespring task create --title "Fix login bug" --priority high
+```
+
+## Syncing Codebase Analysis
+
+After analyzing a codebase, sync findings:
+
+```bash
+# Sync detected technologies
+codespring mindmap tech-stack --add '[{"id":"tech-react","title":"React","description":"Frontend"}]'
+
+# Sync discovered features
+codespring mindmap features --add '[{"title":"Authentication","description":"User login/signup"}]'
+
+# Add analysis notes to a feature
+codespring mindmap note feature-auth --text "Uses OAuth2 with PKCE flow..."
+```
+
+## Generating PRDs
+
+The CLI reads and syncs PRDs; it does not yet generate them. PRD generation and attaching PRD nodes to the canvas is a direct API call the CodeSpring app uses — see [prd-management.md](references/prd-management.md) and [mindmap-structure.md](references/mindmap-structure.md). The `cs-build-create-prd` skill wraps this end-to-end.
+
+## Scripts — run the checks, don't eyeball them
+
+**A check is a script; a judgement is prose.** Anything that must give the same answer every run lives in `scripts/`, read-only, writing nothing to the project or the repo:
+
+```bash
+bash scripts/fetch-project.sh --out /tmp/cs-state   # snapshot the linked project's JSON; prints the projectId
+node scripts/state.mjs        /tmp/cs-state         # the one-line state summary + booleans and counts
+node scripts/check-map.mjs    /tmp/cs-state [--expect-core N]   # map quality + post-write verification
+```
+
+`check-map.mjs` settles the core-feature count, duplicate titles, sub-features flattened to top level, missing notes, duplicate PRDs and unlinked tasks; exit 1 = a real failure, 2 = warnings only. Whether the map is *good* — sidebar-level features, verbs for sub-features, one-sentence card descriptions — stays a judgement and stays in prose. `cs-build-audit-codebase/scripts/check-repo.sh` does the same for the git/delivery reality.
+
+## Detailed References
+
+- [project-state.md](references/project-state.md) — **Start here.** State detection so any skill can be entered from anywhere; **the five questions that decide whether code is worth building on**; the Understand → Plan → Build stages and the seam between them; the map-quality caveat and the two-projects case; the quick health smell test
+- [auditing-and-fixing.md](references/auditing-and-fixing.md) — The audit → verdict → map → tasks pipeline; where audit errors actually come from (the orchestrator's own summarising); the moving-target/git reality; why the map shows the target; the rebuild-vs-fix decision table **and the has-users gate**; the defect categories worth hunting; scope discipline (problems / could-add-later / not-worth-adding) and where future ideas live; plain-language rules; idempotency + verification; FERB edge cases
+- [commands.md](references/commands.md) — Full CLI reference with all flags
+- [task-workflow.md](references/task-workflow.md) — Agentic task execution patterns
+- [analyze-codebase.md](references/analyze-codebase.md) — Codebase analysis checklist (stack detection + deep feature/backend/frontend passes; choosing the smallest core-feature set)
+- [mindmap-structure.md](references/mindmap-structure.md) — Mindmap data formats and node types (incl. PRD bridge nodes)
+- [prd-management.md](references/prd-management.md) — PRD read/sync + generate/attach/dedupe
+- [pitfalls.md](references/pitfalls.md) — Failure modes & guardrails (not checking what exists, wrong-project, flattening, duplicate PRDs, `features --replace` appending, no project delete/move)
+
+## Related skills
+
+This `codespring` skill is the shared knowledge base (how CodeSpring works + the CLI). The task-specific skills build on it. **Every one of them detects the project's real state on entry** (`project-state.md`), so it does not matter which the user invokes:
+
+- `cs-build-getting-started` — connect, report where the project actually is, and name the single next step. Routes on two questions: **is there code**, and **does it do the job** (the five questions in `project-state.md` — never "do we trust it").
+- `cs-build-plan-app` — no code yet, just an idea or a call recording. Interviews or mines the source, picks the platform on capability, proves the one hard part, cuts to a sellable v1, then writes the map and notes.
+- `cs-build-audit-codebase` — diagnose a codebase that isn't doing its job (run it, parallel specialists, git/CI audit), write a plain-English `FINDINGS.md`, and give a rebuild-or-fix-in-place verdict.
+- `cs-build-import-codebase` — map a repo into CodeSpring. With an audit it builds the corrected target map and findings-derived tasks; without one it documents what exists. Owns the map-quality ladder and the node model.
+- `cs-build-ui-mockup` — a throwaway clickable mockup and style guide from the notes, reviewed with the client, corrections fed back into the plan. **Before the PRDs**, for anything with a user interface.
+- `cs-build-create-prd` — generate a Frontend/Backend PRD for a chosen feature (the single source of truth for PRD creation).
+- `cs-build-create-tasks` — turn a feature's PRDs into a numbered, parallel-safe task list.
+- `cs-build-handoff` — turn the finished plan into the pack a paying client actually receives.
+- `cs-build-feature` — interactive build orchestrator (readiness checks → up to 5 sub-agents → break-risk guards).
+- `cs-build-resync-codebase` — keep CodeSpring in sync with the built code (read-only on code). This is what makes a target map describe reality again once the tasks are done.
+
+See `references/codespring-docs.md` for guiding users through web-app-only steps, and `claude-templates/` (repo root) for per-platform `CLAUDE.md` starters.

--- a/.claude/skills/codespring/references/analyze-codebase.md
+++ b/.claude/skills/codespring/references/analyze-codebase.md
@@ -1,0 +1,113 @@
+# Codebase Analysis Checklist
+
+Use this checklist when analyzing a local codebase to sync findings to CodeSpring. Sections 1–5 identify the stack and rough feature list. Sections 6–9 go deeper — they are what make notes and PRDs accurate. Read the code; don't guess.
+
+## 1. Project Identity
+
+- Read `package.json` for: name, version, description, scripts
+- Read `README.md` for: description, feature list, setup instructions
+
+## 2. Dependencies Analysis
+
+From `package.json` dependencies/devDependencies, identify:
+
+### Frontend Frameworks
+`react`, `react-dom`, `next`, `vue`, `nuxt`, `svelte`, `solid-js`, `angular`, `astro`, `remix`
+
+### Backend Frameworks
+`express`, `fastify`, `hono`, `koa`, `nestjs`, `elysia`, `hapi`
+
+### Database/ORM
+`prisma`, `drizzle-orm`, `mongoose`, `typeorm`, `sequelize`, `knex`, `pg`, `redis`, `ioredis`
+
+### State Management
+`zustand`, `jotai`, `recoil`, `valtio`, `mobx`, `xstate`, `redux`, `@reduxjs/toolkit`
+
+### Styling
+`tailwindcss`, `styled-components`, `@emotion/react`, `sass`, `@vanilla-extract/css`
+
+### Testing
+`jest`, `vitest`, `mocha`, `cypress`, `playwright`, `@testing-library/*`
+
+## 3. Directory Structure
+
+| Directory | Indicates |
+|-----------|-----------|
+| `src/app/` | Next.js App Router |
+| `src/pages/` | Next.js Pages Router |
+| `src/components/` | Component library |
+| `src/features/` | Feature-based architecture |
+| `src/hooks/` | Custom React hooks |
+| `src/lib/` or `src/utils/` | Utility functions |
+| `src/services/` | API/business logic |
+| `prisma/` | Prisma ORM |
+| `drizzle/` | Drizzle ORM |
+
+## 4. Feature Discovery
+
+Identify features from:
+1. **Route segments**: `/dashboard`, `/settings`, `/billing`
+2. **Feature directories**: `features/auth`, `features/payments`
+3. **README sections**: "Features", "What's Included"
+4. **Component directories**: Major UI sections
+
+## 5. Sync to CodeSpring
+
+### Tech Stack
+```bash
+codespring mindmap tech-stack --add '[
+  {"id":"tech-react","title":"React","description":"Frontend"},
+  {"id":"tech-typescript","title":"TypeScript","description":"DevTools"}
+]'
+```
+
+### Features
+```bash
+codespring mindmap features --add '[
+  {"title":"Authentication","description":"User login/signup"},
+  {"title":"Dashboard","description":"Main user interface"}
+]'
+```
+
+### Project Metadata
+Update project name/description if discovered from package.json/README.
+
+---
+
+## 6. Find the TRUE core features — read the sidebar first, then cut
+
+Section 4 gives candidates; this pins them down. In most webapps the **core features are the sidebar / primary-nav items = pages**. Find and read the nav/sidebar component (search for `sidebar`, `nav`, `navItems`, `routes`) and take its entries as the candidate list. Only fall back to routes/README when there is no nav. A core feature is the highest-level thing a user recognizes as "a thing the app does"; it should map to a page/section, not a file.
+
+**Then cut the list down.** Aim for **4–8 core features.** Above 8, argue for each one; above 10 you have almost certainly split one feature into many. Merge screens that are one job spread across pages, and drop pages the app shouldn't have (dead ends, orphans, internal galleries). A real run produced **13 confusing** core features before being cut to **6 clean** ones — the smaller list was the correct one. Read the list back to the user and ask them to cut it further before writing anything.
+
+## 7. Sub-features — things a user DOES
+
+Under each core feature, list the specialized capabilities that make it work — the actions inside that page, e.g. under a "Projects" page: Create Project, Invite Teammate, Project Detail. **A sub-feature is a verb: something the user does.** Create them parented to the core feature (`codespring feature create --parent <coreFeatureId>`). Keep descriptions to one sentence; depth goes in the note/PRD.
+
+**Do not turn report/page sections or form field-groups into sub-features.** This is the specific mistake that produced the 13-feature mess:
+- **A report or output section is not a feature.** "Government costs", "Tax benefits", "Glossary" are parts of one feature's output. Twelve report sections make **one** feature plus a good note — not twelve features.
+- **A form field-group is not a feature.** "Location", "Loan details", "Property details" are parts of one feature's input. The feature is *analysing a property*; those are panels of it.
+
+Symptoms you got this wrong: core features that read like a table of contents; sub-features that are nouns; more features than the app has screens; two sub-features a user couldn't tell apart. If detail is being lost, the **note** is too thin — enrich it rather than adding features.
+
+## 8. Backend depth (feeds the note + Backend PRD)
+
+For each core feature capture:
+- **API routes** — path, method, request/response, auth. **Flag any route used by more than one feature** (shared routes are where new features accidentally duplicate work).
+- **Data model** — tables/collections, key columns, enums, relationships; what's read vs written.
+- **Server actions / services / queries** — the reusable functions that already exist (new features should call these, not re-implement them).
+- **Security** — authn/authz, ownership checks, input validation, secrets/keys, row-level security, webhook signature verification.
+- **Shared backend systems** (call these out explicitly — new features collide with them): hosting/deploy target (AWS, Vercel…) and platform limits; crediting/usage metering; payment, subscription, and **refund** systems; background **jobs / pipelines / queues / cron**; storage — **S3 conventions / buckets**, file paths, signed-URL patterns; media/render pipelines (e.g. Remotion/video compositions); databases + migrations; **auth and row-level security (RLS)**; **environment variable names** to reuse; webhooks + signature verification.
+- **External services & env vars** — every integration and the env vars it needs.
+- **Infra & gotchas** — request timeouts/limits, async or polling jobs, hardcoded hosts, rate/credit logic, orphan/misnamed routes.
+- **Dependency / break-risk map** — what depends on this feature's code, so a future change doesn't silently break another feature.
+
+## 9. Frontend depth (feeds the note + Frontend PRD)
+
+- **Design tokens** — colors/branding, corner radius, spacing scale, typography, shadows (pull from the Tailwind config, CSS variables, or theme file).
+- **Component & UI styles** — which UI library, how buttons/cards/inputs/modals are styled, and their states (hover/active/disabled).
+- **Layout, positioning & spacing** — grid/flex, columns, breakpoints, gaps; where things sit relative to each other. Be concrete.
+- **What the user sees** — header, sections, cards, tables, empty/loading states, toasts.
+- **Navigation / interaction map** — the concrete path to and through the feature: which nav item/button opens it, what route it lands on, what it shows, and what each interaction does. Also where it links FROM and TO other features.
+
+Sections 8–9 are what you write into each core feature's "how it works" note before generating PRDs — the generator uses that note as context.

--- a/.claude/skills/codespring/references/auditing-and-fixing.md
+++ b/.claude/skills/codespring/references/auditing-and-fixing.md
@@ -1,0 +1,363 @@
+# Auditing & Fixing a Broken Codebase
+
+The process CodeSpring uses when a user says *"my app is a mess"*. This file holds the **reasoning**, not just the steps, because it is also the knowledge FERB needs to run this workflow without a user invoking a skill.
+
+Read this alongside `project-state.md` (**start here — how every skill detects where the project already is**), `analyze-codebase.md` (how to read a codebase), `mindmap-structure.md` (how the map is stored), `pitfalls.md` (CLI failure modes), and `task-workflow.md`.
+
+> **It must not matter which skill the user runs.** Every skill in this pipeline opens with the state-detection block in `project-state.md`, reports where the project actually is, and does the right *next* thing rather than the thing its own name implies. An audit run against a project that already has a good map updates that map — it does not build a second one.
+
+---
+
+## 1. Two entry points, split by intent
+
+There is one pipeline but two front doors, because users arrive with two different intents and they need different first moves.
+
+| The user says | Intent | Skill | First move |
+|---|---|---|---|
+| "get my app into CodeSpring", "map my app" | *Understand what I have* | `cs-build-import-codebase` | Document what exists |
+| "my app is a mess, diagnose it and plan the fix" | *Tell me what's wrong and what to do* | `cs-build-audit-codebase` | Diagnose, then hand off |
+
+**Routing is two questions: is there code, and does it do the job?** The second one is **never** "do we trust the code?" — that phrasing is meaningless to the person answering. It is the five questions in `project-state.md`:
+
+1. Does the app do what it actually needs to do?
+2. Is it getting things wrong, or presenting made-up or unverifiable figures as fact?
+3. Does the current architecture allow it to do what it needs to do?
+4. Can we build on it scalably?
+5. Can users use it without it breaking?
+
+**All five yes → keep building on it** (import). **Any no → consider rebuilding that part, or all of it** — which starts with an audit, because the audit is what turns a "no" into a specific, sized list, and the verdict (§5) decides fix-or-rebuild. **"The code runs" is not the same as "the code does the job":** a vibe-coded app very often runs fine and still fails 1–3.
+
+**Why split rather than one skill with a flag:** the audit is expensive (parallel sub-agents, running the app, hours of work) and the import is cheap. Code that does its job must not pay for an audit it doesn't need, and code that doesn't must not get a map of its own mess. Splitting by intent means the router asks two questions instead of interrogating the user.
+
+**Split by intent, not by hierarchy.** There is no wrapper skill and no routing tree. Both doors lead to the same pipeline, and each door is state-aware enough to be entered by mistake: an import that smells a broken codebase offers the audit first, and an audit that finds an existing map keeps it. See `project-state.md`.
+
+`cs-build-audit-codebase` does not build the map itself. It produces findings + a verdict and hands both to `cs-build-import-codebase`. One code path builds maps.
+
+---
+
+## 2. The pipeline
+
+```
+audit  ──►  verdict  ──►  map  ──►  tasks
+(what's   (rebuild or   (the      (the gap between
+ wrong)    fix in place)  target)   here and there)
+```
+
+1. **Audit** — run the app, fan out specialists, verify the headlines, audit the repo itself. Output: evidence-labelled findings + a plain-English `FINDINGS.md`.
+2. **Verdict** — rebuild, or fix in place. Argued against an explicit table (§5). Default is fix in place.
+3. **Map** — the corrected target feature map (§6). Same shape on both verdicts.
+4. **Tasks** — the gap between the map and reality, one task per defect or per feature-to-build, each mapped to a core feature and carrying a severity (§7).
+
+Stages 1–3 are **Understand** (they produce context). Stage 4 and PRDs are **Plan** (they produce instructions). The seam between them, and why a PRD is only as good as the note it reads, is in `project-state.md`.
+
+Every stage is idempotent and re-runnable (§8), and every stage may be entered directly — check what already exists first and skip what is already done.
+
+---
+
+## 3. Auditing: how to actually find things
+
+### Run the app. Do not only read it.
+The single highest-yield step. In the real audit this workflow was built from, driving the live app in a browser found things static analysis missed and *disproved* things static analysis suspected:
+
+- A form field cleared to empty threw an exception, the recompute aborted, and the report **kept displaying the previous numbers** with no error. Unreadable from the source; obvious in 10 seconds live.
+- The network panel proved the core calculation made **zero network requests** — which answered "how does it read the database?" with "it doesn't", and reframed the whole audit.
+- A "type anything to sign in" screen looked like an auth bypass in the code. Driving it showed a clearly labelled sample mode. **Running it prevented a false accusation.**
+
+So: start the app (or serve it), drive the main journeys, watch the console and the network panel, try empty and absurd inputs, and inspect where data is actually stored.
+
+### Fan out parallel specialists by domain
+Spawn independent sub-agents, one per domain, each read-only, each with a self-contained brief. Do not let them see each other's work — agreement between two independent methods is your strongest evidence.
+
+Standard domains: **security/auth**, **database/schema**, **core business logic**, **frontend/UX/dead controls**, **architecture/scalability**. Add domains the app clearly needs (a competitor comparison, a user-journey map, a data-provenance pass).
+
+Every finding must carry (a) a `file:line` reference or the exact command that reproduces it, and (b) an evidence label:
+
+- **CONFIRMED** — the agent ran it or read the exact line. Say what it ran.
+- **INFERRED** — deduced from code that was read, not executed. Say what the inference is.
+- **UNVERIFIED** — suspected, could not be checked. Say what would check it.
+
+Findings without a citation and a label do not go in the report. Ranking by consequence is impossible when confidence is unknown, and a confident wrong claim about someone's app destroys the audit's credibility.
+
+### Verify the headline claims yourself
+Do not relay a sub-agent's biggest number without independently reproducing it. In the real audit the orchestrator re-ran the core logic in a second, unrelated way (extracted into a scratch script) and separately in the live browser; both agreed to the cent, which is what made the headline dollar figure safe to put in front of a client. Where two methods agree, say so in the report.
+
+Also check for **contradictions between specialists** and resolve them before writing. A later, better-informed pass corrected an earlier one's table-ownership claim in the real audit; the corrected version is what shipped.
+
+### Audit the repo and delivery setup, not just the code
+Routinely skipped and routinely where the worst risk is:
+
+- **Is the local clone behind the remote?** `git fetch --all`, then compare `HEAD` with the upstream. Check this **first**, not last, report **how many commits behind**, and **offer to update before auditing** — findings from a stale clone may already be fixed. `cs-build-audit-codebase/scripts/check-repo.sh` does the whole check deterministically.
+- **What else is in flight?** Enumerate the remote branches with their dates and authors, so you do not write findings against work that has already been superseded.
+- **Is anyone else working in this repo right now?** Ask. If yes, the findings are a **snapshot at a named commit**: record the commit SHA in `FINDINGS.md` and recommend a **dedicated branch** for the fixes, saying plainly that merge conflicts will need managing.
+- **Assume the owner does not know git, and do not lecture them about it.** Non-technical owners commonly commit straight to `main` while an audit or rebuild is in flight. **Never assume a clean linear history, and never assume `main` is protected.** State what you are doing and why in one line and move on.
+  *Worked example: 12 remote branches, the owner committing directly to `main`, a helper working in parallel, and the audited clone 3 commits behind — with the newest commits touching the exact file under audit.*
+- **Is the app feature-complete, or still being built?** Ask this too, because it changes what "missing" means. If it is still being built, the map may be missing planned modules that the code does not contain yet, so **ask the owner what is planned but not yet built before finalising the feature list.** Real failure: an audit concluded that four pages were a separate product because nothing linked to them — they were unfinished modules of the same product.
+- **Is the whole backend even in the repo?** In the real case the entire server (13 endpoints, all SQL, the only definition of five tables) existed **only** inside a hosting dashboard — not in git, not on the machine. That is a total-loss risk and it was invisible from the code.
+- **Branch and PR structure** — is there a default branch, are branches short-lived, is work reviewed?
+- **CI** — does any automated check exist? Is deploy **gated** on it, or does merging ship straight to production? Auto-deploy with no test gate is the mechanism by which the real app shipped wrong tax law to production for nine days.
+- **Secrets in history** — scan for committed keys/tokens (`git log -p -S` for the obvious markers). Report the negative result too; "no privileged key was ever committed" is one of the most valuable things you can tell someone.
+- **Is there a staging environment?** If credentials are string literals, every preview and local session is talking to the production database.
+- **`.gitignore` adequacy** — fix this *before* telling anyone to commit their backend.
+
+---
+
+## 3a. Where audit errors actually come from
+
+The CONFIRMED / INFERRED / UNVERIFIED labels in §3 apply to **sub-agent output**. In the audit this workflow was generalised from, **nothing checked the orchestrator's own summarising — and that is where every error entered.** The specialists were careful; the write-up that compressed them was not. Label the sub-agents, then audit yourself against the rules below.
+
+Each one is a real mistake that reached the page. The specifics come from one audit of one app and are **labelled worked examples, not assumptions about the codebase in front of you** — the rule is the part that generalises.
+
+1. **Measuring one thing and claiming something broader.**
+   What happened: browser storage was measured on a single page — 45 bytes across 3 keys — and the write-up stated it as a fact about the whole app, which actually used 15 keys product-wide.
+   **Rule: state the scope of every measurement in the same sentence as the number.** *"45 bytes across 3 keys on the report page"* is true; *"45 bytes across 3 keys"* is not.
+
+2. **Compressing a sub-agent's finding into something stronger than it said.**
+   What happened: the write-up said *"the tax tables have drifted between the two engine copies."* A mechanical diff showed the rate tables were **byte-identical** — a different function had drifted. The claim sent the reader to the wrong file to fix the wrong thing.
+   **Rule: before repeating a sub-agent's headline claim, re-run the one command that proves it.** One `diff` would have caught this.
+
+3. **Overstating an advantage.**
+   What happened: the app was called "ahead" of the incumbent product on a feature when it had solved only the easy half of it — one property in one state, not land added up across a portfolio, which was the exact part the incumbent said was too hard.
+   **Rule: when claiming an app does something better, state what it does NOT do in the same breath.** "Better" with no boundary is a claim the owner will repeat to a customer.
+
+4. **Jargon that meant nothing to the reader.**
+   What happened: *"versioned rate tables stamped onto the saved file."* The person it was written for could not act on it.
+   **Rule: every term of art gets explained in the sentence it appears in, or is replaced.** The plain rewrite: *"when you save a report, also save which year's tax rates it used, so fixing a rate later doesn't change what a client was already shown."*
+
+5. **Concluding that part of the codebase was out of scope.**
+   What happened: four pages were called "a separate product" because nothing linked to them and they loaded a different script. The evidence was real, the conclusion was wrong. `git log` showed those files untouched since the initial import while everything around them changed weekly, and the owner had separately said he still had to work out the workflow for that part of the app — *"there is about 5-6 pages to it."* They were **unfinished modules of the same product**, not a different product.
+   **Rule: before concluding that part of a codebase is out of scope, check its git history and ask the owner.** Code that nothing references may be unfinished rather than foreign. `git log --format="%ad %s" -- <path>` per file is cheap and decisive: **a file untouched since the initial import while its siblings change weekly is a strong signal of "not finished yet", not "not part of this."**
+
+### The check that catches all five
+
+**Before writing the findings, list your headline claims and name the specific evidence for each one** — the command you ran, the `file:line` you read, or the screen you drove. **Anything you cannot point at gets dropped, or goes in labelled as unverified.** Write the list out deliberately; it takes minutes, and it is the only step that inspects the orchestrator's own work rather than a sub-agent's.
+
+---
+
+## 4. Defect categories worth hunting
+
+These recur across languages and stacks. Hunt them explicitly rather than hoping to notice them.
+
+### Stale hardcoded reference data
+Rates, prices, tax tables, fee schedules, thresholds, feature lists — anything with an expiry date — typed as literals into shipped source. The mechanism costs a deploy to update. The real cost is that **nothing notices when it expires**, and the output usually keeps asserting the data is current.
+*Real case: eight jurisdictions' tax tables as literals in a web page, plus a printed claim that they were "current for FY2026-27", with nothing checking the date.*
+Fix pattern: move to versioned records with `effective_from` / `effective_to`, ask "which value applied on the date of this event", surface a staleness warning when today is past the range, and stamp the version onto anything published.
+
+### Duplicated logic that has drifted
+The same function, table, or constant existing in two or more places. It is only a smell until it drifts — then it is a correctness bug that no single file review can see.
+*Real case: the calculation engine existed twice; the copy the secondary pages used stayed a financial year behind for nine days, so the same property produced different government charges on different pages. Nobody noticed because there were no tests.*
+Look for: copy-pasted modules, a "shared" file the main entry point never actually imports, constants defined more than once, and design tokens forked across stylesheets. Build a **duplication register**: what, how many copies, has it drifted, which copy is authoritative.
+
+### Silent failure paths
+An error that becomes a zero, an empty object, a stale screen, or a success message. The worst class of bug because the user cannot tell it happened.
+Signatures to grep for: empty catch blocks, `catch → return {}`, `catch → return 0`, promise rejections swallowed with a no-op, a truthiness check treating an error object as success, a lookup miss returning a default instead of "not found", and a save path that reports success without checking the result.
+*Real cases: a network blip wrote eight zeros into a market-data section and saved them, so "median price $0" read as real data; a failed disk write of a client record was swallowed, so the user believed it saved; a cleared input froze the report on the previous numbers, which then exported to PDF.*
+Rule to state in the report: **a missing value and a failure must never look the same.**
+
+### Data that lives only in a browser (or only on one machine)
+Records in `localStorage` / `IndexedDB` / a desktop file with no server copy. Survives a refresh, survives nothing else — a new browser, a second device, or clearing site data loses everything with no warning and no backup, and two colleagues can never see the same records.
+*Real case: every client file — names, incomes, property details — existed in one browser profile on one laptop.*
+Also flag the inverse where it is a genuine asset: if the core computation never touches the network, that is a real privacy property worth stating out loud rather than accidentally destroying.
+
+### Unverifiable currency or accuracy claims
+Any place the software *asserts* something it cannot check: "rates current for FY2026-27", "live data", "verified", a timestamp that is really a build constant, a source attribution read from a string typed next to the numbers. These are the findings that cost client trust rather than dollars, and they are usually one line.
+*Real case: a report named the government source and the financial year beside figures that nothing validated, including for an unrecognised jurisdiction where every charge came out as zero.*
+
+### Also worth a pass
+Numbers presented as precise that are actually unexamined assumptions (an auto-estimate whose "estimated" hint disappears when the mode changes is the nastiest version); controls that do nothing; pages nothing links to; validation that does not exist (no required fields, no bounds — a decimal separator read as a thousands separator silently divides a figure by a thousand); records generated from an empty form that look complete; and dead code paths calling endpoints that were never implemented.
+
+---
+
+## 4a. Scope discipline — three buckets, never blurred
+
+**The default posture of an audit is fix, not extend.** The user's words, and they are a rule rather than a preference: *"I want to avoid adding loads of features now. We just need to get what's currently working, working better."*
+
+Every observation the audit makes goes into exactly one of three buckets, and the buckets are reported separately and labelled:
+
+| Bucket | What goes in it | Where it ends up |
+|---|---|---|
+| **1. Problems** | What is broken, wrong, or silently lying right now. **This is the job.** | The findings write-up **and** the Kanban tasks |
+| **2. Could add later** | Real gaps and good ideas, deliberately **not** being built now | The findings write-up, in its own clearly-titled section. **Never in the task list.** |
+| **3. Not worth adding** | Suggestions that should stop coming up, **with the reason** | The findings write-up, one line each, so the question is closed |
+
+Rules, not suggestions:
+
+- **A feature suggestion may never enter the task list.** If it is not fixing something that is broken, it is bucket 2 or bucket 3. No exceptions, including "while we're in there".
+- **Bucket 3 needs a reason.** "Not worth adding" without a why is just an opinion and it will be raised again next month. In the real audit: *don't build an integration to fetch tax rates automatically — no free authoritative feed exists, and scraping eight government websites would be more fragile than a maintained table plus an annual review.* That closed the question permanently.
+- **Say bucket 2 out loud rather than silently dropping it.** A gap the audit noticed and consciously parked is reassuring. A gap the audit apparently missed is not.
+- **Watch the boundary case:** "this feature is missing" is bucket 2, but "this feature exists and produces a wrong answer" is bucket 1. Missing capital-gains modelling would be bucket 2; capital gains being understated by $337,000 by code that already runs is bucket 1.
+- When the user asks for something from bucket 2 anyway, that is their call — but it becomes its own piece of work with its own tasks, not a passenger on the fix list.
+
+### Where do future ideas actually live? — a real gap, with an interim convention
+
+CodeSpring has features, notes, PRDs and Kanban tasks. **It has no home for "things we might build later."** And those ideas must never be written as tasks: **a task list implies committed work**, so a parked idea sitting in Kanban will either get built by accident or make the board untrustworthy.
+
+**Interim convention, use it every time:** future ideas live in **`FINDINGS.md` in the repo**, in two explicitly titled sections, each entry one line with a reason:
+
+- **"Could add later — deliberately not doing now"** (bucket 2) — the reason is *why it is parked*, plus whether it is worth doing later.
+- **"Not worth adding"** (bucket 3) — the reason is *why the question is closed*, so it stops coming back.
+
+Nothing in either section becomes a task, a feature on the map, or a PRD. If the user later commits to one, it starts its own piece of work and moves out of the section.
+
+**Record this as a product gap for FERB:** there is no first-class "ideas" or "backlog" surface in CodeSpring that is visibly *not* a commitment. Until there is, the two `FINDINGS.md` sections are the answer and FERB should read and write them rather than inventing tasks.
+
+## 4b. Plain language — a hard rule, not a style note
+
+**Every finding must be readable by someone who does not know what a database migration is.** Any term of art must be explained in the same sentence it appears in, or not used.
+
+This is a rule because it has already failed in practice. The phrase *"versioned rate tables stamped onto the saved file"* was written and meant nothing to the person it was written for. The plain version says the same thing:
+
+> *"When you save a report, also save which year's tax rates it used — so that fixing a rate later doesn't change what a client was already shown."*
+
+Note what the good version does: it names the action ("when you save a report"), the thing to save ("which year's tax rates it used"), and — the part that actually persuades — **the consequence of not doing it** ("fixing a rate later changes what a client was already shown"). No jargon, and it is *more* specific than the technical phrasing, not less.
+
+Apply the same test to everything: *idempotent*, *RLS*, *IDOR*, *migration*, *ORM*, *schema drift*, *silent failure path*, *hydration*, *denormalised*. Either explain it inline or find the plain sentence. Full voice rules and structure for the deliverable live in `cs-build-audit-codebase/references/plain-english-writeup.md`.
+
+## 5. The verdict: rebuild or fix in place
+
+### Fix in place is the default. A rebuild has to be argued for.
+Say this plainly, to yourself and to the user: **rebuilding the whole architecture of an app is a large, risky job and is the wrong answer for most codebases.** It suits small apps with little irreplaceable logic — a tiny static-HTML app is a fair rebuild candidate; almost nothing else is.
+
+Users in distress ask for a rewrite, and an agent that agrees is doing the easy thing, not the right thing. A rebuild throws away every undocumented decision that is currently keeping the app working, restarts the bug count from zero, and delivers nothing until it is finished. Recommend it only when the gate and the table below actually point there, and say plainly which signals drove the call.
+
+### The gate: does the app have real users or paying customers?
+
+**Ask this before reading the table, because it can veto a rebuild on its own.**
+
+- **If yes — fix in place is strongly preferred, regardless of how bad the code is.** A rebuild means a migration, a cutover, and a period where both versions exist. That is risk a live business may not be able to absorb, and no amount of ugly code outweighs it.
+- **If a rebuild is genuinely unavoidable *with* live users**, it needs a **parallel-running plan**: the old app stays live, the new one is built alongside it, and there is an explicit cutover with a rollback. The user must understand and accept that before any work starts.
+- **Name the trap out loud:** parallel running usually means a second repo or a long-lived branch, and **multiple versions of an app across repos gets confusing fast** — nobody remembers which one is live. **Default to a branch in the same repo.** Use a separate repo only when the stack changes so completely that one repo genuinely cannot hold both.
+
+A "no users yet" answer does not argue *for* a rebuild — it just removes the veto and lets the table decide.
+
+### The decision table
+
+| Signal | Points to REBUILD | Points to FIX IN PLACE |
+|---|---|---|
+| **Can the current architecture host what the app needs to do?** | No — what is missing is structural (no server, no accounts, nowhere to put the data) and cannot be added where it is | Yes — what is missing can be added inside what already exists |
+| **How much irreplaceable domain logic is there?** | Small and isolatable — you can lift it out cleanly and carry it across | Large or diffuse — the valuable knowledge is spread through the whole app and cannot be lifted |
+| **How big is the total surface area?** | Small — few pages, routes and screens; rewriting is a known quantity | Large — many routes, migrations, integrations; a rewrite is an open-ended bet |
+| **Do tests or CI exist to protect a refactor?** | Irrelevant — you are replacing the code, not refactoring it | Helps a lot — a suite that catches regressions makes fixing in place safe and cheap |
+
+Read it as a whole, not a score. **Rebuild needs the gate to be clear *and* the first row to say "No".** If the architecture can host what's needed, the answer is fix in place regardless of how ugly the code is — ugly is not the same as wrong-shaped.
+
+### Worked both ways, from the real case
+
+**Rebuild — a static-HTML app.** No backend in the repo, no accounts, no database of its own; user records lived in one browser. ~8,800 lines total across 17 pages, of which only ~470 lines were irreplaceable domain logic (verified reference tables and one calculation pipeline) that could be lifted out in a day. Zero tests, zero CI. **No live customers depending on it yet**, so the gate was clear. Architecture row = **No** (there was nowhere to put durable, shared, authenticated data), surface = small, precious logic = small and isolatable. → **Rebuild**, and the plan led with "port these 470 lines deliberately, rewrite everything else".
+
+**Fix in place — a Next.js app.** Real authentication, 133 tables, 133 migrations, ~142 authorization policies, hundreds of routes and server actions. It had genuine, serious problems: signed agreements in a public bucket, endpoints failing open when a secret was unset, schema drift with ~38 undocumented production tables. Architecture row = **Yes** (every one of those is fixable where it stands), surface = large, precious logic = enormous and diffuse. → **Fix in place, never rebuild.** The problems were serious *and* the answer was still not a rewrite. Say that explicitly — a long defect list is not evidence for a rebuild.
+
+### What the verdict must contain
+The recommendation, **the answer to the users gate**, the two or three signals that decided it, an honest statement of the cost of the recommendation, and — if rebuild — **which specific parts get ported deliberately rather than rewritten** plus the parallel-running and rollback plan if the app is live. Also name the highest-value work that is worth doing *whichever* way the verdict goes; in the real case that was backing up the backend that was not in version control, and writing the first test suite — neither of which needed the rebuild to happen.
+
+---
+
+## 6. Why the map always shows the corrected target
+
+**Settled decision: the mindmap always shows the corrected target — what the app *should* be — never the current messy structure annotated with warnings.** This holds on both verdicts and it is deliberate.
+
+Rationale to keep on record:
+
+- **The map means one thing.** A user, or FERB, reading a CodeSpring map never has to ask "is this the real structure or the intended one?" It is always the intended one.
+- **The Kanban always means the same thing:** the gap between here and there. Every task closes a distance between the map and reality. That is true for a rebuild (build this feature) and for a fix in place (make this feature actually work).
+- **One drawing model.** No second node type for "broken", no warning badges, no annotation layer to maintain, and nothing extra to keep in sync when a task is finished.
+
+Accepted cost: **the map does not mirror the repository until the tasks are done.** That is real and must be disclosed to the user in one sentence. It is arguably a feature — the map shows people where they are going, which is what a non-expert needs to see. It is also why `cs-build-resync-codebase` exists: once the work is done, resync brings the map back to describing reality, and from then on the two agree.
+
+Where an audit finding has no home in the target map (a defect in a feature the target does not have, e.g. dead code being deleted), it becomes a task without a new feature — attach it to the closest core feature, or to a core feature named for the cleanup work. Do not invent a feature just to host a defect.
+
+**An existing map is not automatically a good map.** "A map already exists → keep it" is too blunt: an import can produce a map that is genuinely unusable. Judge it against the **map-quality ladder** in `cs-build-import-codebase/references/target-map.md` — exists? good? fixable? — and only recommend a second CodeSpring project when the map is beyond fixing, with the user's explicit confirmation. Two projects for one app is confusing later, so it has to be a deliberate, explained choice.
+
+---
+
+## 7. How findings become tasks
+
+**Only bucket 1 becomes tasks** (§4a). Bucket 2 and bucket 3 stay in the write-up. If the task list contains something that isn't fixing a real defect, it is in the wrong place.
+
+Every task, on either path: mapped to exactly one core feature, carrying a severity, one sentence of title, detail in the description.
+
+### If the verdict is REBUILD — two distinct sets
+1. **Build-to-spec tasks.** One per feature/sub-feature in the target map: build it to the spec in the note and PRDs. Ordered foundations-first.
+2. **Mistakes-to-avoid tasks.** One per significant defect found in the original, carried forward as an explicit "do not reintroduce this" instruction with the concrete example from the audit.
+
+**The second set is the entire reason for auditing before importing.** Without it, a rebuild recreates the same silent failure paths, the same hardcoded tables and the same duplicated logic, because nothing in the new plan says not to. Write them as verifiable constraints, not vibes:
+
+- *"Reference data must be date-scoped records, not literals in source. It must be impossible to update a rate by editing application code."*
+- *"A lookup failure must return an explicit not-found. No code path may substitute zero or an empty object for an error."*
+- *"There is exactly one copy of the calculation logic and both the client and the server import it."*
+- *"Every published document stores the inputs, the results, and the version of the reference data that produced them."*
+- *"Identity for authorization never comes from the request body. Body identifiers are targets, ownership-checked before use."*
+
+Where the audit produced a good test list, attach it here — a mistakes-to-avoid task with a failing test named in it is the strongest form of this.
+
+### If the verdict is FIX IN PLACE — one set
+One task per defect, at the place it lives, **with the file reference in the description** (the user-facing findings text has no file paths; the task description does, because an agent has to act on it). Sequence by consequence and by dependency: guard the silent failures first, then the wrong outputs, then the structural work, then polish. If the audit produced a suggested fix order, use it.
+
+### Severity
+Map audit severity straight onto task priority: Critical → `urgent`, High → `high`, Medium → `medium`, Low → `low`. Do not soften it. A finding that puts a wrong number in front of a paying customer is urgent even if it is a one-line fix.
+
+---
+
+## 8. Idempotency — required on every run
+
+Every skill in this pipeline must assume it is the *second* time it has run. **Check what exists, then update or skip. Never blindly overwrite and never duplicate.**
+
+**A check is a script; a judgement is prose.** Anything that must produce the same answer every run belongs in `codespring/scripts/`, not in a paragraph an agent can skim: state detection, the map's machine-checkable properties, and the post-write verification are all scripts. What stays prose is what needs reasoning — *is this map good? is this a sidebar item? fix or rebuild?* Never move a judgement into a script, and never leave a count in prose.
+
+Before writing anything:
+
+```bash
+bash  codespring/scripts/fetch-project.sh --out /tmp/cs-state   # read-only snapshot; prints the projectId
+node  codespring/scripts/state.mjs        /tmp/cs-state         # the summary line + booleans and counts
+node  codespring/scripts/check-map.mjs    /tmp/cs-state         # what is already wrong, before you add to it
+```
+
+What that reads, if you need it by hand: `codespring status` (the LOCAL project — print the projectId), `codespring mindmap` (nodes, features, notes, PRD bridges), `codespring features` (core + sub-features with ids), `codespring tasks` (**all** states), `codespring prds` (PRDs per feature).
+
+Then:
+
+- **Match on title** (case-insensitive, trimmed) before creating anything. An existing feature with that title is *the* feature — reuse its id, never create a second.
+- **Re-parent strays** rather than recreating them. A sub-feature that has been flattened to top level gets `feature update <id> --parent <coreId>`, not a delete-and-recreate.
+- **Never re-create an existing feature.** `codespring mindmap features --replace` does not replace — it appends (see `pitfalls.md`). Treat feature creation as add-only and diff first.
+- **Never regenerate an existing PRD unless asked.** Read it, report that it exists, and offer to refresh it.
+- **Never duplicate a task.** Match on the numbered title prefix and the feature id; continue the existing numbering rather than restarting.
+- **Update notes in place.** `codespring mindmap note` overwrites the single note for a feature, which is the desired behaviour — but read the existing note first and preserve anything still true.
+
+Report the diff to the user: created N, updated N, skipped N (already correct).
+
+## 9. Verification after every write
+
+**Run the script — it asserts all of this and exits non-zero on a real failure:**
+
+```bash
+bash codespring/scripts/fetch-project.sh --out /tmp/cs-verify
+node codespring/scripts/check-map.mjs    /tmp/cs-verify --expect-core <the number you intended>
+```
+
+Assert, do not assume:
+
+1. **Core-feature count** — fetch the mindmap and check `node-features.items.length` equals the number of core features you intended. Anything higher means sub-features were flattened.
+2. **No flattened sub-features** — every sub-feature still carries the right `parentFeatureId`. Re-parent any stray (`pitfalls.md` §2). Keep a stored sub→core map so this is a one-liner on re-runs.
+3. **No duplicates** — no two features share a title; no two PRDs share a `(feature, prdType)`.
+4. **Notes present** — one "how it works" note per core feature.
+5. **Tasks linked** — every task has a `--feature` id and a severity.
+
+Then give the user the project link: `https://v2.codespring.app/project/<projectId>`.
+
+---
+
+## 10. FERB edge cases
+
+Things FERB must handle deliberately, not discover:
+
+1. **The map is the target, not the repo.** Until the tasks are done, a feature on the map may not exist in the code, and code that exists may not be on the map. FERB must not "correct" the map toward the messy reality, and must not tell the user a feature exists because it is on the map. The Kanban is the source of truth for what is actually built.
+2. **After the tasks are done, resync.** `cs-build-resync-codebase` is what closes the loop and makes the map describe reality again. Prompt for it when a feature's tasks all reach done.
+3. **A fix-in-place map still shows the target.** Its features look almost identical to the current app's — the difference is in the notes (what it *should* do) and in the tasks (what is wrong today). Do not skip the corrected-target step just because the verdict was fix in place.
+4. **Findings text and task text differ on purpose.** The user-facing findings are plain English with no file paths; the task descriptions carry file references because an agent has to act on them. Never paste task text into a client-facing document.
+5. **Evidence labels survive the handoff.** An UNVERIFIED finding must not become a confident task. Turn it into an investigation task ("check whether X — here is what would confirm it") and keep the label.
+6. **The audit may be stale, and the codebase may be a moving target.** If the audit ran against a clone behind the remote, or a while ago, say so before acting on it and re-check the specific findings being worked. If the owner is still adding features to the same repo, the findings are a snapshot at a named commit (§3) — hold the SHA and re-check before acting.
+7. **An existing map is not automatically a good map.** Run the map-quality ladder (`cs-build-import-codebase/references/target-map.md`) before trusting one. Never create a second CodeSpring project for the same app without explicit confirmation, and if there are already two, establish **which one is authoritative** before writing anything.
+8. **There is no home for future ideas, and they must not become tasks.** Parked ideas live in the two named `FINDINGS.md` sections (§4a). A task list implies committed work; putting a "maybe later" idea on the board makes the whole board untrustworthy. This is a known product gap.
+9. **Ask what is planned but not yet built.** On an app that is still being built, code missing for a mapped feature may just be unfinished, and pages nothing links to may be unfinished modules rather than dead ends or a separate product. Check the file's git history before concluding otherwise (§3a, rule 5).
+10. **Routing is the five questions, never "do we trust it."** `project-state.md`. And "the code runs" is not the same as "the code does the job."
+11. **Project placement is manual.** There is no CLI way to create a project in a specific workspace/organisation, and no way to move or delete one afterwards. If the project must live in a team workspace, the user creates it in the web app **first**, then links to it. See `pitfalls.md`.
+12. **A rebuild verdict does not delete anything.** The old code stays until the new thing is proven. Any rebuild plan must include a rollback and an explicit point of no return. With live users it also needs a parallel-running plan and, by default, a branch in the same repo rather than a second one (§5).

--- a/.claude/skills/codespring/references/codespring-docs.md
+++ b/.claude/skills/codespring/references/codespring-docs.md
@@ -1,0 +1,33 @@
+# CodeSpring Docs — pointers for guiding the user
+
+Some steps happen in the **CodeSpring web app**, not the CLI (generating PRDs from the canvas, the Kanban board, picking a journey). Use this to guide users through those, and fetch the live docs when you need the current details.
+
+- Docs home: https://codespring.app/docs
+- Skills library: https://codespring.app/docs/skills
+- A project: `https://v2.codespring.app/project/<projectId>`
+
+> Agents: when you need the exact, current UI steps, fetch the relevant docs page (it's public) rather than relying on this summary, which may lag the product.
+
+## Install the skills (whole pack)
+```bash
+npx skills add CodeSpringApp/codespring-skills   # installs every skill in the pack, once
+```
+
+## Connect the CLI
+```bash
+npm i -g @codespring-app/cli
+codespring auth login      # browser OAuth
+codespring init            # link this directory to a project
+```
+
+## Pick your journey
+The docs frame two starting points: **build a new project from scratch** or **import an existing codebase**. `cs-build-getting-started` routes the user between them.
+
+## Generate a PRD in the web app
+If the user prefers the app over the CLI/API: open the project canvas → find the target **feature's bridge** → add a **PRD Bridge** to it → generate the **Frontend** and/or **Backend** PRD from that bridge → wait for it to finish. The PRD then appears as a `prdFrontend` / `prdBackend` node on that bridge. (Exact clicks are on the docs page — fetch it if unsure.) The same result is available programmatically via `prd-management.md`.
+
+## Kanban board
+Tasks created via the CLI show on the board: in the project, use the top-right **Map / Kanban** toggle → click **Kanban** to see tasks in `todo / in progress / on hold / done`.
+
+## When a user is stuck
+Point them at the relevant docs page (home or `/docs/skills`) rather than guessing UI details, and offer to do the CLI/API path for them where one exists.

--- a/.claude/skills/codespring/references/commands.md
+++ b/.claude/skills/codespring/references/commands.md
@@ -1,0 +1,137 @@
+# CodeSpring CLI — Full Command Reference
+
+## Auth
+
+### `codespring auth login`
+Log in via browser-based OAuth 2.1 flow (PKCE).
+- `--api-key` — Paste an API key instead of browser login
+- `--url <api-url>` — Custom API URL (default: auto-detected)
+
+### `codespring auth status`
+Show current authentication state. Returns `{ authenticated, type, apiUrl }`.
+
+### `codespring auth logout`
+Clear stored credentials from `~/.codespring/credentials.json`.
+
+## Setup
+
+### `codespring init`
+Interactive project linking (Vercel-style):
+1. Select workspace
+2. Select project (auto-detects by directory name)
+3. Writes `.codespring/config.json`
+
+Flags:
+- `--project <id>` — Direct link, skip interactive
+- `--force` — Re-link even if already linked
+
+### `codespring status`
+Show linked project info. Returns `{ linked, projectId, projectName, authenticated }`.
+
+## Data
+
+### `codespring workspaces`
+List all workspaces (personal + organizations). No flags.
+
+### `codespring projects`
+List projects in a workspace.
+- `--org <id>` — Filter by organization ID
+
+### `codespring project create`
+Create a new project.
+- `--name <n>` — Project name (required)
+- `--description <d>` — Project description
+
+### `codespring features`
+List features for the linked project. Requires linked project.
+
+### `codespring feature create`
+Create a new feature for the linked project.
+- `--title <t>` — Feature title (required)
+- `--description <d>` — Feature description
+
+## Tasks
+
+### `codespring tasks`
+List tasks with optional filters.
+- `--status <s>` — Filter: `todo`, `in_progress`, `on_hold`, `done`
+- `--feature <id>` — Filter by feature ID
+- `--priority <p>` — Filter: `low`, `medium`, `high`, `urgent`
+
+### `codespring task create`
+Create a new task for the linked project.
+- `--title <t>` — Task title (required)
+- `--description <d>` — Task description
+- `--priority <p>` — Priority: `low`, `medium`, `high`, `urgent`
+- `--feature <id>` — Link to a feature ID
+- `--estimate <e>` — Estimate (e.g., "2h", "1d")
+
+### `codespring task start <id>`
+Set task status to `in_progress`. Accepts UUID or row number.
+
+### `codespring task done <id>`
+Set task status to `done`. Accepts UUID or row number.
+
+### `codespring task update <id>`
+Update task fields.
+- `--status <s>` — New status
+- `--title <t>` — New title
+- `--description <d>` — New description
+- `--priority <p>` — New priority
+- `--estimate <e>` — New estimate (e.g., "2h", "1d")
+
+## PRDs
+
+### `codespring prds`
+List PRDs grouped by feature structure for the linked project.
+
+### `codespring prd <id>`
+Get full PRD content (includes markdown content, feature info, suggested path).
+
+### `codespring prd sync <id>`
+Update PRD content.
+- `--file <path>` — Read content from file
+- `--stdin` — Read content from stdin
+- `--name <name>` — Optionally update PRD name
+
+## Mindmap
+
+### `codespring mindmap`
+Get full mindmap structure (nodes + edges) for the linked project.
+
+### `codespring mindmap set-info`
+Update the project info node in the mindmap.
+- `--title <t>` — Project title
+- `--description <d>` — Project description
+- `--github <url>` — GitHub repository URL
+
+### `codespring mindmap tech-stack`
+Update the tech stack node.
+- `--add '<json>'` — JSON array of items: `[{"id":"tech-react","title":"React","description":"Frontend"}]`
+- `--replace` — Replace all items (default: merge)
+
+### `codespring mindmap features`
+Update the features node.
+- `--add '<json>'` — JSON array: `[{"title":"Auth","description":"Login/signup"}]`
+- `--replace` — Replace all items (default: append)
+
+### `codespring mindmap note <featureId>`
+Add notes to a specific feature. Creates bridge + notes nodes if needed.
+- `--text '<content>'` — Note content (supports markdown)
+- `--title '<title>'` — Note title (default: "Notes")
+
+## Reference
+
+### `codespring schema`
+Output the CodeSpring data schema (project, mindmap, tech stack items, features, PRDs).
+
+### `codespring node-types`
+Output mindmap node type definitions (primary, secondary, bridge, tertiary, handle patterns).
+
+## Global Flags
+
+- `--md` — Force markdown output (default in terminal)
+- `--json` — Force JSON output (default when piped)
+- `--pretty` — Pretty-print JSON output
+- `--help`, `-h` — Show help
+- `--version`, `-v` — Show version

--- a/.claude/skills/codespring/references/mindmap-structure.md
+++ b/.claude/skills/codespring/references/mindmap-structure.md
@@ -1,0 +1,137 @@
+# Mindmap Structure Reference
+
+## Node Types
+
+### Primary Node (`node-primary`)
+Central project node. Fields: `title`, `description`, `githubUrl`.
+
+### Secondary Nodes
+Major category branches from primary:
+- `node-features` — Features list (items array) — holds the **CORE features**
+- `node-tech-stack` — Technology stack (items array, grid layout)
+- `node-competitors` — Market competitors
+- `node-audience` — Target audience
+- **Sub-feature group nodes** — one per core feature; each holds that feature's sub-features. Its `data.parentFeatureId` = the core feature id.
+
+Data structure for list nodes:
+```json
+{
+  "title": "Features",
+  "subtitle": "Core functionality",
+  "handlePosition": "left",
+  "layout": "list",
+  "items": [
+    { "id": "feature-auth", "title": "Authentication", "description": "User login" }
+  ]
+}
+```
+
+Sub-feature items carry `parentFeatureId`:
+```json
+{ "id": "feature-signup", "title": "Sign up", "description": "Email signup", "parentFeatureId": "feature-auth" }
+```
+
+### Bridge Nodes
+Connector between a feature item and its detail nodes.
+- ID pattern: `bridge-feature-{featureId}` (note the doubled `feature-feature` when a featureId already starts with `feature-`)
+- Data: `{ featureId, count, isExpanded, handlePosition }`
+
+### Tertiary Nodes
+Detail nodes attached via a bridge:
+- **Notes**: `notes-{featureId}` with `{ type: "notes", title, content }` — created by `codespring mindmap note`.
+- **PRDs**: attached through a **PRD Bridge** (see below), not as a plain tertiary node.
+
+## PRD Bridge & PRD Nodes
+
+PRDs render on the canvas as a small sub-graph hanging off a feature's bridge:
+
+```
+feature bridge  →  prdBridge  →  prdFrontend
+                            \→  prdBackend
+```
+
+### `prdBridge` node
+- Type: `prdBridge`
+- ID: `prdBridge-{bridgeNodeId}` (e.g. `prdBridge-bridge-feature-feature-123`)
+- Data:
+  - `title`: `"PRD Bridge"`
+  - `itemId`: the **selected feature card id** (the core feature, or the sub-feature)
+  - `featureId`: the **container node that holds that card** — this is the field the PRD generator uses to locate the feature:
+    - For a **core feature** → `"node-features"`
+    - For a **sub-feature** → that feature's **sub-feature group node id**
+  - `isCollapsed`: `false`, `generatingType`: `null`, `handlePosition`: `"left"`
+- **Common failure:** setting `featureId` to the feature card's own id gives *"Features node not found in mindmap"* on generation. It must point to the container node.
+
+### `prdFrontend` / `prdBackend` nodes
+- Type: `prdFrontend` or `prdBackend`
+- ID: `prdFrontend-{unique}` / `prdBackend-{unique}`
+- Data: `{ prdId: "<PRD record id>", title: "Frontend PRD" | "Backend PRD", isGenerating: false, handlePosition: "left" }`
+
+## Edge / Handle Patterns
+
+### Features → Bridge
+```
+source: "node-features"
+target: "bridge-feature-{featureId}"
+sourceHandle: "node-features-source-{featureId}"
+targetHandle: "bridge-feature-{featureId}-target-{featureId}"
+```
+
+### Bridge → Notes
+```
+source: "bridge-feature-{featureId}"
+target: "notes-{featureId}"
+sourceHandle: "bridge-feature-{featureId}-source-notes"
+targetHandle: "notes-{featureId}-target-notes"
+```
+
+### Bridge → PRD Bridge → PRD nodes
+```
+# feature bridge → prdBridge
+source: "{bridgeNodeId}"       target: "prdBridge-{bridgeNodeId}"
+sourceHandle: "{bridgeNodeId}-source-prd"
+targetHandle: "prdBridge-{bridgeNodeId}-target-prd-bridge"
+
+# prdBridge → prdFrontend / prdBackend
+source: "prdBridge-{bridgeNodeId}"   target: "{prdNodeId}"
+sourceHandle: "prdBridge-{bridgeNodeId}-source-prd-bridge"
+targetHandle: "{prdNodeId}-target-prd"
+```
+All edges use `{ type: "default", className: "stroke-foreground", style: { strokeWidth: 2 } }`.
+
+## Reading & Writing the Mindmap
+
+- Read: `codespring mindmap` (or the raw record via the API `GET /mindmaps/project/{projectId}`).
+- The CLI writes specific parts (`set-info`, `tech-stack`, `features`, `note`). Adding PRD/other nodes uses a direct API write: `PUT /mindmaps/project/{projectId}` with body `{ flowJson: { nodes, edges } }`. This **replaces the whole flowJson**, so fetch the current one, ADD your nodes/edges, and preserve everything else. See `prd-management.md`.
+
+## Tech Stack Categories
+
+Use these in the `description` field when syncing:
+- **Frontend**: react, vue, svelte, next, angular, astro
+- **Backend**: express, fastify, hono, nestjs, elysia
+- **Database**: prisma, drizzle, mongoose, pg, redis
+- **State**: zustand, redux, jotai, mobx, xstate
+- **Styling**: tailwindcss, styled-components, emotion, sass
+- **Testing**: jest, vitest, playwright, cypress
+- **DevTools**: typescript, eslint, prettier, biome
+- **Infrastructure**: vercel, docker, aws-sdk
+
+## Sync Commands
+
+```bash
+# Tech stack (merge by default)
+codespring mindmap tech-stack --add '[{"id":"tech-react","title":"React","description":"Frontend"}]'
+
+# Features (append by default)
+codespring mindmap features --add '[{"title":"Auth","description":"Login/signup"}]'
+
+# Sub-features: create as features parented to a core feature
+codespring feature create --parent <coreFeatureId> --title "Sign up" --description "Email signup"
+
+# Feature notes (creates bridge + notes nodes automatically; ROOT feature ids only; overwrites the single note)
+codespring mindmap note feature-auth --text "OAuth2 implementation notes..." --title "How it works — Auth"
+
+# Replace mode (overwrites existing items)
+codespring mindmap tech-stack --add '[...]' --replace
+codespring mindmap features --add '[...]' --replace
+```

--- a/.claude/skills/codespring/references/pitfalls.md
+++ b/.claude/skills/codespring/references/pitfalls.md
@@ -1,0 +1,53 @@
+# Pitfalls & Guardrails
+
+Hard-won failure modes when driving CodeSpring from an agent. Check these on every run.
+
+## 0. Not checking what already exists (the most common one)
+Every skill must open with the state-detection block in `project-state.md` and then **update or skip, never blindly overwrite or duplicate**. Match on title before creating anything, re-parent strays instead of recreating them, never re-create an existing feature, never regenerate an existing PRD without being asked, never restart task numbering. A skill invoked from "the wrong place" must still do the right next thing. Rules in `auditing-and-fixing.md` §8.
+
+## 1. Wrong project
+The linked project lives in the **local** `<cwd>/.codespring/config.json`. The **global** `~/.codespring/config.json` points at whatever project was last used somewhere else. Any script that reads the global config will silently write to the WRONG project.
+- Always read `projectId` from the local config (or hardcode the intended one) and **print it before any write**.
+- Symptom of getting it wrong: API writes "succeed" but nothing changes in the project you're looking at, or a "bridge/feature not found" error because the ids belong to a different project.
+
+## 2. Sub-features flattened into core features
+After PRD generation and/or creating a checkpoint, sub-features' `parentFeatureId` can reset to `null`, which **promotes every sub-feature into the core features list** (`node-features` balloons while the sub-feature groups still exist). This shows up as "suddenly there are way too many core features."
+- **Detect:** fetch the mindmap and assert `node-features.items.length === <the real number of core features>`.
+- **Fix:** re-parent each stray sub-feature: `codespring feature update <subFeatureId> --parent <coreFeatureId>`. Keep a stored subId→coreId map so you can re-run this quickly.
+- Re-check this after every PRD-generation batch and checkpoint.
+
+## 3. Duplicate PRDs from client timeouts
+`POST /prds/generate` streams for ~20–30s. A client-side abort does NOT stop the server — it finishes and creates the record anyway. A short HTTP timeout + retry therefore creates **duplicates**.
+- Use a timeout ≥ 120s.
+- If duplicates happen: create a checkpoint (`POST /projects/<id>/checkpoints`) then `DELETE /prds/<id>` the extras, keeping the most complete per (feature, prdType). Group by the PRD `name` field, not the unreliable `featureName`.
+
+## 4. PRD bridge metadata
+`prdBridge.data.featureId` must point to the **container** node, not the feature card:
+- core feature → `"node-features"`
+- sub-feature → that feature's sub-feature group node id
+
+`prdBridge.data.itemId` is the selected feature card id. Getting `featureId` wrong yields *"Features node not found in mindmap"* at generation time.
+
+## 5. Notes are one-per-feature and root-only
+`codespring mindmap note <featureId>` accepts only **root (core) feature ids** and **overwrites** the single note node for that feature. Sub-features cannot get a note via the CLI (only via direct `flowJson` editing). Put sub-feature detail and cross-feature links inside the parent core feature's note.
+
+## 6. `PUT /mindmaps/project/<id>` replaces everything
+The flowJson PUT is a full replace. Always fetch the current flowJson, ADD your nodes/edges, and preserve the rest. After writing, re-verify pitfall #2.
+
+## 7. Auth / connection
+Every skill should start by checking `codespring auth status` (this also refreshes an expired OAuth token) and `codespring status` (project link). If not ready, direct the user to `codespring auth login` / `codespring init` and stop.
+
+## 8. Spec / research / planning documents
+Not reachable from the agent token (endpoints 404 / 401). These are web-app-only for now — do not promise to create them from the CLI.
+
+## 9. `mindmap features --replace` does NOT replace — it appends
+`codespring mindmap features --add '[...]' --replace` **appends the items and creates duplicates.** Despite the flag name, nothing is removed. Running an import twice this way doubles the core-feature list.
+- **Treat feature creation as add-only.** Read `codespring features` first, diff by title (case-insensitive, trimmed), and add only what is missing.
+- **Recovery:** `codespring feature delete <id> --yes` does work, and it cascades (the feature's sub-features, bridge, note and PRD nodes go with it). Delete the duplicates, keep the originals whose ids are referenced by existing tasks/PRDs.
+- The same caution does not apply to `tech-stack --replace`, which does replace, or to `mindmap note`, which correctly overwrites the single note for a feature.
+
+## 10. No `project delete`, and no way to move a project
+- **There is no `project delete` command.** A project created by mistake stays. Name it carefully.
+- **`project create` ignores `--org`** and stamps `organizationId: null`, so it always lands in the personal workspace. There is no CLI way to move a project between workspaces or organisations afterwards.
+- **Therefore:** if the project must live in a team/organisation workspace, tell the user to **create it in the web app first**, then `codespring projects` → `codespring init --project <id> --force` to link. Do this before writing anything; a full map in the wrong workspace cannot be relocated and has to be rebuilt.
+- Do not burn time looking for a flag or an API for this. It isn't there.

--- a/.claude/skills/codespring/references/prd-management.md
+++ b/.claude/skills/codespring/references/prd-management.md
@@ -1,0 +1,100 @@
+# PRD Management
+
+## Listing PRDs
+
+```bash
+# List PRDs grouped by feature (tree view)
+codespring prds
+```
+
+Returns PRDs organized by feature with: id, name, featureName, prdType.
+
+> Caveat: when reading a single PRD's detail, the `featureName` field can be unreliable. To group PRDs by feature, key off the PRD `name` (e.g. `"Frontend PRD: Dashboard"` / `"Backend PRD: Dashboard"`).
+
+## Getting PRD Content
+
+```bash
+# Get full PRD with markdown content
+codespring prd <prd-id>
+```
+
+Returns:
+- `id`, `name`, `projectId`, `projectName`
+- `featureName`, `featureSlug`, `prdSlug`
+- `content` — Full markdown content
+- `suggestedPath` — e.g., `.codespring/PRDs/{feature-slug}/{prd-slug}.md`
+- `createdAt`, `updatedAt`
+
+## Syncing PRD Content
+
+Update a PRD's content from a local file:
+
+```bash
+# From file
+codespring prd sync <prd-id> --file ./path/to/prd.md
+
+# From stdin (pipe from another command)
+cat generated-prd.md | codespring prd sync <prd-id> --stdin
+
+# Optionally update the name too
+codespring prd sync <prd-id> --file ./prd.md --name "Updated PRD Title"
+```
+
+## PRD Types
+
+- **frontend** — UI/UX specs: design tokens, component styles, layout, navigation/interaction
+- **backend** — API endpoints, business logic, data model, security, infra
+- **database** — Schema design, migrations, data models
+
+## Generating PRDs (API)
+
+The CLI reads and syncs PRDs but does not yet have a `create`/`generate` command. Generation is a direct API call the CodeSpring app uses. Authenticate first (`codespring auth status` refreshes an expired token), then call the API base `https://server.codespring.app/api` with `Authorization: Bearer <accessToken>` (or `x-api-key: <apiKey>`) read from `~/.codespring/credentials.json`. Use the `projectId` from the **local** `.codespring/config.json`.
+
+```
+POST /prds/generate
+body: { "projectId": "<uuid>", "bridgeNodeId": "bridge-feature-<featureId>", "prdType": "frontend" | "backend" | "database" }
+```
+
+Notes:
+- It **streams (SSE)** and takes ~20–30s. Use an HTTP timeout **≥ 120s**. A client-side abort does NOT stop the server — it still creates the record — so a short timeout + retry produces **duplicate PRD records**.
+- Generation reads the feature's **note** as context (`relatedNotes`), so writing a strong "how it works" note first (`codespring mindmap note`) directly improves PRD quality.
+- It creates the PRD **record** but does NOT add a node to the mindmap. See "Attaching a PRD to the canvas".
+
+## Attaching a PRD to the canvas
+
+A generated PRD will not appear until you add nodes to the mindmap `flowJson` and PUT it back. Build the `prdBridge → prdFrontend/prdBackend` sub-graph (full node/edge schema in `mindmap-structure.md`), then:
+
+```
+PUT /mindmaps/project/<projectId>
+body: { "flowJson": { "nodes": [...], "edges": [...] } }
+```
+
+This **replaces the whole flowJson** — fetch current, ADD your nodes/edges, keep everything else. Key correctness point: `prdBridge.data.featureId` must be the **container** node (`"node-features"` for a core feature, or the sub-feature group node id for a sub-feature), and `itemId` the selected feature card id.
+
+## Deduplicating PRDs
+
+If timeouts caused duplicates, delete the extras. `DELETE /prds/<id>` requires an active checkpoint:
+
+```
+POST /projects/<projectId>/checkpoints   body: { "message": "..." }
+DELETE /prds/<id>
+```
+
+Keep the most complete PRD per (feature, prdType); group by the PRD `name` field.
+
+## Export Workflow
+
+To export all PRDs to local files:
+
+```bash
+# 1. List PRDs to get IDs and suggested paths
+codespring prds
+
+# 2. For each PRD, get content and write to suggested path
+codespring prd <id>
+# Extract content field and write to suggestedPath
+```
+
+## Spec / research / planning documents
+
+These are currently **web-app only** — there is no CLI/API endpoint accessible to the agent token for creating spec, research, or planning documents. Do them in the CodeSpring web app.

--- a/.claude/skills/codespring/references/project-state.md
+++ b/.claude/skills/codespring/references/project-state.md
@@ -1,0 +1,165 @@
+# Project State Detection — enter from anywhere
+
+**The user should never have to know which skill to run.** They will invoke whichever one they remember, from whatever point they are actually at, and it must work. That is only possible if every skill starts by finding out where the project already is and then does the right *next* thing — not the thing its own name implies.
+
+So: **every CodeSpring skill begins with the same state-detection block.** This file is that block. Skills point here rather than re-implementing it.
+
+---
+
+## The three stages, and the seam between them
+
+| Stage | Produces | Artefacts | Skills |
+|---|---|---|---|
+| **Understand** | **context** — what is true now, and what it should be | audit findings, `FINDINGS.md`, core features + sub-features, one "how it works" note per core feature, tech stack | `cs-build-audit-codebase`, `cs-build-import-codebase` |
+| **Plan** | **instructions** — what to build and in what order | PRDs (Frontend / Backend), numbered Kanban tasks with severities | `cs-build-create-prd`, `cs-build-create-tasks` |
+| **Build** | **changed code** | commits, tasks moving to done | `cs-build-feature` |
+| *(then)* | **truth again** | the map redrawn to match what was actually built | `cs-build-resync-codebase` |
+
+**Where Understand ends and Plan begins — this is the seam people get wrong.** Understand writes *context*. Plan writes *instructions*. They connect in exactly one direction: **a PRD reads the note that Understand wrote.** The PRD generator uses the feature's note as its context, so a Backend PRD for a calculation engine belongs to Plan — but it is only any good if Understand wrote a real note first. A thin note produces a thin PRD, which produces vague tasks, which produces the wrong code. If a note is thin, go back and fix the note; do not compensate in the PRD.
+
+The practical rule: **never generate a PRD or a task for a feature that has no note.** Write the note first, always.
+
+---
+
+## The detection block
+
+Run this at the start of every skill, before any write. It is cheap.
+
+**Run it as the script, not by hand** — the summary must be identical every run, and a hand count is exactly where the core-feature number goes wrong:
+
+```bash
+bash codespring/scripts/fetch-project.sh --out /tmp/cs-state   # read-only snapshot; prints the projectId
+node codespring/scripts/state.mjs        /tmp/cs-state         # the summary line + every boolean and count below
+node codespring/scripts/check-map.mjs    /tmp/cs-state         # what is already wrong with the map, before you add to it
+```
+
+What that reads, if you ever need it by hand:
+
+```bash
+cat .codespring/config.json 2>/dev/null      # LOCAL project id — the only one to trust. Print it.
+codespring auth status                       # also refreshes an expired token
+codespring status                            # linked? which project?
+codespring mindmap --json                    # project info, tech stack, node-features items, notes, PRD bridges
+codespring features                          # core features (root) + sub-features, with ids and titles
+codespring prds                              # PRDs per feature
+codespring tasks --json                      # tasks in ALL states, not just todo
+ls FINDINGS.md 2>/dev/null                   # has an audit already been written up?
+```
+
+Reduce the output to six booleans and two counts:
+
+| Signal | How to read it |
+|---|---|
+| `linked` | local `.codespring/config.json` exists and has a `projectId` |
+| `coreFeatures` | count of `node-features.items` in the mindmap |
+| `subFeatures` | count of features with a `parentFeatureId` |
+| `notes` | count of `notes-*` nodes — should equal `coreFeatures` |
+| `prds` | count of PRD records |
+| `tasks` | count of tasks in **all** states |
+| `audited` | `FINDINGS.md` exists in the repo, or a note/task references an audit |
+| `stack` | `node-tech-stack` has items |
+
+**Print the summary to the user in one line before doing anything else**, e.g.
+`Project "PIA App (clean)" — 6 core features, 25 sub-features, 6 notes, 0 PRDs, 0 tasks. Audit: not yet.`
+
+That single line is what makes entering from the wrong place harmless: the user immediately sees where they are, and you immediately know what to skip.
+
+---
+
+## Branch on what you found
+
+| What exists | Where the project is | The single next step |
+|---|---|---|
+| Not linked | Nothing | Link it. Existing project → `codespring projects` + `codespring init --project <id> --force`. New → create it **in the web app** if it must live in a team workspace (see `pitfalls.md`), then link. |
+| Linked, no features | Understand not started | Run the **five questions** below. All five yes → `cs-build-import-codebase`. Any no → `cs-build-audit-codebase`. No code yet → plan from scratch. |
+| Features, no notes | Skeleton map only | Write the "how it works" note per core feature. Do not generate PRDs yet. |
+| Features + notes, no PRDs, no tasks | **Understand done, Plan not started** | If not `audited` and the user came in wanting fixes → audit, then tasks. Otherwise → PRDs (`cs-build-create-prd`) then tasks (`cs-build-create-tasks`). |
+| Features + notes + PRDs, no tasks | Plan half done | `cs-build-create-tasks`. |
+| Tasks in `todo` | Ready to build | `cs-build-feature`. |
+| Tasks mostly `done`, code has moved | Built | `cs-build-resync-codebase`. |
+| `audited` but no tasks | Audit done, nothing actionable yet | Turn the findings into tasks. Re-read `FINDINGS.md` first; do not re-audit. |
+
+**Always name exactly one next step.** Not a menu. If two are genuinely equal, pick one and say why.
+
+---
+
+## The five questions — is this code worth building on?
+
+**Never ask "do you trust the code?"** or "is it working well, or is it a mess?" Those mean nothing to the person answering, and the answer changes with their mood. Ask these five, in this order, and get an answer to each:
+
+1. **Does the app do what it actually needs to do?**
+2. **Is it getting things wrong, or presenting made-up or unverifiable figures as fact?**
+3. **Does the current architecture allow it to do what it needs to do?**
+4. **Can we build on it scalably?**
+5. **Can users use it without it breaking?**
+
+**All five yes → keep building on it** (`cs-build-import-codebase`). **Any no → consider rebuilding that part, or all of it** — start with `cs-build-audit-codebase`, because a "no" tells you *which* part is not fit for purpose, and the verdict (`auditing-and-fixing.md` §5, including the has-users gate) decides whether that part gets fixed where it stands or rebuilt. A "no" is never on its own an instruction to rewrite the app.
+
+**The distinction that matters: "the code runs" is not the same as "the code does the job."** A vibe-coded app very often runs fine — no crashes, no errors in the console — and still fails questions 1, 2 and 3. Running is the cheapest of the five properties to have and the one users notice least.
+
+> **Worked example (illustrative only — not an assumption about the codebase in front of you).** A calculator that technically works: every button responds, nothing throws. It silently reports **$0 in government charges** when a location code is entered in the wrong case, and it has no accounts, no server and no database of its own. It runs fine. It fails **1** (it cannot do the job for a second user or a second device), **2** (it prints a confident zero and claims official figures) and **3** (there is nowhere to put durable, shared data).
+
+Where the answers are guesses rather than knowledge — the user often does not know — run the quick health smell test below and answer questions 2, 4 and 5 from evidence instead.
+
+### Two things the counts alone won't tell you
+
+- **An existing map is not automatically a good map.** Before building anything on top of one, judge it against the **map-quality ladder** in `cs-build-import-codebase/references/target-map.md`: does it exist → is it good → is it fixable → is it beyond fixing. A map with 13 core features that read like a table of contents is worse than no map, because every note, PRD and task inherits the confusion. Fix it in place where you can; recommend a second project only when it is genuinely unsalvageable, and only with the user's explicit confirmation.
+- **There may be more than one project for the same app.** `codespring projects` can show two, because an unusable map was once replaced by a clean one rather than repaired. If so, **establish which project is authoritative before writing anything** and tell the user which one you are using. There is no `project delete`, so both will stay.
+
+---
+
+## Worked example — the case this was designed against
+
+`PIA App (clean)`: **6 core features, 25 sub-features, 6 notes, 0 PRDs, 0 tasks.** The user runs `cs-build-audit-codebase`.
+
+Correct behaviour:
+
+1. Detect: `coreFeatures = 6`, `notes = 6`, `tasks = 0`, `prds = 0`. Understand is essentially done, and the map passes the quality ladder — 6 core features, all sidebar-level, sub-features are verbs, a note each, no duplicates, nothing flattened.
+2. **Do not create features.** Do not "build the target map" — it already exists. Print the six titles and the ids and move on.
+3. Run the audit on the code.
+4. **Update** the existing notes only where the audit adds something the note did not know (a defect, a silent failure path, a stale data set). Read each note first; preserve what is still true.
+5. Create the Kanban tasks from the findings, each linked to one of the **existing** six feature ids.
+6. Verify: still 6 core features, still 25 sub-features correctly parented, notes still 6.
+
+The failure mode this exists to prevent: producing a **second** set of features, so the project ends up with 12 core features and a map nobody trusts. `codespring mindmap features --replace` appends rather than replaces (`pitfalls.md`), so that mistake is one command away and is tedious to undo.
+
+Note the project's name — *"(clean)"*. It is the **second** CodeSpring project for that app: the first import produced 13 confusing core features, and the map was replaced rather than repaired. That is why the ladder exists, why a second project needs explicit confirmation, and why any session that finds two projects for one app must say which one is authoritative before it writes.
+
+---
+
+## Quick health smell test
+
+Used when the user doesn't know whether their app is "healthy" or "a mess", and by `cs-build-import-codebase` to decide whether to offer an audit before importing. Two minutes, read-only, no sub-agents:
+
+```bash
+git fetch --quiet; git rev-list --left-right --count HEAD...@{u}   # is the local clone behind the remote?
+ls -a .github/workflows 2>/dev/null                 # any CI?
+# tests present at all? (adapt to stack)
+grep -rEl '(^|[^a-z])(test|spec)\.' --include='*' -m1 . 2>/dev/null | head
+# swallowed errors
+grep -rEn 'catch *\([^)]*\) *\{ *\}|catch *\{ *\}|except *:? *pass' . | head -20
+# secrets in shipped source
+grep -rEn 'eyJ[A-Za-z0-9_-]{20,}|sk_live_|AKIA[0-9A-Z]{16}|BEGIN [A-Z ]*PRIVATE KEY' . | head
+# browser-only storage
+grep -rEn 'localStorage|indexedDB|sessionStorage' . | wc -l
+# duplicated logic: the same distinctive constant or function name in more than one file
+```
+
+Six smells, any two of which mean "offer the audit":
+
+1. No tests and no CI — nothing protects a change.
+2. Deploy is not gated — merge ships straight to production.
+3. The local clone is behind the remote — you would be auditing the wrong code.
+4. Swallowed errors — silent failure paths.
+5. Credentials in shipped source.
+6. Records that live only in a browser, or reference data (rates, prices, thresholds) hardcoded in source.
+
+Report the count plainly — *"I found 4 of the 6 things that usually mean an app needs diagnosing before mapping. Want me to audit first?"* — and let the user decide. Never audit without being asked; never import a mess silently either.
+
+---
+
+## Idempotency and verification
+
+Both are non-negotiable on every run and are specified once in `auditing-and-fixing.md` §8 (idempotency: match on title, re-parent strays, never re-create, never regenerate a PRD unasked) and §9 (verification: core-feature count, no flattened sub-features, no duplicates, notes present, tasks linked). Every skill applies both.
+
+**A check is a script; a judgement is prose.** The verification above is `codespring/scripts/check-map.mjs` — run it and read the exit code rather than re-deriving the counts in prose. What stays a judgement, and stays in prose: whether the map is *good*, whether a core feature is really a sidebar item, and whether to fix or rebuild.

--- a/.claude/skills/codespring/references/task-workflow.md
+++ b/.claude/skills/codespring/references/task-workflow.md
@@ -1,0 +1,83 @@
+# Agentic Task Workflow
+
+## Overview
+
+CodeSpring tasks follow a Kanban workflow: `todo` → `in_progress` → `done` (with optional `on_hold`).
+
+## Discovery Flow
+
+```bash
+# 1. List features to find the right area
+codespring features
+
+# 2. Find available tasks (optionally filter by feature)
+codespring tasks --status todo --feature <feature-id>
+
+# 3. Pick a task by examining its title and description
+```
+
+## Execution Pattern
+
+```bash
+# Claim the task (UUID or row number from the task list)
+codespring task start 1
+
+# Do the work using your native coding tools (Read, Edit, Bash, etc.)
+# ...
+
+# Mark complete
+codespring task done 1
+```
+
+## Creating Tasks
+
+```bash
+# Create a task with all options
+codespring task create --title "Fix login redirect" --priority high --feature <feature-id> --estimate "2h"
+
+# Simple task
+codespring task create --title "Update README"
+```
+
+## Multi-Task Batch Workflow
+
+When working through multiple tasks:
+
+```bash
+# Get all todo tasks
+TASKS=$(codespring tasks --status todo)
+
+# For each task:
+# 1. Read the task details
+# 2. Start it: codespring task start <id>
+# 3. Implement the changes
+# 4. Complete it: codespring task done <id>
+# 5. Move to next task
+```
+
+## Priority Levels
+
+- **urgent** — Blocking other work, do first
+- **high** — Important, do soon
+- **medium** — Standard priority
+- **low** — Nice to have
+
+Filter by priority: `codespring tasks --status todo --priority high`
+
+## Status Transitions
+
+| From | To | When |
+|------|-----|------|
+| `todo` | `in_progress` | Starting work |
+| `in_progress` | `done` | Work completed |
+| `in_progress` | `on_hold` | Blocked/paused |
+| `on_hold` | `in_progress` | Unblocked, resuming |
+| `done` | `todo` | Reopening |
+
+## Updating Task Details
+
+You can update more than just status:
+
+```bash
+codespring task update <id> --status in_progress --priority high --estimate "2h"
+```

--- a/.claude/skills/codespring/scripts/check-map.mjs
+++ b/.claude/skills/codespring/scripts/check-map.mjs
@@ -1,0 +1,163 @@
+// check-map.mjs — the deterministic half of map quality and post-write verification.
+//
+// These are CHECKS, not judgements. Whether a map is *good* — whether "Reports"
+// is really a sidebar item, whether a sub-feature is a verb — needs reasoning and
+// stays in prose (cs-build-import-codebase/references/target-map.md). Everything a
+// machine can settle is settled here, identically every run. Read-only.
+//
+// Usage:
+//   bash fetch-project.sh --out /tmp/cs-state
+//   node check-map.mjs /tmp/cs-state [--expect-core N] [--min 4] [--max 8] [--json]
+//
+// Checks:
+//   FAIL  duplicate feature titles (case-insensitive, trimmed)
+//   FAIL  sub-features flattened to top level (a sub-feature also present in node-features)
+//   FAIL  a core feature with no note card
+//   FAIL  duplicate PRDs for the same (feature, type)
+//   FAIL  a task with no feature link
+//   FAIL  --expect-core N given and the count differs
+//   WARN  core-feature count outside 4–8 (needs an argument, not a rewrite)
+//   WARN  a core feature with no sub-features
+//   WARN  a task with no priority
+//
+// Exit codes: 0 = all pass · 1 = at least one FAIL · 2 = only WARNs · 3 = snapshot unusable
+
+import { readJson, mindmapModel, featureModel, taskModel, prdModel, normTitle } from './parse.mjs';
+
+const args = process.argv.slice(2);
+const dir = args[0];
+const flag = (name, fallback) => {
+  const i = args.indexOf(`--${name}`);
+  return i !== -1 && args[i + 1] !== undefined ? Number(args[i + 1]) : fallback;
+};
+const MIN = flag('min', 4);
+const MAX = flag('max', 8);
+const EXPECT = flag('expect-core', null);
+const jsonOnly = args.includes('--json');
+
+if (!dir) {
+  console.error('usage: node check-map.mjs <snapshot-dir> [--expect-core N] [--min 4] [--max 8] [--json]');
+  process.exit(3);
+}
+
+const map = mindmapModel(readJson(dir, 'mindmap.json'));
+const features = featureModel(readJson(dir, 'features.json'));
+const tasks = taskModel(readJson(dir, 'tasks.json'));
+const prds = prdModel(readJson(dir, 'prds.json'));
+
+if (!map.ok) {
+  console.error(`CANNOT CHECK: ${map.reason}`);
+  process.exit(3);
+}
+
+const results = [];
+const add = (level, check, detail) => results.push({ level, check, detail });
+
+const coreItems = map.coreItems;
+const coreCount = coreItems.length;
+
+// --- core-feature count -----------------------------------------------------
+if (EXPECT !== null && coreCount !== EXPECT) {
+  add('FAIL', 'core-feature count', `expected ${EXPECT}, found ${coreCount} — something created or flattened features`);
+} else if (coreCount < MIN || coreCount > MAX) {
+  add('WARN', 'core-feature count', `${coreCount} core features (target ${MIN}–${MAX}) — above ${MAX}, argue for each one; well above it usually means an output document or a form was split into features`);
+} else {
+  add('PASS', 'core-feature count', `${coreCount} core features`);
+}
+
+// --- duplicate titles -------------------------------------------------------
+const byTitle = new Map();
+for (const f of [...coreItems.map((i) => ({ id: String(i.id ?? ''), title: String(i.title ?? '') })), ...features.all]) {
+  const key = normTitle(f.title);
+  if (!key) continue;
+  if (!byTitle.has(key)) byTitle.set(key, new Set());
+  byTitle.get(key).add(f.id);
+}
+const dupes = [...byTitle.entries()].filter(([, ids]) => ids.size > 1);
+if (dupes.length) {
+  add('FAIL', 'no duplicate titles', dupes.map(([t, ids]) => `"${t}" → ${[...ids].join(', ')}`).join(' · ') + ' — recover with: codespring feature delete <id> --yes');
+} else {
+  add('PASS', 'no duplicate titles', `${byTitle.size} distinct titles`);
+}
+
+// --- flattened sub-features -------------------------------------------------
+const coreIds = new Set(coreItems.map((i) => String(i.id ?? '')));
+const coreTitles = new Set(coreItems.map((i) => normTitle(i.title)));
+const flattened = [];
+for (const group of map.subGroups) {
+  for (const item of group.items) {
+    const id = String(item?.id ?? '');
+    if (coreIds.has(id) || coreTitles.has(normTitle(item?.title))) {
+      flattened.push({ id, title: String(item?.title ?? ''), parent: group.parentFeatureId });
+    }
+  }
+}
+for (const item of coreItems) {
+  if (item?.parentFeatureId) {
+    flattened.push({ id: String(item.id ?? ''), title: String(item.title ?? ''), parent: String(item.parentFeatureId) });
+  }
+}
+if (flattened.length) {
+  add('FAIL', 'no flattened sub-features', flattened.map((f) => `"${f.title}" belongs under ${f.parent}`).join(' · ') + ' — fix with: codespring feature update <subId> --parent <coreId>');
+} else {
+  add('PASS', 'no flattened sub-features', `${map.subGroups.length} sub-feature groups intact`);
+}
+
+// --- a note per core feature ------------------------------------------------
+const noteIds = new Set(map.noteIds);
+const hasNote = (id) => noteIds.has(`notes-${id}`) || [...noteIds].some((n) => n.endsWith(String(id)));
+const missingNotes = coreItems.filter((i) => !hasNote(String(i.id ?? ''))).map((i) => String(i.title ?? i.id));
+if (missingNotes.length) {
+  add('FAIL', 'a note per core feature', `no note for: ${missingNotes.join(', ')} — never generate a PRD or a task for a feature with no note`);
+} else {
+  add('PASS', 'a note per core feature', `${noteIds.size} notes`);
+}
+
+// --- sub-features present ---------------------------------------------------
+const emptyCores = coreItems.filter((i) => !map.subGroups.some((g) => g.parentFeatureId === String(i.id ?? '') && g.items.length));
+if (emptyCores.length) {
+  add('WARN', 'sub-features present', `no sub-features under: ${emptyCores.map((i) => String(i.title ?? i.id)).join(', ')}`);
+} else if (coreItems.length) {
+  add('PASS', 'sub-features present', 'every core feature has sub-features');
+}
+
+// --- duplicate PRDs ---------------------------------------------------------
+const prdKeys = new Map();
+for (const p of prds) {
+  const key = `${p.featureId ?? '?'}::${normTitle(p.prdType)}`;
+  if (!prdKeys.has(key)) prdKeys.set(key, []);
+  prdKeys.get(key).push(p.id);
+}
+const dupPrds = [...prdKeys.entries()].filter(([, ids]) => ids.length > 1);
+if (dupPrds.length) {
+  add('FAIL', 'no duplicate PRDs', dupPrds.map(([k, ids]) => `${k} × ${ids.length}`).join(' · ') + ' — a client timeout does not stop generation; keep the most complete per (feature, type)');
+} else {
+  add('PASS', 'no duplicate PRDs', `${prds.length} PRDs`);
+}
+
+// --- tasks linked -----------------------------------------------------------
+const unlinked = tasks.filter((t) => !t.featureId);
+if (unlinked.length) {
+  add('FAIL', 'every task linked to a feature', `${unlinked.length} unlinked: ${unlinked.slice(0, 5).map((t) => t.title || t.id).join(' · ')}${unlinked.length > 5 ? ' …' : ''}`);
+} else if (tasks.length) {
+  add('PASS', 'every task linked to a feature', `${tasks.length} tasks`);
+}
+const noPriority = tasks.filter((t) => !t.priority);
+if (noPriority.length) {
+  add('WARN', 'every task carries a severity', `${noPriority.length} without a priority — Critical→urgent, High→high, Medium→medium, Low→low`);
+}
+
+// --- report -----------------------------------------------------------------
+const fails = results.filter((r) => r.level === 'FAIL');
+const warns = results.filter((r) => r.level === 'WARN');
+
+if (jsonOnly) {
+  console.log(JSON.stringify({ coreCount, fails: fails.length, warns: warns.length, results }, null, 2));
+} else {
+  for (const r of results) console.log(`${r.level.padEnd(4)}  ${r.check} — ${r.detail}`);
+  console.log(`\n${fails.length} fail, ${warns.length} warn, ${results.length - fails.length - warns.length} pass`);
+  if (fails.length) console.log('A FAIL is a machine-checkable defect: fix it before writing anything else.');
+  if (warns.length && !fails.length) console.log('WARNs need a human judgement, not an automatic fix.');
+}
+
+process.exit(fails.length ? 1 : warns.length ? 2 : 0);

--- a/.claude/skills/codespring/scripts/fetch-project.sh
+++ b/.claude/skills/codespring/scripts/fetch-project.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# fetch-project.sh — snapshot the linked CodeSpring project to a directory of JSON files.
+#
+# READ-ONLY. It runs only `codespring` read commands and writes nothing to the
+# project, the mindmap or the repo. Its output directory is disposable.
+#
+# Why a script: the state-detection block must produce the SAME answer every run.
+# Prose invites the agent to skip a command or eyeball a count. This does not.
+#
+# Usage:
+#   bash fetch-project.sh --out /tmp/cs-state [--repo /path/to/repo]
+#
+# Then:
+#   node state.mjs     /tmp/cs-state
+#   node check-map.mjs /tmp/cs-state --expect-core 6
+#
+# Writes into --out:
+#   mindmap.json features.json prds.json tasks.json   (raw CLI output)
+#   repo.json                                         (projectId, cwd, FINDINGS.md present?)
+#   errors.log                                        (any command that failed)
+#
+# Exit codes: 0 = every command succeeded · 1 = not linked / CLI missing · 2 = some command failed (see errors.log)
+
+set -u
+
+OUT=""
+REPO="$PWD"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --out)  OUT="${2:-}"; shift 2 ;;
+    --repo) REPO="${2:-}"; shift 2 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+[ -n "$OUT" ] || { echo "fetch-project.sh: --out <dir> is required" >&2; exit 1; }
+
+CLI="codespring"
+command -v codespring >/dev/null 2>&1 || CLI="npx @codespring-app/cli"
+
+mkdir -p "$OUT"
+: > "$OUT/errors.log"
+
+CONFIG="$REPO/.codespring/config.json"
+if [ ! -f "$CONFIG" ]; then
+  echo "NOT LINKED: no $CONFIG" | tee -a "$OUT/errors.log"
+  echo "Link it first: codespring projects  →  codespring init --project <id> --force" >&2
+  printf '{"linked":false,"cwd":"%s"}\n' "$REPO" > "$OUT/repo.json"
+  exit 1
+fi
+
+PROJECT_ID="$(node -e 'const fs=require("fs");try{const c=JSON.parse(fs.readFileSync(process.argv[1],"utf8"));process.stdout.write(String(c.projectId||c.project_id||c.id||""))}catch(e){}' "$CONFIG")"
+[ -n "$PROJECT_ID" ] || { echo "NOT LINKED: no projectId in $CONFIG" | tee -a "$OUT/errors.log" >&2; exit 1; }
+
+# Print the projectId before anything else — the local config is the only one to trust.
+echo "projectId: $PROJECT_ID  (from $CONFIG)"
+
+FINDINGS=false
+[ -f "$REPO/FINDINGS.md" ] && FINDINGS=true
+
+node -e '
+  const [id, cwd, findings] = process.argv.slice(1);
+  process.stdout.write(JSON.stringify({ linked: true, projectId: id, cwd, findingsMd: findings === "true" }, null, 2));
+' "$PROJECT_ID" "$REPO" "$FINDINGS" > "$OUT/repo.json"
+
+STATUS=0
+fetch() { # fetch <outfile> <args...>
+  local file="$1"; shift
+  if ( cd "$REPO" && $CLI "$@" --json ) > "$OUT/$file" 2>>"$OUT/errors.log"; then
+    [ -s "$OUT/$file" ] || { echo "empty output: $CLI $* --json" >> "$OUT/errors.log"; STATUS=2; }
+  else
+    echo "failed: $CLI $* --json" >> "$OUT/errors.log"
+    echo 'null' > "$OUT/$file"
+    STATUS=2
+  fi
+}
+
+fetch mindmap.json  mindmap
+fetch features.json features
+fetch prds.json     prds
+fetch tasks.json    tasks
+
+if [ "$STATUS" -ne 0 ]; then
+  echo "some commands failed — see $OUT/errors.log (auth expired? run: codespring auth login)" >&2
+fi
+
+echo "snapshot: $OUT"
+exit "$STATUS"

--- a/.claude/skills/codespring/scripts/parse.mjs
+++ b/.claude/skills/codespring/scripts/parse.mjs
@@ -1,0 +1,155 @@
+// parse.mjs — shared, shape-tolerant readers for a `fetch-project.sh` snapshot.
+//
+// The CLI's JSON envelope has changed before (bare array vs { data: [...] } vs
+// { features: [...] }), and the mindmap arrives as a record wrapping flowJson.
+// So nothing here indexes a fixed path: it searches for the shape it needs and
+// says so loudly when it cannot find it. Read-only; pure functions.
+//
+// Node model it expects (see codespring/references/mindmap-structure.md):
+//   node-features        → data.items = the CORE features
+//   sub-feature group    → one node per core feature, data.parentFeatureId = coreId, data.items = sub-features
+//   bridge-feature-<id>  → connector from a feature card to its detail nodes
+//   notes-<featureId>    → the single "how it works" note card for that core feature
+//   node-tech-stack      → data.items = the tech stack
+
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function readJson(dir, name, fallback = null) {
+  const p = join(dir, name);
+  if (!existsSync(p)) return fallback;
+  const raw = readFileSync(p, 'utf8').trim();
+  if (!raw || raw === 'null') return fallback;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // Some CLI versions print a human line before the JSON body.
+    const start = raw.search(/[[{]/);
+    if (start > 0) {
+      try { return JSON.parse(raw.slice(start)); } catch { /* fall through */ }
+    }
+    return fallback;
+  }
+}
+
+/** Breadth-first search for the first array of objects reachable from `root`. */
+export function findArray(root, preferKeys = []) {
+  if (Array.isArray(root)) return root;
+  if (!root || typeof root !== 'object') return null;
+  for (const key of preferKeys) {
+    if (Array.isArray(root[key])) return root[key];
+  }
+  const queue = [root];
+  const seen = new Set();
+  while (queue.length) {
+    const node = queue.shift();
+    if (!node || typeof node !== 'object' || seen.has(node)) continue;
+    seen.add(node);
+    for (const key of preferKeys) {
+      if (Array.isArray(node[key])) return node[key];
+    }
+    for (const value of Object.values(node)) {
+      if (Array.isArray(value) && value.some((v) => v && typeof v === 'object')) return value;
+      if (value && typeof value === 'object') queue.push(value);
+    }
+  }
+  return null;
+}
+
+/** The mindmap's flow nodes, wherever they are wrapped. */
+export function mindmapNodes(mindmap) {
+  if (!mindmap) return null;
+  const candidates = [
+    mindmap?.flowJson?.nodes,
+    mindmap?.mindmap?.flowJson?.nodes,
+    mindmap?.data?.flowJson?.nodes,
+    mindmap?.nodes,
+  ];
+  for (const c of candidates) if (Array.isArray(c)) return c;
+  const found = findArray(mindmap, ['nodes']);
+  return Array.isArray(found) ? found : null;
+}
+
+const itemsOf = (node) => {
+  const items = node?.data?.items ?? node?.items;
+  return Array.isArray(items) ? items : [];
+};
+
+export function mindmapModel(mindmap) {
+  const nodes = mindmapNodes(mindmap);
+  if (!nodes) {
+    return { ok: false, reason: 'could not find the mindmap nodes array', nodes: [], coreItems: [], subGroups: [], noteIds: [], techItems: [] };
+  }
+  const featuresNode = nodes.find((n) => n?.id === 'node-features');
+  const techNode = nodes.find((n) => n?.id === 'node-tech-stack');
+  const noteIds = nodes
+    .filter((n) => String(n?.id ?? '').startsWith('notes-') || n?.data?.type === 'notes')
+    .map((n) => String(n.id));
+  const subGroups = nodes
+    .filter((n) => n?.id !== 'node-features' && n?.data?.parentFeatureId && itemsOf(n).length >= 0)
+    .filter((n) => Array.isArray(n?.data?.items ?? n?.items))
+    .map((n) => ({ id: String(n.id), parentFeatureId: String(n.data.parentFeatureId), items: itemsOf(n) }));
+  return {
+    ok: Boolean(featuresNode),
+    reason: featuresNode ? null : 'no node with id "node-features" — is the mindmap for this project initialised?',
+    nodes,
+    coreItems: itemsOf(featuresNode),
+    subGroups,
+    noteIds,
+    techItems: itemsOf(techNode),
+  };
+}
+
+/** Features as reported by `codespring features --json`, split core vs sub. */
+export function featureModel(features) {
+  const list = findArray(features, ['features', 'items', 'data']) ?? [];
+  const norm = list
+    .filter((f) => f && typeof f === 'object')
+    .map((f) => ({
+      id: String(f.id ?? f.featureId ?? ''),
+      title: String(f.title ?? f.name ?? ''),
+      parentFeatureId: f.parentFeatureId ?? f.parent_feature_id ?? f.parentId ?? null,
+    }));
+  return {
+    all: norm,
+    core: norm.filter((f) => !f.parentFeatureId),
+    sub: norm.filter((f) => Boolean(f.parentFeatureId)),
+  };
+}
+
+export function taskModel(tasks) {
+  const list = findArray(tasks, ['tasks', 'items', 'data']) ?? [];
+  return list
+    .filter((t) => t && typeof t === 'object')
+    .map((t) => ({
+      id: String(t.id ?? ''),
+      title: String(t.title ?? t.name ?? ''),
+      status: String(t.status ?? ''),
+      priority: t.priority ?? null,
+      featureId: t.featureId ?? t.feature_id ?? t.feature?.id ?? null,
+    }));
+}
+
+export function prdModel(prds) {
+  const list = findArray(prds, ['prds', 'items', 'data']) ?? [];
+  return list
+    .filter((p) => p && typeof p === 'object')
+    .map((p) => ({
+      id: String(p.id ?? ''),
+      name: String(p.name ?? p.title ?? ''),
+      featureId: p.featureId ?? p.feature_id ?? null,
+      prdType: String(p.prdType ?? p.type ?? ''),
+    }));
+}
+
+export const normTitle = (s) => String(s ?? '').trim().toLowerCase().replace(/\s+/g, ' ');
+
+/** Leading task number, so numbering can be continued rather than restarted. */
+export function highestTaskNumber(tasks) {
+  let max = 0;
+  for (const t of tasks) {
+    const m = /^\s*(\d+)\s*[.)\-:]/.exec(t.title);
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  return max;
+}

--- a/.claude/skills/codespring/scripts/state.mjs
+++ b/.claude/skills/codespring/scripts/state.mjs
@@ -1,0 +1,74 @@
+// state.mjs — the state-detection block, as a deterministic script.
+//
+// Prints the one-line summary every skill must show before it does anything,
+// then the booleans and counts from references/project-state.md. Read-only.
+//
+// Usage:
+//   bash fetch-project.sh --out /tmp/cs-state
+//   node state.mjs /tmp/cs-state [--json]
+//
+// Exit codes: 0 = state read · 1 = snapshot unusable (not linked, or the mindmap could not be parsed)
+
+import { readJson, mindmapModel, featureModel, taskModel, prdModel, highestTaskNumber } from './parse.mjs';
+
+const dir = process.argv[2];
+const jsonOnly = process.argv.includes('--json');
+
+if (!dir) {
+  console.error('usage: node state.mjs <snapshot-dir> [--json]   (make one with: bash fetch-project.sh --out <dir>)');
+  process.exit(1);
+}
+
+const repo = readJson(dir, 'repo.json', {});
+if (repo.linked === false) {
+  console.error('NOT LINKED — no local .codespring/config.json. Link the project before anything else.');
+  process.exit(1);
+}
+
+const map = mindmapModel(readJson(dir, 'mindmap.json'));
+const features = featureModel(readJson(dir, 'features.json'));
+const tasks = taskModel(readJson(dir, 'tasks.json'));
+const prds = prdModel(readJson(dir, 'prds.json'));
+
+// Core-feature count: the mindmap's node-features items are authoritative
+// (that is the list the canvas draws, and the list pitfalls.md §2 inflates).
+const coreCount = map.ok ? map.coreItems.length : features.core.length;
+const subCount = map.subGroups.length
+  ? map.subGroups.reduce((n, g) => n + g.items.length, 0)
+  : features.sub.length;
+
+const state = {
+  projectId: repo.projectId ?? null,
+  cwd: repo.cwd ?? null,
+  linked: true,
+  coreFeatures: coreCount,
+  subFeatures: subCount,
+  notes: map.noteIds.length,
+  prds: prds.length,
+  tasks: tasks.length,
+  tasksByStatus: tasks.reduce((acc, t) => ({ ...acc, [t.status || 'unknown']: (acc[t.status || 'unknown'] ?? 0) + 1 }), {}),
+  highestTaskNumber: highestTaskNumber(tasks),
+  audited: Boolean(repo.findingsMd),
+  stack: map.techItems.length > 0,
+  mindmapParsed: map.ok,
+};
+
+if (jsonOnly) {
+  console.log(JSON.stringify(state, null, 2));
+} else {
+  const bits = [
+    `${state.coreFeatures} core features`,
+    `${state.subFeatures} sub-features`,
+    `${state.notes} notes`,
+    `${state.prds} PRDs`,
+    `${state.tasks} tasks`,
+  ];
+  console.log(`Project ${state.projectId} — ${bits.join(', ')}. Audit: ${state.audited ? 'FINDINGS.md present' : 'not yet'}.`);
+  console.log(JSON.stringify(state, null, 2));
+  if (!map.ok) console.error(`WARNING: ${map.reason} — counts fell back to \`codespring features\`.`);
+  if (state.notes !== state.coreFeatures) {
+    console.error(`WARNING: ${state.notes} notes for ${state.coreFeatures} core features — every core feature needs one before any PRD or task.`);
+  }
+}
+
+process.exit(0);

--- a/.claude/skills/cs-build-audit-codebase/SKILL.md
+++ b/.claude/skills/cs-build-audit-codebase/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: cs-build-audit-codebase
+description: >
+  Diagnose a broken or untrusted codebase and plan the fix. Runs the app for
+  real, fans out parallel specialist sub-agents (security, database, core logic,
+  frontend/UX, architecture), audits the git/CI/deploy setup, verifies the
+  headline claims independently, then gives a plain-English findings list ranked
+  by real-world cost, writes FINDINGS.md into the repo, and delivers a
+  rebuild-or-fix-in-place verdict (fix in place wins by default, and having real
+  users can veto a rebuild outright) before handing off to cs-build-import-codebase and
+  creating the Kanban tasks. Works on any codebase in any language. Triggers,
+  "my app is a mess", "audit my codebase", "what's wrong with my app", "diagnose
+  this codebase", "should I rebuild or fix this", "find the bugs in my app",
+  "review my whole app".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(git:*) Bash(gh:*) Bash(node:*) Bash(npm:*) Bash(python3:*) Bash(curl:*) Bash(grep:*) Bash(rg:*)
+metadata:
+  author: codespring
+  version: "0.2"
+---
+
+# Audit a codebase and plan the fix
+
+For when the user says *"my app is a mess — tell me what's wrong and what to do about it."* Diagnostic, language-agnostic, and evidence-based. It ends with a plain-English findings list, a `FINDINGS.md` in the repo, a **verdict** (rebuild or fix in place), and Kanban tasks.
+
+**Read first:** the `codespring` skill's `references/project-state.md` (enter-from-anywhere, the five questions), `references/auditing-and-fixing.md` (**the reasoning behind every step here**), `references/analyze-codebase.md`, `references/pitfalls.md`. Then this skill's `references/specialist-briefs.md` (copy-ready sub-agent briefs) and `references/plain-english-writeup.md` (the deliverable's structure and voice).
+
+**Scripts** — run these instead of doing the equivalent by hand; a check must give the same answer every time. `scripts/check-repo.sh` (this skill: git/delivery reality) and the `codespring` skill's `scripts/fetch-project.sh` + `state.mjs` + `check-map.mjs` (state detection and map verification). All read-only. Judgement calls stay prose.
+
+**Script paths below are relative to this skill's own folder**, and the skills install side by side — so `../codespring/scripts/…` reaches the core skill's scripts. Resolve them once at the start (`SKILL_DIR=$(dirname <this file>)`) and use absolute paths after that, because your working directory will be the user's repo.
+
+**Language- and stack-agnostic.** Every named specific in this skill and its references — a rate table, a report, a state code — is a **labelled worked example** from the audit this was generalised from, never an assumption about the codebase in front of you. Translate the pattern; do not look for the example.
+
+**Guardrails:** read-only on the target codebase, with exactly one exception — `FINDINGS.md` at the repo root, written only after asking, never committed. Live probing of the user's own running app and own services is fine and must be non-destructive.
+
+## 0. Detect where the project already is
+Run the state-detection **scripts** — same answer every run, no hand-counting (the `codespring` skill's `scripts/`, installed alongside this one):
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state   # read-only snapshot; prints the projectId
+node ../codespring/scripts/state.mjs       /tmp/cs-state          # the one-line summary + booleans and counts
+node ../codespring/scripts/check-map.mjs   /tmp/cs-state          # the machine-checkable map faults
+```
+
+Print the one-line summary to the user. **This decides what you skip.**
+
+- Not linked → link first (or tell the user to create the project in the web app if it must live in a team workspace — `pitfalls.md`).
+- **A map already exists → judge it before you keep it** (the ladder below). Either way, do not create features, do not "build the target map", do not run `mindmap features` here. Print the existing core features and their ids, then audit.
+- `FINDINGS.md` already present → read it. You are updating an audit, not starting one.
+- Tasks already exist → note the highest task number; you will continue the sequence, not restart it.
+
+Always read `projectId` from the **local** `.codespring/config.json` and print it before any write.
+
+### 0a. Is the existing map any good? — the ladder
+*"A map exists → keep it"* is too blunt. An unusable map poisons every note, PRD and task built on it. Full version, including the CLI commands: `cs-build-import-codebase/references/target-map.md`.
+
+1. **Does a map exist?** No → it gets built later, by `cs-build-import-codebase` (§10). Not here.
+2. **Is it good?** `check-map.mjs` (above) settles the count, duplicate titles, flattened sub-features and missing notes. **You** judge the rest: are the core features **4–8** and each one something a user would recognise as a **sidebar item**; are sub-features things a user **does**, not sections of an output document or groups of form fields; are card descriptions one sentence with the depth in the notes. A map can pass every automated check and still be incomprehensible.
+3. **Good → keep it.** Update the notes, add the tasks. **Never recreate it.**
+4. **Fixable** (mostly right, a few strays) → **fix in place and say what you changed:** `codespring feature update <subId> --parent <coreId>` to re-parent, `codespring feature delete <dupId> --yes` to remove a duplicate, `codespring feature update <id> --title "..."` to rename.
+5. **Not fixable** (so wrong it is confusing — wildly too many core features, output sections standing in as features, no coherent structure) → **do not try to salvage it.** Explain plainly why, and recommend a **new CodeSpring project** with a clean map; the old one **stays as history**. **Get explicit confirmation before creating a second project — never silently.**
+
+⚠️ **Two projects for one app is confusing later**, so it must be a deliberate, explained choice — and the user must be told **which project is now authoritative**. The real case: a 13-core-feature import was unusable, a second project with a clean 6-feature map replaced it, and both still exist. There is no `project delete`, so this is permanent. If you arrive and find two projects for one app, establish which is authoritative before writing anything.
+
+## 1. Scope the audit with the user (short)
+Confirm: the repo path, how to start the app, what the app is *for*, whether there is an incumbent product it replaces, and anything already known to be broken. Ask what they most want answered — the real audit was shaped by three of the owner's own questions ("is it wrong in different areas?", "how is it reading the database?", "why do some reports look better?") and each produced a headline finding.
+
+Three more questions, because each one changes what the findings mean (§2):
+- **Does the app have real users or paying customers?** This can veto a rebuild on its own (§9) — ask it now, not at verdict time.
+- **Is anyone else working in this repo right now?**
+- **Is the app feature-complete, or still being built?**
+
+State the posture up front: **the job is making what already works work properly, not adding features.** See `auditing-and-fixing.md` §4a.
+
+## 2. Recon + the repo/delivery audit (do this yourself, first)
+It caveats everything else, so it comes before the fan-out. Commands in `specialist-briefs.md` §6. Establish:
+- **Is the local clone behind the remote?** `git fetch`, then compare local `HEAD` with `origin/<branch>`. If behind, **say so and offer to update before auditing** — auditing a stale clone produces findings that may already be fixed. (The real audit ran two merges behind production.)
+- Is the **server-side source even in the repo**, or does it live only in a hosting dashboard? If the latter, that is a critical, total-loss finding — give the exact backup commands.
+- Branch/PR structure; **is deploy gated on any automated check** or does merging ship to production; any CI at all; `.gitignore` adequacy; secrets in history (report the negative result too); is there a staging environment or does every session talk to production.
+- Fix the stack description now so the sub-agents don't each re-derive it.
+
+### 2a. The codebase is a moving target — run the script first
+```bash
+bash scripts/check-repo.sh --repo <abs repo path> [--paths <suspect files…>]
+```
+Read-only (`git fetch` touches remote-tracking refs only). It prints the commit the findings will apply to, how far behind the remote you are and which files those unseen commits touch, every remote branch with its date and author, recent authors, whether the working tree is dirty, and whether any automated check exists. Exit code 2 means the clone is behind.
+
+**Worked example of what this catches, from a real audit:** 12 remote branches, the owner committing directly to `main`, a helper working in parallel, and the audited clone **3 commits behind** — with the newest commits touching the exact file under audit.
+
+Then:
+- **If behind: say how many commits, and offer to update before auditing.** One line, no lecture. **Never audit a stale clone silently** — findings from old code may already be fixed.
+- **Enumerate the remote branches and report what is in flight**, so you do not write findings against work that has already been superseded.
+- **Record the exact commit SHA in `FINDINGS.md`**, in the header beside the review dates. The findings are a snapshot of that commit and nothing else.
+- **Anyone else working in the repo right now?** Ask. If yes, recommend a **dedicated branch** for the fixes and say plainly that merge conflicts will need managing.
+- **Feature-complete, or still being built?** If still being built, the map may be missing planned modules the code does not yet contain, so **ask the owner what is planned but not yet built before finalising the feature list.** Real failure: an audit concluded four pages were a separate product because nothing linked to them — they were unfinished modules of the same product (§6a, rule 5).
+- If the remote moves during the audit, re-check the specific findings you are about to ship rather than re-running everything.
+
+**Assume no git knowledge and do not lecture the owner about it.** Non-technical owners commonly do not understand branches and will commit straight to `main` while an audit or a rebuild is in flight. State what you are doing and why in one line — *"I'll work on a branch called `fixes` so your own commits to main don't collide with mine"* — and never assume a clean linear history or that `main` is protected.
+
+## 3. Run the app and drive it
+**The highest-yield step. Do not skip it and do not substitute reading the code.** Start or serve the app, drive the main journeys, watch the console and the network panel, try empty/zero/negative/absurd/wrong-case inputs, and find where data is actually stored.
+
+In the real audit this found a cleared input that froze the report on stale numbers, proved the core calculation made zero network requests (which reframed the whole audit), and *disproved* a suspected auth bypass that was really a labelled sample mode. Running it prevents false accusations as often as it finds bugs.
+
+## 4. Fan out parallel specialists
+Launch them **in one message, concurrently**, each read-only, each with a fully self-contained brief and no sight of the others. Independence is the evidence. Briefs in `references/specialist-briefs.md`:
+
+**security/auth · database/schema · core business logic · frontend/UX/dead controls · architecture/scalability**
+
+Add domains the app warrants — an incumbent/competitor comparison, a user-journey-and-failure map, a data-provenance pass. Every finding must carry a `file:line` or a reproducing command, plus an evidence label: **CONFIRMED** (ran it / read the exact line), **INFERRED** (deduced, not executed), **UNVERIFIED** (suspected, say what would check it). Unlabelled, uncited findings are dropped.
+
+While they run, keep driving the app. You are the sixth agent and the one who resolves disagreements.
+
+## 5. Hunt the specific defect categories
+Named in `auditing-and-fixing.md` §4 — hunt these deliberately rather than hoping to notice them:
+- **Stale hardcoded reference data** — rates/prices/thresholds as literals in source, with nothing noticing when they expire.
+- **Duplicated logic that has drifted** — build a duplication register; check whether the copies agree *today* and whether they ever didn't; check which copy the main entry point actually loads.
+- **Silent failure paths** — an error becoming a zero, an empty object, a stale screen, or a success message. *A missing value and a failure must never look the same.*
+- **Data that lives only in a browser** — or only on one machine, with no backup and no warning.
+- **Unverifiable currency/accuracy claims** — anything the software asserts that it cannot check.
+
+## 6. Verify the headlines yourself
+Do not relay a sub-agent's biggest number. Reproduce it independently — a second method (extract the logic into a scratch harness) and/or the live app. In the real audit both agreed to the cent, which is what made the headline dollar figure safe to show a client; say so in the write-up when they do. Reconcile contradictions between specialists; a later, better-informed pass beats an earlier one — record the correction rather than shipping both.
+
+### 6a. Then audit yourself — this is where the errors actually came from
+The CONFIRMED / INFERRED / UNVERIFIED labels only govern **sub-agent output**. In the real audit **nothing checked the orchestrator's own summarising, and that is where every error entered.** Full worked examples in `auditing-and-fixing.md` §3a. The four rules:
+
+1. **State the scope of every measurement in the same sentence as the number.** *"45 bytes across 3 keys"* was measured on one page; the app used 15 keys product-wide.
+2. **Before repeating a sub-agent's headline claim, re-run the one command that proves it.** *"The tax tables have drifted between the two engine copies"* was written when a `diff` showed the rate tables byte-identical and a different function drifted — it sent the reader to the wrong file.
+3. **When claiming an app does something better, state what it does NOT do in the same breath.** Calling the app "ahead" of the incumbent hid the fact that it had solved only the easy half of that feature.
+4. **Every term of art gets explained in the sentence it appears in, or is replaced.** *"Versioned rate tables stamped onto the saved file"* → *"when you save a report, also save which year's tax rates it used, so fixing a rate later doesn't change what a client was already shown."*
+5. **Concluding that part of the codebase is out of scope.** Four pages were called "a separate product" because nothing linked to them and they loaded a different script. The evidence was real; the conclusion was wrong — `git log` showed those files untouched since the initial import while their siblings changed weekly, and the owner had already said he still had to work out that part's workflow. They were **unfinished modules of the same product**. **Rule: before concluding that part of a codebase is out of scope, check its git history and ask the owner.** Unreferenced code may be unfinished rather than foreign: `git log --format="%ad %s" -- <path>` per file is cheap and decisive, and `scripts/check-repo.sh --paths <files>` does it for a list.
+
+**Required step, before writing anything in §8: list your headline claims and name the specific evidence for each one** — the command, the `file:line`, or the screen you drove. **Anything you cannot point at gets dropped or labelled unverified.** Write the list out; it is the only check on your own work rather than a sub-agent's.
+
+## 7. Sort everything into the three buckets
+**Rule, not a suggestion** (`auditing-and-fixing.md` §4a). The audit's default posture is **fix, don't extend** — the goal is usually getting something live, not making it richer.
+1. **Problems** — broken or wrong now. *This is the job*, and the only bucket that becomes tasks.
+2. **Could add later** — real gaps, deliberately parked. Written up in their own section, **never in the task list**.
+3. **Not worth adding** — with the reason, so the question is closed.
+
+A feature suggestion may never enter the task list, including "while we're in there". "This is missing" is bucket 2; "this exists and gives a wrong answer" is bucket 1.
+
+### 7a. Where future ideas go — there is nowhere else yet
+CodeSpring has features, notes, PRDs and Kanban tasks. **It has no home for "things we might build later"**, and those must never become tasks: **a task list implies committed work**, so a parked idea on the board either gets built by accident or makes the board untrustworthy.
+
+**Interim convention — use it every time:** future ideas live in **`FINDINGS.md` in the repo**, in two explicitly titled sections, one line each **with a reason**:
+- **"Could add later — deliberately not doing now"** — the reason it is parked, plus whether it is worth doing later.
+- **"Not worth adding"** — the reason the question is closed, so it stops coming up.
+
+Nothing in either section becomes a task, a feature on the map, or a PRD. Say the posture out loud once in the document. **Report this to the user as a product gap for FERB** — there is no first-class ideas surface that is visibly *not* a commitment.
+
+## 8. Write the plain-English findings
+Full structure and voice in `references/plain-english-writeup.md`. Non-negotiables:
+- **Roughly third-grade reading level.** Short bullets, one concrete example per problem.
+- **Ranked by real-world consequence** — dollar impact or client-trust impact — hardest-hitting first.
+- **No file paths, no line numbers, no jargon** in the user-facing text. Every finding readable by someone who does not know what a database migration is; any term of art explained in the same sentence. (*"Versioned rate tables stamped onto the saved file"* failed this test. *"When you save a report, also save which year's tax rates it used, so fixing a rate later doesn't change what a client was already shown"* passes.)
+- **Say what is good**, and mark it as not-to-break.
+- **Two explicitly titled sections for future ideas** (§7a): *"Could add later — deliberately not doing now"* and *"Not worth adding"*, one line and one reason each.
+- **Name the commit** the audit was based on in the header, with the review dates — findings are a snapshot (§2a).
+- **Close with what you did not verify**, and what would verify it.
+
+Ask, then write `FINDINGS.md` at the repo root. If it exists, update in place and preserve anything the user edited. **Never commit it.** The quality bar, and the structure section by section, is in `references/plain-english-writeup.md`.
+
+## 9. The verdict — rebuild or fix in place
+**Fix in place is the default. A rebuild has to be argued for.** State it plainly, to the user and to yourself: **rebuilding the whole architecture of an app is a large, risky job and is the wrong answer for most codebases.** It suits small apps with little irreplaceable logic — a tiny static-HTML app is a fair rebuild candidate; almost nothing else is. Warn yourself against over-recommending one: users in distress ask for a rewrite, and agreeing is the easy move, not the right one. A long defect list is *not* evidence for a rebuild.
+
+### The gate — ask this before the table, because it can veto a rebuild on its own
+**Does the app have real users or paying customers?**
+
+- **If yes → fix in place is strongly preferred, regardless of how bad the code is.** A rebuild means a migration, a cutover, and a period where both versions exist — risk a live business may not be able to absorb.
+- **If a rebuild is genuinely unavoidable *with* live users**, it needs a **parallel-running plan**: the old app stays live, the new one is built alongside it, with an explicit cutover and a rollback. The user must understand and accept that before work starts.
+- **Say the trap out loud:** that usually means a second repo or a long-lived branch, and **multiple versions of an app across repos gets confusing fast**. **Default to a branch in the same repo**; use a separate repo only if the stack changes so completely that one repo cannot hold both.
+- "No users yet" does not argue *for* a rebuild. It only removes the veto and lets the table decide.
+
+| Signal | Points to REBUILD | Points to FIX IN PLACE |
+|---|---|---|
+| **Can the current architecture host what the app needs to do?** | No — what is missing is structural (no server, no accounts, nowhere to put the data) and cannot be added where it is | Yes — what is missing can be added inside what already exists |
+| **How much irreplaceable domain logic is there?** | Small and isolatable — you can lift it out cleanly and carry it across | Large or diffuse — the valuable knowledge is spread through the whole app and cannot be lifted |
+| **How big is the total surface area?** | Small — few pages, routes and screens; rewriting is a known quantity | Large — many routes, migrations, integrations; a rewrite is an open-ended bet |
+| **Do tests or CI exist to protect a refactor?** | Irrelevant — you are replacing the code, not refactoring it | Helps a lot — a suite that catches regressions makes fixing in place safe and cheap |
+
+Read it whole, not as a score. **Rebuild needs the gate to be clear *and* the first row to say "No".** If the architecture can host what's needed, fix in place regardless of how ugly the code is — ugly is not the same as wrong-shaped.
+
+Worked both ways from the real case: a static-HTML app with no backend in the repo, no accounts, records in one browser, no live customers yet, ~8,800 lines total and only ~470 lines of irreplaceable domain logic → **rebuild** (and port those 470 lines deliberately). A Next.js app with real authentication, 133 migrations, ~142 authorization policies and hundreds of routes, with serious security problems → **fix in place, never rebuild**, because every one of those problems is fixable where it stands.
+
+Deliver: the recommendation, **the answer to the gate**, the two or three signals that decided it, the honest cost of following it, and on a rebuild **which parts get ported rather than rewritten** plus the parallel-running and rollback plan if the app is live. Also name the highest-value work that is worth doing *either way* — in the real case, backing up the backend that was not in version control and writing the first test suite, neither of which needed the rebuild.
+
+## 10. Hand off to the map
+Call **`cs-build-import-codebase`**, passing the findings, the verdict, and **which rung of the ladder the existing map landed on** (§0a). It builds the **corrected target map** — what the app *should* look like — on either verdict, and it keeps or repairs an existing map rather than duplicating it. Do not build the map here; one code path builds maps.
+
+## 11. Create the Kanban tasks
+Task writing happens **inside `cs-build-import-codebase` §7**, because that is where the feature ids exist — don't re-implement it here. Your job is to hand it a clean input and check the result.
+
+Hand over, per finding: the **bucket-1 findings only**, each with its severity (Critical → `urgent`, High → `high`, Medium → `medium`, Low → `low`), its evidence label, its file reference, and which core feature it belongs to. Bucket 2 and bucket 3 stay in the write-up and **must not appear in the task list**.
+
+Then confirm the shape is right for the verdict:
+- **Rebuild** → build-to-spec tasks **plus a distinct set of "mistakes to avoid" tasks** carrying forward the specific defects found, so they are not reintroduced. That second set is the whole reason for auditing first — if it is missing, the handoff failed.
+- **Fix in place** → one task per defect, where it lives, **with the file reference in the description** (the user-facing text has none; the task needs it because an agent has to act on it).
+
+An **UNVERIFIED** finding becomes an investigation task that keeps its label — never a confident fix task.
+
+## 12. Verify, then report
+**Run the check, don't eyeball it** (`auditing-and-fixing.md` §9):
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-verify
+node ../codespring/scripts/check-map.mjs   /tmp/cs-verify --expect-core <the count you intended>
+```
+
+It asserts the core-feature count, no flattened sub-features, no duplicate features or PRDs, one note per core feature, and every task linked to a feature with a severity. A non-zero exit is a real failure — fix it before reporting. Then report the diff plainly — created N, updated N, skipped N — and give the project link `https://v2.codespring.app/project/<projectId>`.
+
+## What good looks like
+- The app was actually run, and at least one finding exists that reading the code could not have produced.
+- Every finding cites a `file:line` or a command and is labelled CONFIRMED / INFERRED / UNVERIFIED; the headline numbers were independently reproduced.
+- **Your own headline claims were listed with their evidence before you wrote them**, every measurement states its scope, and no claim is stronger than what a sub-agent actually found.
+- The clone was compared to the remote **before** auditing, the commit the findings are based on is named, and the user was asked who else is in the repo and whether the app is finished.
+- The git/CI/deploy setup was audited, and the user knows whether their backend is backed up and whether anything gates their deploys.
+- The user-facing findings are plain, ranked by what they cost, contain no file paths, and say what is good as clearly as what is broken — including what a "better than the competitor" feature still does not do.
+- Problems, could-add-later and not-worth-adding are separated; the task list contains only problems, and the future ideas are in the two named `FINDINGS.md` sections.
+- The users gate was asked and answered, a verdict was given with its reasons, and "fix in place" was the answer unless the app has no users *and* the architecture genuinely couldn't host what's needed.
+- Nothing in CodeSpring was duplicated — an existing map was kept, or repaired in place, and a second project was only ever created with explicit confirmation.

--- a/.claude/skills/cs-build-audit-codebase/references/plain-english-writeup.md
+++ b/.claude/skills/cs-build-audit-codebase/references/plain-english-writeup.md
@@ -1,0 +1,117 @@
+# The plain-English write-up — structure, voice, and the quality bar
+
+An audit produces two different documents. Do not mix them up.
+
+| | Internal notes | `FINDINGS.md` (the deliverable) |
+|---|---|---|
+| Audience | you, and the agents that will do the work | the app's owner — often not a developer |
+| Language | technical | plain English, roughly third-grade reading level |
+| References | `file:line`, commands, evidence labels | **none** — no file paths, no line numbers, no function names |
+| Ordering | by domain | by real-world consequence |
+| Lives | scratchpad | committed into the audited repo as `FINDINGS.md` |
+
+The internal notes feed the tasks. `FINDINGS.md` is what the owner reads and decides with.
+
+**Every named specific below is a labelled worked example** from the audit this structure was generalised from — a rate table, a report, a suburb figure. They are there to show the *shape* of a good sentence. Nothing here assumes anything about the codebase in front of you, which may be in any language and any domain.
+
+---
+
+## Voice rules for `FINDINGS.md`
+
+1. **Third-grade reading level.** Short sentences. Common words. If a nine-year-old couldn't follow the sentence structure, rewrite it. (The *subject* can be advanced — the *language* cannot.)
+2. **Short bullets.** One idea per bullet. No paragraph longer than three lines.
+3. **One concrete example per problem.** Not "validation is missing" — "typing a full stop instead of a comma turns 800,000 into $800."
+4. **Name the consequence, not the mechanism.** The owner needs to know what it costs them, not where the bug is. Say "the report shows $0 in government charges while still claiming it used official rates", not "the lookup is case-sensitive with no default branch".
+5. **Put a number on it wherever you honestly can** — dollars, a count, a percentage. Numbers are what make an owner act. If you can't size it, say what it damages instead (client trust, a legal obligation, a sale). **State what the number covers in the same sentence** — "45 bytes across 3 keys" measured on one page is not a fact about the whole app (`auditing-and-fixing.md` §3a).
+6. **No file paths, no line numbers, no function or variable names, no jargon.** Hard rule: **every finding must be readable by someone who does not know what a database migration is.** Any term of art is either explained in the same sentence it appears in, or not used.
+
+   This has already failed once in practice. *"Versioned rate tables stamped onto the saved file"* meant nothing to the person it was written for. The plain version says the same thing and is **more** specific:
+
+   > *"When you save a report, also save which year's tax rates it used — so that fixing a rate later doesn't change what a client was already shown."*
+
+   Notice the shape: the action, the thing, then **the consequence of not doing it**. The consequence is what persuades. Run the same test over *idempotent, RLS, IDOR, migration, ORM, schema drift, silent failure path, denormalised* — explain inline or find the plain sentence.
+7. **Rank by consequence, hardest-hitting first** — inside every section and across the whole document. The reader should be able to stop after section 2 and still have the important part.
+8. **Say what is good — with its boundary.** A write-up that only lists faults is neither trustworthy nor useful. Where something is genuinely well done — a verified data set, a correct security check, a decision better than the competitor's — say so in the same plain voice, and mark it as something not to break.
+
+   **When you claim the app does something better, say what it does NOT do in the same breath.** This has already failed once. *Worked example: the app was called "ahead" of the incumbent product on one calculation when it had in fact solved only the easy half of it — the single-record case, not the case of combining records across a portfolio, which was the exact part the incumbent had said was too hard.* The owner will repeat "we're ahead on this" to a customer, so the boundary has to travel with the claim.
+9. **Be explicit about what you did not verify.** Give it a closing section. It protects the owner and it protects you.
+10. **Distinguish "wrong today" from "wrong later".** *"This is wrong today, not wrong next year"* is the most action-forcing sentence available — use it only when it is true.
+
+---
+
+## Structure
+
+Open with a two-line header: what this document is, what it is based on, and the dates. **Name the commit** — findings are a snapshot, and on a repo someone else is still working in that matters.
+
+> Plain-English record of what the app gets wrong, what it can't do, and what needs to change.
+> No code. Real-world implications only.
+> Reviewed *dates*, against commit *short SHA* on *branch*. Based on the live app, the code, the database, and *any other sources*.
+
+Then the sections below. Drop any that don't apply — do not pad.
+
+**1. The most important thing to understand.**
+One structural truth that reframes everything else, then a short "that means:" list. This is the section that changes the owner's mind. In the real audit it was: almost nothing comes from a database — every figure is calculated in the browser from typed-in values, and the rate tables are typed into the web page itself.
+
+**2. Where it's wrong — in order of how much it matters.**
+The core of the document. One `###` sub-heading per defect, written as a plain statement of the problem *with its size in it* ("Capital gains tax is understated by about $337,000"). Two to five bullets under each: what it does, when it happens, what it costs. Hardest-hitting first.
+
+**3. Numbers that look precise but are actually fixed assumptions.**
+Anything the app presents as a computed fact that is really a choice someone made. Open with the framing sentence: *these are not calculated from anything; someone chose them, and the user cannot see or change them.* One bullet each, with the value and its effect.
+
+**4. Data that isn't really data.**
+Anything typed in by hand, stale, defaulted to zero on failure, or asserted without verification. Say plainly what a missing value and a failure look like to the user (identical, usually). If an integration is expected to fix this, **set the expectation honestly** — in the real case, connecting the data provider would stop the typing but would not change a single calculated figure, and saying so up front prevented a wasted project.
+
+**5. Why it behaves inconsistently.**
+The "why do some outputs look different from others" section. Users notice inconsistency before they notice errors, and the answer is often "nothing is broken, the setting is just invisible". Worth its own section because it converts a suspicion into a fact.
+
+**6. Where the work actually lives.**
+Storage, durability, sharing. What survives a refresh, a new browser, a new machine, two colleagues. What is lost permanently, with no backup, and with no warning that it was ever a risk.
+
+**7. Compared to what it's replacing.** *(only if there is an incumbent or named competitor)*
+Three lists, in this order: **where this app is already better** (put it first — it is true, and it earns the rest of the document a fair hearing), **what the other product has that this one doesn't**, and **differences worth deciding deliberately** rather than calling bugs.
+
+**8. What it cannot do at all.**
+Not bugs — gaps. The things a customer or a competitor will raise. Rank by how likely they are to come up in a real conversation.
+
+**8a. Could add later — deliberately not doing now.** *(bucket 2, `auditing-and-fixing.md` §4a)*
+Real gaps that are consciously parked. Title the section in those words so it is unmistakable, and say the posture out loud once: *the job right now is making what already works work properly, not adding to it.* One line each, with the reason it is parked and whether it is worth doing later. Nothing in this section becomes a task.
+
+**8b. Not worth adding.** *(bucket 3)*
+One line each, **with the reason**, so the question stops coming up. A "not worth it" without a why gets asked again next month. Real example: *don't build an integration to fetch tax rates automatically — no free authoritative feed exists, and scraping eight government websites would be more fragile than a maintained table plus a yearly review.*
+
+> **These two sections are the only home a future idea has.** CodeSpring has features, notes, PRDs and Kanban tasks and no "ideas" surface, and a parked idea must never be written as a task because **a task list implies committed work**. So they live here, in the repo, titled exactly as above. Flag it to the user as a known product gap.
+
+**9. What needs to change — the principle, not the code.**
+The fix direction, as principles a non-developer can hold in their head and check work against. `###` per principle. In the real audit: reference data moves out of the app and into dated records; reading it must not happen on every output; there must be a visible staleness check; a published document must be frozen; there is no free API for this so it is a maintained table plus an annual review; assumptions should become fields.
+
+**10. Not yet verified.**
+Everything you could not confirm, and what would confirm it. Short. Honest.
+
+---
+
+## Where the verdict goes
+
+The rebuild-or-fix verdict does **not** go in `FINDINGS.md` — that document is about the app, not about the plan. Deliver the verdict in the conversation, and if the user wants it written down, as a separate plan document. Keeping them apart means the owner can circulate the write-up without circulating a recommendation they haven't agreed to yet.
+
+Spoken, the verdict is four things: the recommendation, the two or three signals that decided it (from the decision table in `auditing-and-fixing.md`), the honest cost of following it, and — on a rebuild — exactly which parts get carried across rather than rewritten.
+
+---
+
+## Writing it out
+
+- `FINDINGS.md` at the audited repo's root is the **one** file this skill may add to the target repo. Say so before you write it, and ask.
+- **Never commit it.** Leave it as an untracked change for the user to review.
+- If it already exists, read it first and **update in place**: keep any section the user has edited, fold in what's new, add the new review date to the header. Never silently discard their words.
+- Keep it a single file. A pack the owner has to navigate is a pack the owner won't read.
+
+## The quality bar
+
+Measured against the audit this structure was generalised from, a `FINDINGS.md` is good when:
+
+- **Every problem is sized** — in money where money applies, otherwise in a count, a percentage, or the specific trust it costs.
+- **The good parts are stated as clearly as the faults**, each with the boundary of what it does *not* do.
+- **Expectations are set honestly** where the owner is about to spend money on the wrong fix. In the real case, one paragraph explaining that connecting a paid data provider would stop the manual typing but would not change a single calculated figure prevented a wasted project. That paragraph was worth more than any single defect.
+- **There is not one file path, line number or function name in the whole document** — and no term of art that isn't explained where it appears.
+- **A non-technical owner can read it top to bottom and act on it**, and can circulate it without a translation layer.
+
+Test it before you hand it over: read the first three sections as if you had never seen the code. If any sentence needs you to know what a database migration is, rewrite it.

--- a/.claude/skills/cs-build-audit-codebase/references/specialist-briefs.md
+++ b/.claude/skills/cs-build-audit-codebase/references/specialist-briefs.md
@@ -1,0 +1,106 @@
+# Specialist Sub-Agent Briefs
+
+Copy-ready briefs for the parallel audit fan-out. Every brief is **self-contained** — the sub-agent gets the target path, the rules, and its own domain, and nothing from the other agents. Independence is the point: two agents reaching the same conclusion by different routes is the strongest evidence you can get, and that only works if they never saw each other's output.
+
+## The shared preamble — prepend to EVERY brief
+
+> **Target:** `<absolute repo path>` · **Live app:** `<url the orchestrator started, or "not running">`
+> **Stack (already established, do not re-derive):** `<one paragraph — languages, frameworks, build, hosting, backend, database>`
+> **Scratchpad for your output:** `<absolute path>/findings-<domain>.md`
+>
+> **Rules:**
+> - **READ-ONLY on the repo.** Do not create, edit, move or delete any file under the target path. Write only to your scratchpad file.
+> - Cite everything. Every finding carries a `file:line` reference **or** the exact command you ran and its output.
+> - Label every finding **CONFIRMED** (you executed it or read the exact line — say which), **INFERRED** (deduced from code you read but did not run — state the inference), or **UNVERIFIED** (suspected, not checked — state what would check it). A finding with no label is not a finding.
+> - **Report honestly.** If you cannot verify something, say so. Never present a guess as fact. Do not inflate severity to seem useful, and do not soften a real problem.
+> - **Report the positives too.** "No privileged key was ever committed", "the input sanitiser is genuinely correct", "these controls are all correctly wired" are high-value findings. Include a "what works well — don't break it" section.
+> - Rank findings **Critical → High → Medium → Low** by real-world consequence (money, legal/regulatory exposure, or loss of customer trust), not by how interesting the bug is.
+> - Structure: executive summary (5–8 bullets, the headline first) → evidence tables → numbered findings → what works well.
+> - Live probing of the user's own running app and own services is authorised where stated in your brief, and must be **non-destructive**: no deletes, no updates, no bulk data extraction. If you must prove write access, one clearly-labelled test row, and report exactly what you inserted and where.
+
+## 1. Security / auth / trust boundary
+
+> Audit the trust boundary between whatever ships to the user and whatever runs on a server.
+> 1. **Enumerate the API surface** — every endpoint/action/route the client can call: what it sends, what it returns, what the server checks. One row per call.
+> 2. **Test authentication for real.** Strip the credential and call anyway. Does it 401 at the gateway, or does it run? Is identity a verified session/token, or an opaque identifier the client supplies?
+> 3. **Test authorization per action** — separately for reads and writes. Can a caller act on a record they do not own? Does a write with a bogus identifier return success? Does the server scope results, or does the client filter after receiving everything?
+> 4. **Secrets** — what is embedded in shipped code, and what does it actually grant? Scan history for privileged keys. State the negative result explicitly if there is one.
+> 5. **Row-level / database-level protection** — is it on and effective? Prove it (a table with data that reads empty through the public path proves the policy works; an empty result alone proves nothing).
+> 6. **Third-party code** — scripts loaded from a CDN, pinned versions, integrity hashes, what those pages have access to.
+> 7. **Response headers**, error verbosity (do errors leak internal names?), rate limiting, payment/entitlement paths.
+> 8. For each finding: what an attacker gets, what it would take, and the fix.
+
+## 2. Database / schema / data layer
+
+> Audit how data is stored and reached.
+> 1. **Trace the full data path** from user action to storage. Name every hop.
+> 2. **Inventory the schema** — every table/collection/store, key columns, enums, relationships. Mark each **CONFIRMED (named in code)**, **CONFIRMED (observed live)** or **INFERRED**.
+> 3. **Ownership** — which tables does *this* app own, which are shared with another system, which are read-only for it. A shared naming prefix does not prove shared ownership; check the actual call sites both ways.
+> 4. **Schema management** — are there migrations? In version control? Can the schema be rebuilt from the repo? Is there a local/staging database, or does every change hit production?
+> 5. **Is the server-side source in the repo at all?** If the backend lives only in a hosting dashboard, that is a critical finding — say what would be lost and give the exact commands to back it up.
+> 6. **Orphans and unknowns** — what is unused, and what you *cannot* determine from where you sit (say so, and give the query that would answer it).
+> 7. **Typing** — does the client guess field names? Fallback chains for a single field are a symptom; count them.
+> 8. Output a concrete capture-and-migrate sequence the user can run.
+
+## 3. Core business logic
+
+> Audit the part of this app that produces its actual output — the calculation, the pipeline, the ranking, the decision, whatever the product is *for*. This is usually where the money is.
+> 1. **Establish ground truth by executing the real code**, not by reading it. Extract the logic into a scratch harness and run it, or drive it in the live app. Prove your harness is faithful (identical source, only the environment stubbed) and say how. Where two independent methods agree, state that.
+> 2. **Verify the outputs against authoritative external sources** where the domain has any — published rates, specifications, official documentation. Report which ones you checked and which you could not.
+> 3. **Walk one complete output end to end**, showing every intermediate figure, so a human can check it by hand.
+> 4. **Edge and degenerate inputs**: empty, zero, negative, absurdly large, wrong case, wrong type, wrong format, whitespace. For each: correct result, wrong result, exception, or **silent wrong result** — the last is the worst and the most important to find.
+> 5. **Hunt hardcoded reference data** — anything with an expiry date typed as a literal. Table it: what, where, duplicated where, what happens when it goes stale, and whether the output *claims* to be current.
+> 6. **Hunt drift** — is this logic duplicated? Do the copies agree *today*? Did they ever disagree (check history)? Which copy does the main entry point actually load?
+> 7. **Separate genuine errors from undisclosed assumptions.** A number that is a guess presented as precise is a finding even when the arithmetic is perfect.
+> 8. **Size every error in the units the user cares about** — dollars, percentage points, hours.
+
+## 4. Frontend / UX / dead controls
+
+> Audit what the user actually experiences. Test live where possible, not just statically.
+> 1. **Dead controls** — every interactive element: is it wired, does its handler exist, does it do anything? Report the negative loudly if wiring is good ("not one inert button in 194 controls" is a real finding).
+> 2. **Orphan pages/screens** — reachable by URL, linked from nowhere. And the reverse: dead ends with no way out.
+> 3. **Validation** — count required fields, bounds, patterns. Test what a wrong format does (a decimal separator read as a thousands separator silently divides by a thousand). Are negatives and absurd values accepted and printed confidently?
+> 4. **Persistence** — which screens save work and which lose it on refresh? Is there an unsaved-changes guard? Does anything reload placeholder/demo content over real work?
+> 5. **Failure and empty states** — what does the user see when a request fails? Is a failure distinguishable from an empty result? Does anything **fabricate plausible content** on failure? Does anything report success without checking?
+> 6. **Destructive actions** without confirm or undo.
+> 7. **Accessibility** — accessible names on controls, label association, live regions for content that updates, keyboard reachability, focus visibility, colour contrast (compute it, per theme).
+> 8. **Mobile and print** — the output the customer is actually handed. Check the printed/exported artefact specifically; it is often styled differently from the screen.
+
+## 5. Architecture / quality / scalability
+
+> Audit structure, maintainability and limits. Be balanced — say plainly where the current design is a *reasonable* choice for the app's size, and do not recommend a rewrite by reflex.
+> 1. **Measure it**: total lines, files, largest file, dependency count, build step, test count.
+> 2. **Duplication register** — one row per duplicated thing: what, how many copies, where, drifted (today? historically? check history), which copy is authoritative, which copy is actually loaded.
+> 3. **Test / lint / CI** — what exists. If nothing, say what the cheapest suite that would have caught the worst bug you found looks like.
+> 4. **Delivery** — branch structure, review practice, whether deploy is gated on any automated check, whether the local clone is current with the remote, staging vs production, environment-variable mechanism.
+> 5. **Error handling and observability** — count swallowed errors, count log/report calls, is there any global handler. If it breaks in production, does anyone find out?
+> 6. **Measured performance limits** — payload size, largest assets versus their rendered size, work per interaction, caching, anything unbounded (a list with no pagination, a loop that never stops).
+> 7. **Supply chain** — external origins, third-party scripts, integrity, privacy implications.
+> 8. **A recommended path forward in three buckets:** this week / this month / **explicitly not doing** — and justify the "not doing" list.
+
+## 6. Repository & delivery setup (do this yourself, it is fast)
+
+Not a sub-agent brief — the orchestrator runs these directly, **before** the fan-out, because the answers caveat everything else.
+
+```bash
+git -C <repo> rev-parse --abbrev-ref HEAD          # current branch
+git -C <repo> rev-parse HEAD                       # local head
+git -C <repo> ls-remote --heads origin             # remote heads → is the clone behind?
+git -C <repo> log --oneline -30                    # commit quality, intent-revealing messages?
+git -C <repo> branch -a                            # branch structure, stale branches
+ls -a <repo>/.github/workflows 2>/dev/null         # any CI at all?
+cat <repo>/.gitignore                              # is it adequate before anyone commits secrets?
+git -C <repo> log -p -S 'BEGIN PRIVATE KEY' --oneline | head
+git -C <repo> log -p -S 'service_role' --oneline | head     # adapt markers to the stack
+gh pr list --state all --limit 30                  # review practice (if gh is available)
+```
+
+Answer, in the report: is the clone current with the remote (if not, **caveat the whole audit**); is the server-side source in the repo; is deploy gated on any check or does merge ship to production; were secrets ever committed; is there a staging environment.
+
+## Fan-out mechanics
+
+- Launch all specialists **in one message, concurrently**. They are independent.
+- Give each one only its own brief plus the shared preamble. No cross-talk.
+- While they run, do the live pass yourself (§Run the app in `auditing-and-fixing.md`) — you are the sixth agent and the one who resolves disagreements.
+- Add domains the app warrants: a competitor/incumbent comparison (invaluable when the app replaces a known product), a user-journey-and-failure map, a data-provenance pass ("which figures are real, which are typed in, which are assumptions"). Give each the same preamble.
+- When they return: reconcile contradictions, independently reproduce the headline claims, and only then write the report. A later, better-informed pass beats an earlier one — record the correction rather than shipping both.

--- a/.claude/skills/cs-build-audit-codebase/scripts/check-repo.sh
+++ b/.claude/skills/cs-build-audit-codebase/scripts/check-repo.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# check-repo.sh — is this clone the code you think you are auditing?
+#
+# Run this FIRST, before the fan-out. Every answer below caveats every finding.
+# Read-only: `git fetch` updates remote-tracking refs only — it does not touch the
+# working tree, any branch, or any file. Nothing here writes to the repo.
+#
+# Usage:
+#   bash check-repo.sh [--repo /path/to/repo] [--paths file1 file2 ...]
+#
+#   --paths  files or directories you suspect are out of scope. For each one it
+#            prints first commit, last commit and commit count, so "unreferenced"
+#            can be told apart from "unfinished" (see the rule in
+#            codespring/references/auditing-and-fixing.md §3a).
+#
+# Exit codes: 0 = clone is current · 2 = clone is behind the remote · 1 = not a git repo
+
+set -u
+
+REPO="$PWD"
+PATHS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) REPO="${2:-}"; shift 2 ;;
+    --paths) shift; while [ $# -gt 0 ] && [ "${1#--}" = "$1" ]; do PATHS+=("$1"); shift; done ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  echo "NOT A GIT REPO: $REPO"
+  echo "There is no version history at all. Say so plainly — it is a finding in its own right:"
+  echo "  nothing can be rolled back, and no change can be traced to a reason."
+  exit 1
+}
+
+BRANCH="$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+HEAD_FULL="$(git -C "$REPO" rev-parse HEAD)"
+HEAD_SHORT="$(git -C "$REPO" rev-parse --short HEAD)"
+
+echo "=== The commit these findings apply to (record this in FINDINGS.md) ==="
+echo "branch: $BRANCH"
+echo "commit: $HEAD_SHORT ($HEAD_FULL)"
+git -C "$REPO" log -1 --format='date:   %ad%nauthor: %an%nsubject:%s' --date=iso
+
+echo
+echo "=== Is this clone current with the remote? ==="
+if git -C "$REPO" remote | grep -q .; then
+  git -C "$REPO" fetch --all --quiet 2>/dev/null || echo "(fetch failed — no network, or no access to the remote)"
+  UPSTREAM="$(git -C "$REPO" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+  if [ -n "${UPSTREAM:-}" ]; then
+    COUNTS="$(git -C "$REPO" rev-list --left-right --count "HEAD...$UPSTREAM" 2>/dev/null || echo "0	0")"
+    AHEAD="$(printf '%s' "$COUNTS" | cut -f1)"
+    BEHIND="$(printf '%s' "$COUNTS" | cut -f2)"
+    echo "upstream: $UPSTREAM — $AHEAD ahead, $BEHIND behind"
+    if [ "${BEHIND:-0}" -gt 0 ]; then
+      echo
+      echo "*** BEHIND BY $BEHIND COMMIT(S). Tell the owner in one line and offer to update BEFORE auditing."
+      echo "*** Auditing a stale clone produces findings that may already be fixed."
+      echo "Commits you do not have yet, and the files they touch:"
+      git -C "$REPO" log --oneline --name-only "HEAD..$UPSTREAM" | head -60
+    else
+      echo "up to date with $UPSTREAM"
+    fi
+  else
+    echo "no upstream set for $BRANCH — cannot tell whether it is behind. Compare against origin's default branch by hand."
+  fi
+else
+  echo "no remote configured — this code exists only on this machine. That is a finding: there is no off-machine copy."
+fi
+
+echo
+echo "=== What else is in flight? (do not write findings against superseded work) ==="
+echo "remote branches:"
+git -C "$REPO" for-each-ref --sort=-committerdate --format='  %(refname:short)  %(committerdate:short)  %(authorname)  %(contents:subject)' refs/remotes 2>/dev/null | head -30
+echo "recent authors (last 50 commits):"
+git -C "$REPO" log -50 --format='%an' | sort | uniq -c | sort -rn
+echo
+echo "Ask the owner: is anyone else working in this repo right now?"
+echo "If yes: the findings are a snapshot at $HEAD_SHORT, recommend a dedicated branch for the fixes,"
+echo "and say plainly that merge conflicts will need managing. Do not lecture them about git."
+
+echo
+echo "=== Working tree ==="
+if [ -n "$(git -C "$REPO" status --porcelain)" ]; then
+  echo "DIRTY — uncommitted work is present, so the audited state is not any commit:"
+  git -C "$REPO" status --short | head -20
+else
+  echo "clean"
+fi
+
+echo
+echo "=== Delivery: is anything gated? ==="
+if [ -d "$REPO/.github/workflows" ]; then
+  ls -1 "$REPO/.github/workflows"
+else
+  echo "no .github/workflows — no automated check, so merging ships straight to production unless the host gates it"
+fi
+
+if [ "${#PATHS[@]}" -gt 0 ]; then
+  echo
+  echo "=== Suspected out-of-scope paths: unreferenced, or just unfinished? ==="
+  echo "A file untouched since the initial import while its siblings change weekly is"
+  echo "a strong signal of \"not finished yet\", NOT \"not part of this product\"."
+  echo "Repo activity window, for comparison:"
+  git -C "$REPO" log -1 --format='  newest commit: %ad' --date=short
+  git -C "$REPO" log --reverse -1 --format='  oldest commit: %ad' --date=short
+  for p in "${PATHS[@]}"; do
+    echo
+    echo "--- $p"
+    COUNT="$(git -C "$REPO" log --oneline -- "$p" | wc -l | tr -d ' ')"
+    echo "  commits touching it: $COUNT"
+    git -C "$REPO" log -1 --format='  last:  %ad  %s' --date=short -- "$p"
+    git -C "$REPO" log --reverse --format='  first: %ad  %s' --date=short -- "$p" | head -1
+  done
+  echo
+  echo "Then ASK THE OWNER before concluding anything is out of scope."
+fi
+
+if [ -n "${BEHIND:-}" ] && [ "${BEHIND:-0}" -gt 0 ]; then exit 2; fi
+exit 0

--- a/.claude/skills/cs-build-create-prd/SKILL.md
+++ b/.claude/skills/cs-build-create-prd/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: cs-build-create-prd
+description: >
+  Specialist for creating CodeSpring PRDs. Interactive — it lists the user's
+  core features, asks which one and whether to generate a Frontend, Backend, or
+  Both PRD, then deep-dives the real code and generates the PRD(s) and attaches
+  them to the feature's bridge on the canvas. The PRDs capture the shared
+  backend contracts and design system so new features are built without
+  duplicating or breaking what exists. Use when the user wants a PRD / spec for
+  a feature. Triggers, "create a PRD", "make a frontend PRD", "make a backend
+  PRD", "generate PRDs for this feature", "document this feature in CodeSpring",
+  "spec out X so I can design new features".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(node:*) Bash(curl:*)
+metadata:
+  author: codespring
+  version: "0.2"
+---
+
+# Create a PRD in CodeSpring
+
+A PRD gives CodeSpring a full, accurate understanding of a feature so new features build on what exists instead of duplicating backend, re-creating a shared API route, or reinventing the design system. This skill makes the **Frontend** and/or **Backend** PRD for a chosen feature, grounded in the real code.
+
+This is the single source of truth for how PRDs get made — other skills (e.g. `cs-build-import-codebase`) call this rather than re-implementing it.
+
+Shared knowledge is in the `codespring` skill's references: `references/analyze-codebase.md`, `references/mindmap-structure.md`, `references/prd-management.md`, `references/pitfalls.md`, `references/codespring-docs.md`.
+
+## 0. Connect first
+`codespring auth status` (login if needed) + `codespring status`. Use the projectId from the **local** `.codespring/config.json`; print it. If the codebase isn't in CodeSpring yet, run `cs-build-import-codebase` first. This skill READS code and WRITES only to CodeSpring — never modify the codebase.
+
+## 1. Ask what to generate (interactive)
+Show the user their **core features** (from `codespring features` / the mindmap `node-features` items), then ask:
+1. **Which feature?** (one, several, or all)
+2. **Frontend, Backend, or Both?**
+Wait for their choice unless they already said.
+
+## 2. Deep-dive the real code
+Read the actual code for the feature (don't guess). Pull in the depth from `analyze-codebase.md` §8–9. Cover:
+
+### Backend PRD — capture the shared contracts (this is the riskiest part when adding new features)
+- **Architecture & structure** — how the feature's code is organized and the conventions it follows.
+- **Routers / API routes / endpoints** — path, method, request/response, and **flag every route shared by more than one feature**.
+- **Data model** — tables + enums, key columns, relationships; reads vs writes.
+- **Reusable server code** — actions/services/queries/hooks that already exist and should be reused, not re-implemented.
+- **Shared backend systems** — call these out explicitly because new features collide with them:
+  - hosting / deploy target (AWS, Vercel, Fly, etc.) and any platform limits
+  - crediting / usage-metering systems; payment, subscription, and **refund** systems
+  - background **jobs / pipelines / queues / cron**; long-running or async generation jobs
+  - storage: **S3 conventions / buckets**, file paths, signed-URL patterns
+  - media/render pipelines (e.g. Remotion/video compositions) if present
+  - databases, migrations
+  - **auth and row-level security (RLS)**
+  - **environment variable names** that must be used or can be reused
+  - webhooks (and signature verification)
+- **Security** — authz, ownership checks, validation, secrets, RLS, webhook signing.
+- **Reuse & dependency map** — a "reuse this, don't rebuild it" list, PLUS **what depends on this** so a future change doesn't silently break other features.
+
+### Frontend PRD — capture the design system AND the navigation
+- **Design tokens** — colors/branding, corner radius, spacing scale, typography, shadows (from Tailwind config / CSS vars / theme).
+- **Component & UI styles** — the UI library and how buttons/cards/inputs/modals are styled, incl. states.
+- **Layout, positioning & spacing** — grid/flex, columns, breakpoints, gaps; where things sit relative to each other. Be concrete.
+- **What the user sees** — header, sections, cards, tables, empty/loading states, toasts.
+- **Navigation / interaction map** — the concrete path: which nav item/button opens it → route → what it shows → what each interaction does; plus links FROM/TO other features.
+
+### Write it into the feature's note first (it is the generator's context)
+```bash
+codespring mindmap note <coreFeatureId> --title "How it works — <Feature>" --text "$(cat note.txt)"   # redirect output to /dev/null
+```
+
+## 3. Generate (see prd-management.md)
+```
+POST /prds/generate  { projectId, bridgeNodeId: "bridge-feature-<featureId>", prdType: "frontend" | "backend" }
+```
+Timeout ≥120s (a client abort still creates the record → duplicates). For "Both", make two calls. After generation, read the PRD back (`codespring prd <id>`) and confirm the shared-systems detail above actually landed; if thin, enrich the note and regenerate, or `prd sync` a better version.
+
+## 4. Attach to the canvas (see mindmap-structure.md)
+Add `prdBridge → prdFrontend/prdBackend` nodes and `PUT /mindmaps/project/<projectId>`. For a **core** feature `prdBridge.data.featureId = "node-features"`; for a **sub-feature** it's that feature's sub-feature group node id. `itemId` = the selected feature id. If a `prdBridge` already exists for the feature, add the PRD node to it instead of creating a second bridge.
+
+> The user can also generate PRDs in the CodeSpring web app (right-click the feature's PRD bridge → add + generate). If they'd rather do that, point them at `references/codespring-docs.md`.
+
+## 5. Dedupe if needed + verify
+Duplicates from timeouts → checkpoint then delete extras (`prd-management.md`). Verify (`pitfalls.md`): PRD content is real and includes the shared-systems detail; the canvas shows the `prdBridge` + PRD node(s) with valid `prdId`; and `node-features` still has the right core-feature count (re-parent any flattened sub-features). Give the user their project link.
+
+## What good looks like
+- The Backend PRD reads like a contract for the shared systems: routes (with the shared ones flagged), data model, auth/RLS, jobs/cron, storage/buckets, payments/credits/refunds, env vars, and a clear "reuse this / don't break this" dependency map.
+- The Frontend PRD captures the design system and the concrete navigation path.
+- Both are attached to the feature's bridge and grounded in the real code.

--- a/.claude/skills/cs-build-create-tasks/SKILL.md
+++ b/.claude/skills/cs-build-create-tasks/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: cs-build-create-tasks
+description: >
+  Turn a CodeSpring feature's notes + PRDs into a numbered, prioritized Kanban
+  task list linked to that feature. Reads the feature, its sub-features, its
+  PRDs, and any features that link to it, then writes ordered tasks that are
+  safe to build in parallel — each with what/why/what-it-touches/what-not-to-
+  touch/dependencies. Use when the user has a feature planned and wants a build
+  plan. Triggers, "create tasks", "make a task list", "break this feature into
+  tasks", "generate a build plan", "turn my PRD into tasks", "what do I build
+  first".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*)
+metadata:
+  author: codespring
+  version: "0.2"
+---
+
+# Create a task list for a feature
+
+Turn a feature's plan into a numbered Kanban task list that an agent (or a fleet of sub-agents) can build safely. See the `codespring` skill's `references/task-workflow.md`, `references/prd-management.md`, `references/pitfalls.md`.
+
+This skill READS the CodeSpring plan and WRITES tasks. It does not modify the codebase.
+
+## 0. Connect first
+`codespring auth status` + `codespring status` (use the LOCAL project config; print the projectId).
+
+## 1. Pick the feature
+```bash
+codespring features        # core features are the root features
+```
+Ask the user which feature to create tasks for.
+
+## 2. Load the FULL context for that feature
+Before writing any task, gather everything CodeSpring knows so the tasks are safe:
+- The feature's **note** (how it works) and its **Frontend + Backend PRDs** (`codespring prds`, then `codespring prd <id>`).
+- Its **sub-features** (`codespring features --parent <featureId>`).
+- **Other features that link to it** — read the whole mindmap and the notes/PRDs of features referenced by this one (and that reference it). The Backend PRD's shared-systems + dependency map is the key input.
+- If PRDs are missing, stop and tell the user to generate them first (run `cs-build-create-prd`, or generate in the web app — see `references/codespring-docs.md`). Do not invent tasks without the PRDs.
+
+## 3. Work out the numbering
+CodeSpring tasks are numbered like `X.Y.Z` (e.g. `0.1.0`, `0.1.1`). Continue the existing sequence — do not restart at 0:
+```bash
+codespring tasks --json    # or: codespring tasks --status todo / in_progress / on_hold / done
+```
+Scan tasks in ALL states (todo, in_progress, on_hold, done) for this feature, find the **highest number already used**, and start the new tasks at the next increment (e.g. existing max `0.1.2` → new tasks `0.1.3`, `0.1.4`, …). Put the number at the start of each task title.
+
+## 4. Break the work into tasks (ordered + parallelizable)
+Derive tasks from the PRDs. A task = one deliverable a person/agent can finish and verify (not a whole feature). Rules:
+- **Foundations first:** data model / migrations → shared backend/services → API routes → UI that consumes them.
+- **Parallel-safe:** group tasks so independent ones can run at the same time by different sub-agents; sequence only true dependencies. Note which tasks can run concurrently.
+- **Flag shared systems:** any task touching a shared API route, shared table, credits/payments/jobs/storage/auth from the Backend PRD must say so.
+
+For EACH task write a detailed description containing:
+- **What** it builds and **why**.
+- **What it may touch** (files/routes/tables).
+- **What it must NOT touch** (out of scope; protected shared systems).
+- **What already exists to reuse** (from the PRD reuse map) so it isn't rebuilt.
+- **Dependencies / break-risk:** what else depends on the code it changes, so it doesn't silently break another feature.
+
+## 5. Create the tasks — always linked to the feature
+```bash
+codespring task create --title "0.1.3 Add users table + migration" --priority high --feature <featureId> --description "..."
+codespring task create --title "0.1.4 POST /api/login (auth + validation)" --priority high --feature <featureId> --description "..."
+codespring task create --title "0.1.5 Login form UI + client validation" --priority medium --feature <featureId> --description "..."
+```
+- Always pass `--feature <featureId>` so the task is linked to the feature.
+- Sub-features are also features (they have ids); linking a task to a sub-feature via `--feature <subFeatureId>` may work — try it and confirm it attaches correctly, otherwise link to the parent core feature and name the sub-feature in the title.
+- Set priorities (`urgent|high|medium|low`). New tasks land in `todo`.
+
+## 6. Confirm
+```bash
+codespring tasks --status todo --feature <featureId>
+```
+Report the numbered list and the recommended build order (and which can run in parallel). Point the user to the Kanban board in CodeSpring (see `references/codespring-docs.md`). Hand off to `cs-build-feature` to actually build them.
+
+## What good looks like
+- A numbered, prioritized set of tasks in `todo`, linked to the feature, continuing the existing numbering.
+- Foundations sequenced before dependents; independent tasks marked parallel-safe.
+- Every task states what to reuse, what not to touch, and what it could break — so a fleet of agents can build without duplicating or breaking shared systems.

--- a/.claude/skills/cs-build-feature/SKILL.md
+++ b/.claude/skills/cs-build-feature/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: cs-build-feature
+description: >
+  Interactive orchestrator that builds a feature from its CodeSpring plan. It
+  interviews the user about what they're building, checks the feature has enough
+  context (notes + Frontend/Backend PRDs) and a numbered task list, guides them
+  to fill any gaps, then builds the Kanban tasks — optionally spawning up to 5
+  parallel sub-agents — while guarding the shared systems it could break. Use
+  when the user wants to build/implement a feature they planned in CodeSpring.
+  Triggers, "build this feature", "implement my feature", "start building from
+  CodeSpring", "let's build X", "work through my Kanban tasks".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*)
+metadata:
+  author: codespring
+  version: "0.1"
+---
+
+# Build a feature from its CodeSpring plan
+
+A guided, interactive build. Do NOT jump straight to writing code — walk the user through readiness first, then build in a controlled way. This skill both reads the plan and (in the build phase) edits the codebase, so be deliberate.
+
+Uses: `codespring` skill references (`task-workflow.md`, `prd-management.md`, `pitfalls.md`, `codespring-docs.md`), and the sibling skills `cs-build-create-prd` and `cs-build-create-tasks`.
+
+## 0. Connect first
+`codespring auth status` + `codespring status` (LOCAL project; print it).
+
+## 1. Interview — what are we building?
+Ask the user what feature they want to build. Then read what CodeSpring has and reflect it back in **3 simple bullet points**: "Here's what I think we're building — confirm or correct." Keep it plain-language.
+
+## 2. Readiness check — is there enough context?
+For the target feature, verify:
+- A **how-it-works note** exists and is substantive.
+- **Frontend and Backend PRDs** exist (`codespring prds` / `codespring prd <id>`).
+- The Backend PRD actually covers the shared systems (routes, data model, auth/RLS, jobs/cron, storage, payments/credits, env vars) and a dependency map.
+
+If context is missing:
+- Offer to generate PRDs now via **`cs-build-create-prd`**, OR
+- Tell the user to do it in the CodeSpring web app and walk them through it using `references/codespring-docs.md` (open the project → the feature's PRD bridge → add + generate the Frontend/Backend PRD). Then: "Come back and tell me when that's done," and re-check.
+
+## 3. Tasks check — is there a plan to build?
+Check the Kanban for numbered tasks on this feature (`codespring tasks --feature <id>`). If there are none, run **`cs-build-create-tasks`** first. Then point the user to the board: in CodeSpring, top-right toggle **Map / Kanban** → click **Kanban** to see the tasks (see `references/codespring-docs.md`).
+
+## 4. Build mode — ask, don't assume
+Ask the user two things:
+1. **How do you want to build?**
+   - **One task at a time** (more control, review between each), or
+   - **Run for a while** (build a batch autonomously).
+2. If autonomous: **how many parallel sub-agents?** (1–5; cap at 5). Then confirm which tasks each will take.
+
+## 5. Choose the tasks + order
+List the feature's `todo` tasks by number. Recommend which to do first — pick the set that gets to a **testable slice** soonest (foundations/backend before dependent UI). Ask the user which tasks to work on now.
+
+## 6. Break-risk guard (important)
+Ask: **"Are there any existing features you're worried this could break?"** If yes:
+- Add explicit Kanban check tasks (via `cs-build-create-tasks` numbering) to verify those features still work after the build, and
+- Tell every sub-agent, in its brief, not to modify the shared systems those features depend on (from the Backend PRD dependency map) without flagging it.
+
+## 7. Build
+- Move each task to in progress (`codespring task start <id>`), implement it, then `codespring task done <id>`.
+- For parallel builds, spawn up to N sub-agents (max 5). Give each a self-contained brief: its task number + description, the reuse map, the "must not touch" list, and the break-risk guard. Assign independent (parallel-safe) tasks to different agents; keep dependent tasks sequential.
+- Report progress against task numbers so the user can watch the board move.
+
+## 8. Wrap up
+Summarize what was built, which tasks are done, and what remains. Recommend running the app / tests to verify the testable slice. Suggest **`cs-build-resync-codebase`** once the feature is finalized, so CodeSpring reflects what was actually built.
+
+## What good looks like
+- The user confirmed a 3-bullet understanding before any code was written.
+- Missing PRDs/tasks were filled (in-app or via the sibling skills) before building.
+- The build ran at the control level the user chose (single-step or up to 5 agents), foundations first, with explicit guards so existing features weren't broken.

--- a/.claude/skills/cs-build-getting-started/SKILL.md
+++ b/.claude/skills/cs-build-getting-started/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: cs-build-getting-started
+description: >
+  The CodeSpring entry point. Connects the agent to the user's CodeSpring
+  account, reports where the project actually is (map? notes? PRDs? tasks?), and
+  names the single next step — audit an app that isn't doing its job, import one
+  that is, plan a new one from scratch, or carry on from wherever the project
+  already got to. Routes on two questions: is there code, and does it do the job
+  (five specific checks, not "do you trust it").
+  Safe to run at any point, not just the beginning. Use when the user is unsure
+  where to begin or what to do next, or right after installing the CodeSpring
+  skills. Triggers, "get started with CodeSpring", "set up CodeSpring", "connect
+  CodeSpring", "I just installed the CodeSpring skills", "what can I do with
+  CodeSpring", "where do I start", "what should I do next".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(node:*) Bash(git:*) Bash(grep:*) Bash(rg:*)
+metadata:
+  author: codespring
+  version: "0.4"
+---
+
+# Getting started with CodeSpring
+
+Connect, say where the project is, name **one** next step. Keep it short — then hand off.
+
+Uses the `codespring` skill's `references/project-state.md` (state detection, the five questions, the three stages), `references/pitfalls.md`, and its `scripts/` (deterministic state detection).
+
+## Step 1 — Connect
+1. **CLI installed?** If `codespring` is missing: `npm i -g @codespring-app/cli`.
+2. **Authenticated?** `codespring auth status`. If not, ask them to run `codespring auth login` and wait. (Running it also refreshes an expired token.)
+3. **Project linked?** `codespring status`.
+   - Linked → note the name and continue.
+   - Not linked → link an existing project (`codespring projects` → `codespring init --project <id> --force`), or create one. **If it must live in a team workspace, they create it in the web app first** — `project create` ignores `--org` and there is no way to move or delete a project from the CLI (`pitfalls.md`).
+   - Always trust the **local** `.codespring/config.json` for which project is active, and print the projectId.
+
+## Step 2 — Say where the project is
+Run the state-detection **scripts** rather than eyeballing the CLI output — the summary must be identical every run. They live in the `codespring` skill, which installs alongside this one, so the path is relative to this skill's folder; resolve it to an absolute path first, because your working directory will be the user's repo.
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state   # read-only snapshot; prints the projectId
+node ../codespring/scripts/state.mjs /tmp/cs-state                # the one-line summary + the counts
+```
+
+Then report it in one line:
+
+> Connected as *workspace*, project *name* — 6 core features, 25 sub-features, 6 notes, 0 PRDs, 0 tasks. Audit: not yet.
+
+That line is the whole point of this skill. It tells the user what they already have, so they stop guessing which skill to run.
+
+## Step 3 — Name the single next step
+Use the branch table in `project-state.md`. **One recommendation, not a menu.** If the project already has a map, notes, PRDs or tasks, the next step comes from that table — don't restart from the beginning.
+
+If the project is empty, there are only two questions: **is there code?** and, if there is, **does it do the job?** The second one is the five-question diagnostic in `project-state.md` — ask it, do not ask "do you trust it":
+
+1. Does the app do what it actually needs to do?
+2. Is it getting things wrong, or presenting made-up or unverifiable figures as fact?
+3. Does the current architecture allow it to do what it needs to do?
+4. Can we build on it scalably?
+5. Can users use it without it breaking?
+
+| Answer | Next step |
+|---|---|
+| **Any of the five is a no** | **`cs-build-audit-codebase`** — diagnose it, get a plain-English list of what's wrong ranked by what it costs, and a rebuild-or-fix verdict (having real users can veto a rebuild on its own). It then builds the map and the tasks. |
+| **All five yes** | **`cs-build-import-codebase`** — map the real code into core features with notes and PRDs. (It will offer the audit anyway if the code smells broken.) |
+| **There's no code yet — it's an idea** | **`cs-build-plan-app`** — the no-code-yet counterpart to import. Interviews them (or mines a call recording), walks the screens, picks the platform on capability, finds the one hard part and real prior art for it, cuts to a sellable v1, then **reads the whole plan back for a yes before writing anything**. It writes the map and notes itself, then hands to `cs-build-create-prd`. |
+
+**"The code runs" is not the same as "the code does the job."** A vibe-coded app often runs fine and still fails questions 1–3, so do not accept "it works" as five yeses. If the user can't answer from knowledge — most can't — run the quick health smell test in `project-state.md` and answer from evidence: *"4 of the 6 things that usually mean an app needs diagnosing"*, then let them choose.
+
+It does not matter if they picked "wrong". Every skill detects the real state on entry and does the right next thing.
+
+## The rest of the journey
+Once there's a map with notes: **`cs-build-ui-mockup`** → **`cs-build-create-prd`** → **`cs-build-create-tasks`** → **`cs-build-feature`** → **`cs-build-resync-codebase`**.
+
+**`cs-build-ui-mockup` comes before the PRDs, and it is not optional for anything with a user interface.** It builds a throwaway clickable mockup from the notes and runs the review that catches what a written plan cannot express — screen order, hierarchy, position, and choices that turn out to be incomplete. A PRD generated from a plan nobody has looked at just encodes the misunderstanding in more detail. Understand produces context (the map + notes); Plan produces instructions (PRDs + tasks); a PRD is only as good as the note it reads (`project-state.md`).
+
+## What good looks like
+- Authenticated and pointed at the correct **local** project before anything else — and if two projects exist for one app, the user was told which one is authoritative (`project-state.md`).
+- The user is told where their project actually is, in one line, from the script's output rather than a hand count.
+- Routing came from the **five questions**, not from "do you trust it" — and "it works" was not accepted as five yeses.
+- Exactly one next step is named, and it fits the state the project is really in — not a wall of options.

--- a/.claude/skills/cs-build-handoff/SKILL.md
+++ b/.claude/skills/cs-build-handoff/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: cs-build-handoff
+description: >
+  Turn a finished CodeSpring plan into the pack a paying client actually
+  receives — a plain-English summary of what is being built, the mockup and its
+  style guide, the plan and task links, an honest phase-by-phase build order,
+  what was assumed, what is still open, what is needed from them, and exactly
+  what to do next to start building. Written at a reading level a non-technical
+  owner can follow, with no file paths and no jargon. Run it once the map,
+  notes, PRDs and tasks exist and the plan is about to leave your hands.
+  Triggers, "hand this over to the client", "create the client pack", "write the
+  handover", "send them the plan", "what do I send the client", "onboard them
+  onto this plan", "package this up for delivery".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(node:*) Bash(git:*) Bash(grep:*) Bash(rg:*)
+metadata:
+  author: codespring
+  version: "0.1"
+---
+
+# Hand the plan over
+
+**When the plan is the product, the handover is the delivery.** Everything upstream produced artefacts for the build — a map, notes, PRDs, a task board. None of those are written for the person paying, and handing someone a link to a canvas they have never opened is not a delivery.
+
+This produces the thing they receive.
+
+Run it **after** `cs-build-create-tasks`, once the map, notes, PRDs and tasks all exist.
+
+Read: `codespring` skill `references/project-state.md` and `references/pitfalls.md`, and **`cs-build-audit-codebase/references/plain-english-writeup.md`** — the voice rules there apply here exactly. Third-grade reading level, no file paths, no jargon, no framework names.
+
+---
+
+## 0. Check there is something to hand over
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state
+node ../codespring/scripts/state.mjs       /tmp/cs-state
+node ../codespring/scripts/check-map.mjs   /tmp/cs-state
+```
+
+**Do not hand over a plan with holes in it.** Check and say plainly if any of these are missing:
+
+- Core features, each with a real note
+- PRDs on every core feature
+- Tasks, numbered, ordered, each linked to a feature
+- A mockup, if the thing has a user interface
+
+A missing piece is not a reason to write around it — go back and finish it. The one exception is where something is deliberately deferred, and then it belongs in **"what we haven't decided yet"** rather than being quietly absent.
+
+## 1. Know who is reading it
+
+Usually a non-technical owner who has paid real money and is nervous. Often they have been burned by a previous agency or program.
+
+**Write for them, not for the builder.** Two consequences that decide the whole tone:
+
+- **No jargon, no file paths, no framework names, no task IDs in the prose.** They do not need to know what a PRD is to understand what they are getting.
+- **Say what it does for their user, not how it is built.** "She picks how long she has and the app runs the session" — not "the session controller reads the workout schema".
+
+If they *are* technical, they will not be annoyed by clarity. The reverse is not true.
+
+## 2. Write the pack
+
+One document. Sections in this order, because that is the order their questions arrive in.
+
+### What we're building
+Two or three paragraphs, plain English, in **their own words wherever possible** — pull the phrasing straight out of the call or the notes. They should recognise their idea, said back more clearly than they said it.
+
+State the job it does and who it does it for. No feature list yet.
+
+### What it does
+The core features, each with a sentence or two on what the person using it can actually do. **Named the way they talk**, not the way the map is organised.
+
+If there is a mockup, put the screenshots here, beside the feature each one shows. This is the section they will read most carefully.
+
+### What you'll see
+The mockup: how to run it, or where it is hosted, and one line making clear it is **a sketch of the finished thing, not the app** — nothing in it works yet, the data is made up, and it exists so they can react to the shape before anything is built.
+
+Include the **style guide** page if there is one, and say what it is for: the colours, type and spacing are all set in one place, so changing the look later is a small job rather than a rebuild.
+
+### How it gets built
+The task list as **phases, not tasks.** Nobody wants to read sixty rows. Group them into the four or five stages they already exist in, and for each give: what happens, roughly how long, and what it unlocks.
+
+Two things must be honest here:
+- **Name the hard part** and say it is being proven first, before the screens are built around it. If the plan has a spike as task one, explain why in one sentence.
+- **Name what they have to do.** Content, decisions, reviews, accounts. This is the most-skipped section and the most common cause of a stalled build.
+
+**Do not give a total delivery date** unless one was actually agreed. Give the shape and the sequence.
+
+### What we assumed
+Every assumption made on their behalf, in plain words, each with a one-line reason. Platform, scope, audience, anything cut from v1.
+
+This section buys trust rather than spending it. An assumption they disagree with is cheap to fix now and expensive after the build — and surfacing them is what separates a plan from a guess.
+
+### What we haven't decided yet
+The genuinely open questions, and **who needs to answer each one.** Be specific about what a decision unblocks: *"we need your exercise list before the content work can start"* is actionable; *"TBC"* is not.
+
+### What's not in the first version
+Named explicitly, each with a reason, and clearly marked as *later* rather than *never*. An unspoken cut is heard as a broken promise the moment they see the build.
+
+### What to do next
+Numbered, concrete, and short. Typically:
+1. Open the plan (link)
+2. Look at the mockup (link or command)
+3. Send back the things in "what we haven't decided yet"
+4. Open the project in the build tool and start with task one
+
+Assume they have never used any of these tools. **Include the actual links and the actual first task**, not a description of them.
+
+### Where everything lives
+A short reference: the plan link, the mockup, the docs, the task board, and who to contact.
+
+## 3. Deliver it in the form they will actually read
+
+Ask, or use what you know about them. The document is the same; the wrapper differs:
+
+- **A rendered page** they can open and share — usually the best default, and it keeps the screenshots inline.
+- **A markdown file** in the repo if they are comfortable there.
+- **An email or message body**, if the pack is short and they are more likely to read it in their inbox than to click a link.
+
+Whatever the form, **put the screenshots in it.** A plan without pictures reads as an invoice; a plan with pictures reads as a product.
+
+## 4. Record it in CodeSpring
+
+So the next session knows what the client has already been told:
+
+- Set the project description to the plain-English "what we're building" paragraph, so the canvas opens with something they recognise.
+- Put the handover date and what was sent in the project info or a note.
+- If assumptions or open questions were listed, make sure they also exist in the relevant feature's note — otherwise they live only in a document nobody reads again.
+
+```bash
+codespring mindmap set-info --title "..." --description "<the plain-English paragraph>"
+```
+
+## 5. Say what you sent
+
+Tell the person who commissioned it — usually not the same person as the client — in three lines: what went out, what you are waiting on from the client, and what happens when it arrives.
+
+---
+
+## What good looks like
+
+- The client could read the whole pack and **explain their own app back to someone else.**
+- **No jargon, no file paths, no task IDs, no framework names** anywhere in the prose.
+- The mockup screenshots are in it, beside the features they show.
+- Build order is **phases with what-it-unlocks**, not sixty rows.
+- **Assumptions are stated**, each with a reason.
+- **What they owe is named**, specifically, with what it unblocks.
+- Cuts are named as *later*, not left silent.
+- The next steps are numbered, with real links and the real first task.
+- The plain-English summary is on the CodeSpring project, so the canvas opens with something they recognise.

--- a/.claude/skills/cs-build-import-codebase/SKILL.md
+++ b/.claude/skills/cs-build-import-codebase/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: cs-build-import-codebase
+description: >
+  Get an existing app into CodeSpring as a visual feature map — a small set of
+  core features (sidebar-level) with nested sub-features and a "how it works"
+  note each — then PRDs (via cs-build-create-prd) and Kanban tasks. Takes an
+  OPTIONAL audit + verdict: with no audit it documents what exists; with an audit
+  it builds the corrected target map (what the app should be) and generates fix or
+  rebuild tasks from the findings. Detects an existing map, judges whether it is
+  any good, and keeps or repairs it instead of duplicating it — and offers to
+  audit first if the codebase looks broken.
+  Triggers, "import my codebase into CodeSpring", "map my existing app", "reverse
+  engineer my app into features", "bring this project into CodeSpring",
+  "visualize my code in CodeSpring".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(git:*) Bash(node:*) Bash(curl:*) Bash(grep:*) Bash(rg:*)
+metadata:
+  author: codespring
+  version: "0.5"
+---
+
+# Import a codebase into CodeSpring
+
+Turn a real repo into an accurate CodeSpring model: **core features → sub-features → notes → PRDs → tasks**. Reads code and git; writes only to CodeSpring — never modifies the codebase.
+
+Shared knowledge, read it: `codespring` skill `references/project-state.md` (enter-from-anywhere, the five questions), `references/auditing-and-fixing.md` (audit → verdict → map → tasks, and why the map shows the target), `references/analyze-codebase.md`, `references/mindmap-structure.md` (the exact node/edge schema), `references/prd-management.md`, `references/pitfalls.md`. Then this skill's `references/target-map.md` (**the map rules — the node model, the corrected target, and how to keep it small**).
+
+**Language- and stack-agnostic.** Any named specific here or in the references is a **labelled worked example**, never an assumption about the repo in front of you.
+
+**Script paths are relative to this skill's own folder**; the skills install side by side, so `../codespring/scripts/…` reaches the core skill's scripts. Resolve them to absolute paths once at the start — your working directory will be the user's repo.
+
+## 0. Detect where the project already is
+Run the state-detection **scripts** rather than counting by hand (the `codespring` skill's `scripts/`, installed alongside this one):
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state   # read-only snapshot; prints the projectId
+node ../codespring/scripts/state.mjs       /tmp/cs-state          # summary line + booleans and counts
+node ../codespring/scripts/check-map.mjs   /tmp/cs-state          # machine-checkable map faults, before you add to them
+```
+
+Read `projectId` from the **local** `.codespring/config.json` and print it before any write.
+
+**Branch on what exists — do not assume you are starting from nothing:**
+- **A map already exists** → you are **updating**, not importing. Print the existing core features and ids, then **run the map-quality ladder** (below). Match on title; never re-create; re-parent strays. Skip straight to whatever is actually missing (notes → PRDs → tasks).
+- Not linked → link. If the project must live in a team workspace, the user creates it in the **web app** first (there is no CLI way to place or move a project — `pitfalls.md`).
+- Tasks exist → note the highest number and continue the sequence.
+- **Two projects already exist for this one app** → establish **which is authoritative** before writing anything, and say so to the user.
+
+### 0a. The map-quality ladder — an existing map is not automatically a good map
+*"A map exists → keep it"* is too blunt; an unusable map poisons every note, PRD and task built on it. Full version with the CLI commands and the two-projects warning: `references/target-map.md`.
+
+1. **Does a map exist?** No → build it (§2–§4).
+2. **Is it good?** `check-map.mjs` settles the count, duplicate titles, flattened sub-features and missing notes. **You** judge the rest: core features **4–8**, each one something a user would recognise as a **sidebar item**; sub-features are things a user **does**, not sections of an output document or groups of form fields; card descriptions one sentence with the depth in the note card. A map can pass every check and still be incomprehensible.
+3. **Good → keep it.** Update notes, add tasks. **Never recreate it.**
+4. **Fixable** (mostly right, a few strays) → **fix in place and say what you changed:** `codespring feature update <subId> --parent <coreId>`, `codespring feature delete <dupId> --yes`, `codespring feature update <id> --title "..."`.
+5. **Not fixable** (wildly too many core features, output sections standing in as features, no coherent structure) → **do not salvage it.** Explain why plainly, recommend a **new CodeSpring project** with a clean map, and say the old one **stays as history**. **Get explicit confirmation before creating a second project — never silently.** Two projects for one app is confusing later, so it must be a deliberate, explained choice, and the user must be told **which project is now authoritative**. (Real case: a 13-core-feature import was unusable; a second project with a clean 6-feature map replaced it; both still exist, and there is no `project delete`.)
+
+## 1. Do you have an audit?
+This is the one input that changes the output.
+
+| | Behaviour |
+|---|---|
+| **No audit** | Document **what exists** — the app as it is today. |
+| **Audit + verdict** | Build the **corrected target map** — what the app *should* look like, simplified into core features a non-expert recognises. |
+
+**If there's no audit, ask the five questions** (`project-state.md`) before importing — does the app do what it needs to do; is it getting things wrong or presenting unverifiable figures as fact; does the architecture allow what it needs to do; can it be built on scalably; can users use it without it breaking. **Any no → offer the audit first.** Do not ask "do you trust the code", and do not accept "it works" as five yeses — **"the code runs" is not the same as "the code does the job."**
+
+**Then run the quick health smell test** (`project-state.md`), because the user often cannot answer questions 2, 4 and 5 from knowledge. Six smells: no tests/CI, ungated deploy, local clone behind the remote, swallowed errors, credentials in shipped source, browser-only records or hardcoded reference data. **Two or more → stop and offer the audit**, plainly: *"I found 4 of the 6 things that usually mean an app needs diagnosing before mapping. Want me to run `cs-build-audit-codebase` first?"* Do not silently import a mess — a map of a broken app is a map nobody should trust. If they decline, import what exists and say the map documents today's behaviour, faults included.
+
+## 2. Analyse the code
+Follow `analyze-codebase.md`: frontend map (routes, components, what the user sees, navigation) and backend map (API routes and which features share them, data model, security, shared systems — payments/credits, jobs/cron, storage, auth, env vars — and infra). Set the real tech stack. Read files; don't guess. On the audit path you already have most of this — reuse the findings rather than re-deriving them.
+
+## 3. Decide the features — smallest recognisable set
+Rules and the worked failure in `references/target-map.md`. The short version:
+
+- **Core feature** = a sidebar/nav-level thing the user would point at. **Aim for 4–8.** The first real run produced **13 confusing** core features; after redirection, **6 clean** ones. Push hard toward the smallest set.
+- **Sub-feature** = something the user **does**. A verb. *Save a client. Compare two properties. Export the PDF.*
+- **The mistake not to repeat: do not turn report/page sections or form field-groups into sub-features.** A report section is part of one feature's output; a form field-group is part of one feature's input. Twelve report sections are one feature plus a good note, not twelve features.
+- **Card descriptions stay to one short sentence. ALL detailed information goes into the note card attached to that feature via its bridge — never into the card description.** The node model (features node → card → bridge → note card, and bridge → PRD bridge → PRDs) is in `references/target-map.md`; the exact schema is in `mindmap-structure.md`. The first real run failed on exactly this: long descriptions on the cards *and* output sections promoted to sub-features, giving 13 unusable core features.
+- **Notes are root-feature-only** via the CLI, so sub-feature detail goes in the parent core feature's note (`pitfalls.md` §5).
+
+On the audit path, add a feature the current app lacks **only** where a bucket-1 fix has nowhere else to live (durable storage for records that exist only in a browser; sign-in where there is none). A bucket-2 "could add later" idea never becomes a feature (`auditing-and-fixing.md` §4a).
+
+**Ask whether the app is feature-complete or still being built.** If it is still being built, **ask what is planned but not yet built before finalising the list** — missing code is not proof a feature is missing, and pages nothing links to may be unfinished modules rather than dead ends or a separate product.
+
+**Read the list back to the user and ask them to cut it before you write anything.**
+
+## 4. Write the map (CLI)
+```bash
+codespring mindmap set-info --title "..." --description "..." --github "<repo url>"
+codespring mindmap tech-stack --replace --add '[{"id":"tech-...","title":"...","description":"Frontend"}, ...]'
+codespring mindmap features --add '[{"title":"Dashboard","description":"..."}, ...]'   # CORE features; keep the returned ids
+codespring feature create --parent <coreId> --title "..." --description "..."           # sub-features
+codespring mindmap note <coreId> --title "How it works — X" --text "$(cat note.txt)"    # one per core feature; redirect output to /dev/null
+```
+
+**Idempotency (`auditing-and-fixing.md` §8):** diff by title first and only add what is missing. **`codespring mindmap features --replace` does NOT replace — it appends and creates duplicates.** If duplicates happen, recover with `codespring feature delete <id> --yes`, which does work and cascades.
+
+**The note per core feature** carries the depth from `analyze-codebase.md` §8–9 and, on the audit path, three things: what the feature *should* do, how it works today, and what is wrong with it today (severity + file reference; on a rebuild, the "do not reintroduce this" constraints). The PRD generator reads this note as its context, so a thin note produces a thin PRD. When updating an existing note, read it first and keep what is still true.
+
+## 5. Say what the map is
+One sentence to the user, because it prevents a real misunderstanding: **the map shows the corrected target, not the current structure — so it won't mirror the repo until the tasks are done, and the Kanban is the gap between the two.** Rationale in `references/target-map.md`; this is deliberate and applies on both verdicts.
+
+## 6. PRDs — via `cs-build-create-prd`
+Do not re-implement PRD mechanics. For each core feature use **`cs-build-create-prd`** (Both frontend + backend); it captures the shared backend contracts and attaches the PRD bridge nodes correctly. Mind its ≥120s timeout and dedupe rules. **Never regenerate a PRD that already exists** unless asked — read it, say it exists, offer to refresh it. And never generate a PRD for a feature with no note.
+
+## 7. Tasks — the two paths differ, and this is the important part
+Only **bucket 1 (real problems)** becomes tasks. Every task: linked to exactly one core feature, carrying a severity (Critical → `urgent`, High → `high`, Medium → `medium`, Low → `low`), one-sentence title, detail in the description, continuing the existing numbering.
+
+**Future ideas have nowhere to live in CodeSpring, and they must not become tasks** — a task list implies committed work. Buckets 2 and 3 go in `FINDINGS.md` in the repo, in two explicitly titled sections with a one-line reason each: *"Could add later — deliberately not doing now"* and *"Not worth adding"*. Never on the map, never in Kanban, never as a PRD (`auditing-and-fixing.md` §4a — it is a known product gap for FERB).
+
+**Verdict = REBUILD → two distinct sets.**
+1. **Build-to-spec tasks** — one per feature/sub-feature, foundations first.
+2. **"Mistakes to avoid" tasks** — one per significant defect found in the original, carried forward as an explicit do-not-reintroduce constraint with the concrete example. **This second set is the entire reason for auditing before importing** — without it a rebuild recreates the same silent failures, the same hardcoded tables and the same duplicated logic, because nothing in the new plan says not to. Write them as verifiable constraints:
+   - *"Reference data lives in dated records, not as values typed into the code. It must be impossible to change a rate by editing the app."*
+   - *"When a lookup finds nothing, say so. No code path may put a zero or a blank where an error happened."*
+   - *"There is exactly one copy of the calculation logic, and everything imports that copy."*
+   - *"When a report is published, save the inputs, the results, and which year's rates produced them — so fixing a rate later doesn't change what a client was already shown."*
+   - *"Who someone is never comes from the request body. Identifiers in a request are targets, and ownership is checked before use."*
+
+**Verdict = FIX IN PLACE → one set.** One task per defect, at the place it lives, **with the file reference in the description** (the user-facing findings have no paths; the task needs one because an agent has to act on it). Sequence: silent failures first, then wrong outputs, then structural work, then polish — or the audit's own suggested fix order.
+
+**No audit** → tasks come from the PRDs, not from findings. Hand off to **`cs-build-create-tasks`** for that; it owns PRD-derived task lists. This skill only writes the findings-derived tasks, because it is the only place the findings exist.
+
+An **UNVERIFIED** finding becomes an investigation task keeping its label — never a confident fix task.
+
+## 8. Verify (`pitfalls.md`, `auditing-and-fixing.md` §9)
+**Run the check, don't eyeball it:**
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-verify
+node ../codespring/scripts/check-map.mjs   /tmp/cs-verify --expect-core <the count you intended>
+```
+
+- `node-features.items.length` equals the intended core-feature count — **and no sub-features have been flattened to top level.** Re-parent any stray with `codespring feature update <subId> --parent <coreId>`; keep a sub→core map so re-runs are one command.
+- No duplicate features (by title) and no duplicate PRDs (by feature + type).
+- One note per core feature. Every task linked to a feature with a severity.
+- A non-zero exit is a real failure: fix it before reporting. Then report the diff: created N, updated N, skipped N. Give the project link `https://v2.codespring.app/project/<projectId>`.
+
+## 9. Optional independent audit of the map (no-audit path only)
+On the audit path, skip this — you already have one. Otherwise spawn a **background sub-agent** with a FULLY SELF-CONTAINED brief and **no context from the import work**, so the comparison is unbiased:
+
+> You are an independent auditor. Read-only: do not modify the codebase or the CodeSpring map.
+> 1. **Inventory the whole codebase** — every route, page, table + enum, external provider, webhook, cron/job, and the shared backend contracts (payments/credits/refunds, job pipelines, storage conventions, auth, env vars).
+> 2. **Read everything documented in CodeSpring** — every feature's notes and PRDs (via the `codespring` CLI).
+> 3. **Compare critically and report**, prioritising **shared backend gaps and conflict risks** (the riskiest part of adding a new feature). Flag anything in the code that's undocumented, anything that could break or duplicate a shared system, and anything documented but missing critical backend detail — each **rated by severity** with exact file/route/table references, plus a shortlist of what to add to CodeSpring.
+
+Report when it finishes and offer to fold the shortlist into the notes/PRDs, or hand off to `cs-build-resync-codebase`.
+
+## What good looks like
+- The map holds the **smallest** set of core features a non-expert would recognise — not report sections, not form field-groups.
+- With an audit, the map is the **corrected target** and the user has been told so in one sentence; without one, it honestly documents what exists.
+- Nothing was duplicated: an existing map was judged against the ladder and then kept or repaired in place, features were matched on title, strays were re-parented, existing PRDs were left alone.
+- A second CodeSpring project was only ever created with **explicit confirmation**, with the reason explained and the authoritative project named.
+- Future ideas are in the two named `FINDINGS.md` sections, not on the map and not in Kanban.
+- Every core feature has a real "how it works" note, and every PRD was generated from one.
+- On a rebuild, a distinct set of "mistakes to avoid" tasks exists so the original's defects cannot come back. On a fix in place, every defect has a task where it actually lives.

--- a/.claude/skills/cs-build-import-codebase/references/target-map.md
+++ b/.claude/skills/cs-build-import-codebase/references/target-map.md
@@ -1,0 +1,159 @@
+# Building the map — the node model, the corrected target, and how to keep it small
+
+Applies to any codebase in any language. The named examples (a report's sections, a form's field-groups, a 13-feature first attempt) are **labelled worked examples** from real runs, not assumptions about the repo in front of you.
+
+Two inputs, one output shape.
+
+| Input | What the map shows |
+|---|---|
+| **No audit** | What exists — the app documented as it is today |
+| **An audit + a verdict** | **The corrected target** — what the app *should* look like, simplified into core features a non-expert recognises |
+
+## The settled decision
+
+**The mindmap always shows the corrected target. It never shows the messy current structure annotated with warnings.** True on a rebuild verdict and true on a fix-in-place verdict.
+
+Recorded rationale:
+
+- **The map means one thing.** Nobody reading a CodeSpring map — user or agent — has to ask "is this the real structure or the intended one?" It is always the intended one.
+- **The Kanban always means the same thing:** the gap between here and there. Every task closes a distance between the map and reality, whether that task builds a feature or fixes one.
+- **One drawing model.** No second node type for "broken", no warning badges, no annotation layer, and nothing extra to unwind when a task is finished.
+
+Accepted cost: **the map does not mirror the repository until the tasks are done.** Disclose that to the user in one sentence. It is arguably a feature — the map shows people where they are going, which is what a non-expert needs to see — and `cs-build-resync-codebase` is what brings the two back into agreement afterwards.
+
+**A fix-in-place target map looks almost identical to the current app.** The difference lives in the notes (what each feature *should* do, including the corrections) and in the tasks (what is wrong today). Do not skip the corrected-target step just because the verdict was fix in place.
+
+Where a finding has no home in the target map — dead code being deleted, a page being removed — it becomes a task without a new feature. Attach it to the nearest core feature, or to a core feature named for the cleanup. **Never invent a feature just to host a defect.**
+
+---
+
+## Is the existing map any good? — the ladder
+
+*"A map already exists → keep it"* is too blunt. An import can produce a map that is genuinely unusable, and keeping it means every note, PRD and task afterwards inherits the confusion. Walk the ladder, in order, and say out loud which rung you landed on.
+
+**1. Does a map exist?** No → build it (the rest of this file).
+
+**2. Is it good?** Judge it against these tests, not against your own taste:
+
+- **Core features are 4–8**, and each one is something a user would recognise as a **sidebar item**.
+- **Sub-features are things a user *does*** — verbs — not sections of an output document and not groups of form fields.
+- **Every core feature has a note**, and the **card descriptions are one sentence** with the depth in the note (below).
+- **No duplicates** — no two features share a title.
+- **No sub-features flattened to top level** (`pitfalls.md` §2).
+
+Run the machine-checkable half rather than counting by hand — it is identical every time:
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state
+node ../codespring/scripts/check-map.mjs /tmp/cs-state            # add --expect-core N once you know the number
+```
+
+It settles the count, duplicate titles, flattened sub-features, missing notes, duplicate PRDs and unlinked tasks. **The judgement calls stay yours:** whether a core feature is really a sidebar item, whether a sub-feature is a verb, and whether the whole thing is comprehensible. A map can pass every check and still be wrong.
+
+**3. Good → keep it.** Update the notes, add the tasks. **Never recreate it.** Print the core features and their ids and move on.
+
+**4. Fixable** — mostly right, a few strays → **fix it in place, and say what you changed:**
+
+```bash
+codespring feature update <subId> --parent <coreId>     # re-parent a stray sub-feature
+codespring feature delete <dupId> --yes                 # remove a duplicate (cascades)
+codespring feature update <id> --title "..."            # rename to something a user would recognise
+```
+
+**5. Not fixable** — so wrong that it is confusing: wildly too many core features, sections of an output document standing in as features, no coherent structure → **do not try to salvage it.** Explain plainly *why* it cannot be fixed (say which tests it fails and how many features would have to change), and recommend a **new CodeSpring project with a clean map**, telling the user the old project **stays as history**. **Get explicit confirmation before creating a second project — never silently.**
+
+### Warning: two projects for one app
+
+This is a real case, not a hypothetical. An import produced a **13-core-feature** map that the owner could not use; the fix was a **second** CodeSpring project with a clean **6-feature** map. **Both still exist.**
+
+- **Two projects for one app gets confusing later** — links, notes, PRDs and tasks split across two places, and nobody remembers which is current.
+- So it must be a **deliberate, explained choice**, never a quiet workaround for a map you did not want to fix.
+- **Tell the user which project is now authoritative**, in those words, and record it in the new project's info/description so the next session does not have to guess.
+- On entry, if you find two projects for one app, establish which is authoritative **before writing anything** (`project-state.md`).
+- There is no `project delete` and no way to move a project between workspaces, so a second project is permanent. Name it so the difference is obvious.
+
+---
+
+## How a map is stored — the node model
+
+The same shape for every project, whatever the codebase. Exact node ids, edge handles and JSON live in `mindmap-structure.md`; this is the model you need in your head before you write anything.
+
+- **Core features are items on one node.** The features node holds an array of items, and each item **is** a core feature card — a `title` and a one-sentence `description`. There is no separate node per core feature.
+- **Each core feature gets a sub-feature group node.** One node per core feature, holding that feature's sub-feature cards and pointing back at its core feature (`parentFeatureId`). That parent link is the whole difference between a sub-feature and an extra core feature, and it is the thing that breaks (`pitfalls.md` §2).
+- **Detail attaches through a bridge.** A feature card connects to a **bridge node**; the bridge connects to the detail cards — the **note card** (one per core feature) and, later, a PRD bridge carrying the Frontend and Backend PRD cards. Nothing detailed hangs off a feature card directly.
+
+```
+features node ──(card)──► bridge ──► note card
+                             └────► PRD bridge ──► Frontend PRD / Backend PRD
+```
+
+### Where detail goes — the rule
+
+> **Card descriptions stay to one short sentence. ALL detailed information goes into a note card attached to that feature via a bridge — never into the card description.**
+
+Cards are read at a glance on a canvas, so a paragraph on a card hides the structure the map exists to show. The note card has no practical length limit, and it is the **note** — not the card — that the PRD generator reads as its context (`project-state.md`).
+
+**Notes are root-feature-only through the CLI** (`pitfalls.md` §5): `codespring mindmap note <coreFeatureId>` overwrites that core feature's single note, and a sub-feature cannot have one. So **sub-feature detail belongs in the parent core feature's note** — which is one more reason not to invent sub-features to hold detail.
+
+### The real failure this prevents
+
+First attempt on a real app: long descriptions written onto the cards **and** the report's own sections and the form's field-groups promoted into sub-features → **13 core features, unusable**, and the owner said so plainly. Second attempt: **6 core features**, one-sentence descriptions, every piece of depth in the notes → usable. Same codebase, same information, different placement.
+
+---
+
+## The smallest set of core features that a user would recognise
+
+The first run on the real app produced **13 core features** and the user found them confusing. After redirection it produced **6**, which were right. Push hard toward the smallest set.
+
+**Test for a core feature:** would this be a sidebar item? Would the user point at it and say "that's a thing my app does"? If the answer needs explaining, it is not a core feature.
+
+**Test for a sub-feature:** is it something the user **does**? A verb. *Save a client. Compare two properties. Export the PDF. Enrol someone.*
+
+### The specific mistake that was made — do not repeat it
+
+**Sub-features are not sections of an output document, and they are not groups of form fields.**
+
+The first run turned the report's own sections into sub-features ("Government costs", "Tax benefits", "Market intelligence", "Glossary", "How to read these figures") and turned form field-groups into sub-features ("Location", "Loan details", "Property details"). Both are wrong:
+
+- **A report section is not a feature.** It is part of the output of one feature. Twelve report sections do not make twelve features — they make one feature called "the report", and the sections are detail that belongs in that feature's note.
+- **A form field-group is not a feature.** It is part of the input to one feature. "Location" is not something a user does; *analysing a property* is, and Location is one panel of it.
+
+Symptoms you have made this mistake: core features that read like a table of contents; sub-features that are nouns rather than verbs; more than about 8 core features on an app with 6 screens; two sub-features that a user could not tell apart.
+
+### Practical shape
+
+- **Core features: aim for 4–8.** Above 8, argue for each one. Above 10, you have almost certainly split an output document or a form.
+- **Sub-features: the actions inside that feature.** A handful each, not twenty.
+- Depth goes in the **note**, not in more features. If detail is being lost, the note is too thin — enrich it rather than adding features.
+- **Card descriptions stay one sentence.** Always.
+
+### Building the target list from an audit
+
+1. Start from what the app is *for* — the two or three jobs a user comes to do.
+2. Take the real navigation as the candidate list (`analyze-codebase.md` §6), then **collapse**: merge screens that are one job split across pages, and drop pages that the target does not have (dead ends, orphans, internal galleries shipping to production).
+3. Add features the target genuinely needs and the current app lacks **only where the audit put them in bucket 1** — a *fix* that has no home in the current structure (durable storage for records that currently live in one browser, an accounts/sign-in feature where there is none). A bucket-2 "could add later" idea **never** becomes a feature on the map; it lives in the *"Could add later — deliberately not doing now"* section of `FINDINGS.md` (`auditing-and-fixing.md` §4a).
+   **On an app that is still being built, ask what is planned but not yet built before you finalise the list.** Code that is missing is not proof a feature is missing, and pages nothing links to may be unfinished modules rather than dead ends.
+4. Name them the way the user talks, not the way the code is organised.
+5. Read the list back to the user and ask them to cut it before you write anything.
+
+---
+
+## Writing the notes
+
+One "how it works" note per core feature. On the audit path each note says three things:
+
+1. **What this feature should do** — the target behaviour, plainly.
+2. **How it works today** — the real structure, files, routes and data, at the depth in `analyze-codebase.md` §8–9. The PRD generator reads this note as its context, so thin notes produce thin PRDs (`project-state.md`).
+3. **What is wrong with it today** — the audit findings that belong to this feature, each with its severity and its file reference, and, on a rebuild, the "do not reintroduce this" constraints.
+
+Notes are **root-feature only** and there is one per feature, which the CLI overwrites (`pitfalls.md` §5). Put sub-feature detail and cross-feature links inside the parent's note. When updating an existing note, **read it first and preserve what is still true.**
+
+---
+
+## CLI reality check before you write
+
+- `codespring mindmap features --replace` **does not replace — it appends**, creating duplicates. Treat feature creation as add-only, diff by title first. Recovery is `codespring feature delete <id> --yes`, which does work and cascades.
+- There is **no `project delete`**, and no way to move a project between workspaces or organisations from the CLI — `project create` ignores `--org` and stamps `organizationId: null`. If the project must live in a team workspace, the user creates it **in the web app first**, then you link to it.
+- Always read `projectId` from the **local** `.codespring/config.json` and print it before any write.
+
+Full details and the rest of the failure modes: `pitfalls.md`.

--- a/.claude/skills/cs-build-plan-app/SKILL.md
+++ b/.claude/skills/cs-build-plan-app/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: cs-build-plan-app
+description: >
+  Turn an idea into a CodeSpring plan — from a sales-call recording, a transcript,
+  a voice note, or someone just talking at you about what they want. Interviews
+  the person (or mines the recording) for the job the app does, walks the screens
+  with them, picks the platform from what the app actually needs to do, finds the
+  one technically hard part and names a real solution for it (including existing
+  open-source prior art), cuts to a v1 that can be sold, then writes the map —
+  core features, sub-features, notes — and hands off to cs-build-create-prd and
+  cs-build-create-tasks. The no-code-yet counterpart to cs-build-import-codebase.
+  Triggers, "plan my app", "generate a plan", "turn this recording into a plan",
+  "I have an idea for an app", "design my app in CodeSpring", "map out this idea",
+  "I've got a client call recording, make the plan", "plan from scratch".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(node:*) Bash(git:*) Bash(grep:*) Bash(rg:*) WebSearch WebFetch
+metadata:
+  author: codespring
+  version: "0.7"
+---
+
+# Plan an app from an idea
+
+There is no code yet. Produce the same artefact `cs-build-import-codebase` produces — **core features → sub-features → notes → PRDs → tasks** — but derived from a person instead of a repo.
+
+**Two phases with a gate between them:**
+
+| | | |
+|---|---|---|
+| **A. Think** (§1–§6) | Conversational, nothing is written | the job, the journey, every kind of user, the platform call, the hard part and what solves it, the systems checks, the v1 cut |
+| **GATE** | **Read the plan back and get an explicit yes** | §6a |
+| **B. Write** (§7) | CodeSpring gets touched | the map and the notes |
+| **C. Show** (§7a) | Hand off to `cs-build-ui-mockup` | the cheapest possible disagreement — corrections come back into the notes |
+| **D. Instruct** (§8–§9) | Only once the mockup is agreed | PRDs, then tasks |
+
+**Never write to CodeSpring during phase A.** A map is expensive to unpick and it makes people feel committed to a plan they were still arguing with. Phase A is meant to be argued with.
+
+This is the **no-code-yet counterpart to `cs-build-import-codebase`** and it deliberately does its own writing rather than handing over — that skill's engine is *reading a repo*, and there is no repo. What the two share is the destination, and that is already factored out: the node model and map rules in `cs-build-import-codebase/references/target-map.md`, the schema in `mindmap-structure.md`, the CLI in `commands.md`. Use those; do not re-derive them and do not fork them.
+
+Shared knowledge, read it: `codespring` skill `references/project-state.md` (enter-from-anywhere, the three stages), `references/mindmap-structure.md` (the exact node/edge schema), `references/prd-management.md`, `references/pitfalls.md`. **And `cs-build-import-codebase/references/target-map.md` — the node model, the one-sentence-card rule and the 4–8 core feature ceiling are identical here; do not restate or re-derive them.**
+
+Then this skill's own references, which cover what is different about planning from nothing:
+
+| Reference | Read it when |
+|---|---|
+| `references/elicitation.md` | Always. Getting the real app out of a person's head, and out of a recording. |
+| `references/platform-choice.md` | Before you name a stack. Mac vs web vs iOS decided by capability — **and the constraint that can overrule it: what the owner can actually build in and maintain.** Plus what each choice costs. |
+| `references/hard-part-first.md` | Always. Every app has one genuinely hard bit; find it, find the prior art, prove it. |
+| `references/data-and-shape.md` | Always, and the actor question **before the feature list is final**. The five systems checks nobody asks for: figures someone else publishes and how they get updated, logic shared across products, every kind of user and the owner's admin surface, whose database this lives in, and showing how current the data is. |
+| `references/v1-scope.md` | Before you write the map. Cutting to one loop, and the revenue gate. |
+
+---
+
+## The difference that governs everything
+
+**Importing a codebase has ground truth. Planning an idea does not.**
+
+With a repo you can be wrong and find out — you read the file. With an idea, a confident plan that does not match what is in the person's head reads exactly like a good one, right up until they see it built. Every rule below exists to fight that.
+
+The second thing, and it is the harder one:
+
+> **They do not know what they don't know, and they do not know what they need.**
+
+Non-technical people describe apps in terms of what they have seen. They will ask for the thing they saw on Instagram. Your job is not to transcribe their request and it is not to substitute your own product taste for theirs — it is to get at **the job they are trying to do**, then bring the technical judgement they cannot bring: what is possible, what is expensive, what already exists, and what the hard part really is. They own the *what*. You own the *how*, and you own telling them when the *what* is going to cost more than they think.
+
+**Never let a planning session end with only their words in it.** If the plan contains nothing they could not have written themselves, you have taken dictation, not planned.
+
+---
+
+## 0. Detect where the project already is
+
+Same entry as every other skill in the pack — you may not be starting from nothing even when the *code* is nothing.
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state   # read-only snapshot; prints the projectId
+node ../codespring/scripts/state.mjs       /tmp/cs-state          # summary line + booleans and counts
+node ../codespring/scripts/check-map.mjs   /tmp/cs-state          # map faults, before you add to them
+```
+
+Read `projectId` from the **local** `.codespring/config.json` and print it before any write.
+
+- **A map already exists** → you are extending a plan, not starting one. Run the map-quality ladder in `target-map.md`, match on title, never re-create.
+- **Code exists after all** → wrong skill. Route to `cs-build-import-codebase` (or `cs-build-audit-codebase` if it fails any of the five questions in `project-state.md`). A half-built prototype from Lovable/Base44/v0 **is** code, even if the user calls it "just a mockup" — go and look before you accept "there's nothing there yet."
+- Not linked → link. Team workspace projects must be created in the **web app** first (`pitfalls.md`).
+
+### ⚠️ Give the new project its own directory — the trap unique to this skill
+
+Every other skill in the pack runs inside the repo it is mapping. **You have no repo**, so there is no natural home — and the directory you happen to be standing in is very often the parent folder of the user's *other* projects, which already has a `.codespring/config.json` pointing at one of them.
+
+**Running `codespring init` there silently repoints that config at your new project**, and the next session on the sibling project writes into the wrong place. Real case: a planning run started in a folder whose config pointed at a live Mac app project; creating the new project in a fresh subfolder was the only thing that prevented hijacking it.
+
+```bash
+codespring status                       # ALWAYS run first — whose project is this directory linked to?
+mkdir -p "<AppName>" && cd "<AppName>"  # a new directory for the new project, even with no code in it
+codespring project create --name "..." --description "..."
+codespring init --project <newId> --force
+codespring status                       # confirm the new id
+cat ../.codespring/config.json          # confirm the PARENT's link is untouched
+```
+
+That folder becomes the repo later, so this is not throwaway scaffolding. **Never `init` into a directory that is already linked to something else**, and never assume an empty-looking folder is unlinked — check.
+
+## 1. Get the raw material in
+
+The input is whatever exists: a call recording or transcript, a voice note, a Loom, screenshots of apps they like, a rambling paragraph, or a live conversation.
+
+**Read all of it before asking a single question.** Turning up to an interview with questions the recording already answered is the fastest way to lose a non-technical person's confidence.
+
+**Extract, do not summarise.** Pull out, in their own words:
+- who it is for and what that person is trying to get done
+- every screen, button, moment or behaviour they described
+- every constraint they stated (platform, offline, price, deadline, audience age, accessibility)
+- every reference app or screenshot, and specifically **what they liked about it**
+- anything they said twice — repetition marks what actually matters to them
+- anything they rejected, and why
+
+**Keep their phrasing.** *"Five minutes is the floor, anything less isn't worth the time"* survives into the note and eventually into the PRD; *"configurable session duration"* does not. Their words carry constraints and reasons that yours will quietly drop.
+
+Full method, including how to mine a sales call and what to do when the only input is a rambling voice note: `references/elicitation.md`.
+
+## 1a. Ask what they are set on building it in — before anything else
+
+One question, asked early, because the answer can invalidate the whole plan:
+
+> **"Are you set on building this in a particular tool? Base44, Lovable, v0, Replit, Bubble, something else?"**
+
+Non-technical people frequently already have a subscription and a half-learned tool, and they will not mention it unless asked — it does not feel like a requirement to them, it feels like a detail. **It is a hard constraint.** AI web-app builders emit web apps and cannot produce a native desktop or mobile app at all, so a plan that says "Mac app" is a plan they cannot execute.
+
+Ask it here, in §1, not at §4 when the platform is being chosen — by then you have already reasoned toward an answer their tool may not be able to reach.
+
+Follow-ups: *are you committed to it or just already paying for it?*, *who maintains this in a year?* Then carry the answer into §4 and resolve any conflict openly (`references/platform-choice.md` — *"the constraint that overrules capability"*).
+
+## 2. Find the job before you find the features
+
+One paragraph, agreed out loud, before anything else:
+
+> **Who** opens this, **what** are they trying to get done, **what happens today** without it, and **how do we know it worked?**
+
+If you cannot write that paragraph, you do not have enough to plan and more feature discussion will not help. Go back to §1.
+
+The last part is not decoration. *"She does her three sessions a week"* is a testable outcome; *"she feels supported"* is not, and an app cannot be aimed at it.
+
+## 3. Walk the screens with them
+
+This is the elicitation engine and it works on people who cannot describe software:
+
+> *Close your eyes and imagine you're using it. It's open in front of you. What's the first thing you see? What do you click? What happens then?*
+
+Walk it as **a journey, not a feature list**: open → first screen → first click → the main thing they came to do → done → what brings them back tomorrow. Non-technical people are excellent at this and hopeless at "what are your core features."
+
+**Sidebar-first.** For a desktop or web app, the question *"what's in the sidebar?"* produces the core feature list almost directly, and it produces one a user would recognise. Ask it in those words.
+
+**Treat the sidebar as a prompt for finding core features, not as the definition of one.** A core feature is **a big thing the user does**. The sidebar is simply where most of them are listed, which is why the question works — but some apps have a major screen you reach by pressing a button rather than by clicking the nav, and it is still a core feature. *How* the user gets to it is a navigation detail for the note, not the thing that decides whether it goes on the map.
+
+The test that actually matters: **is this a big thing the user does, and would leaving it off hide a large part of the build?** Both yes → it is a core feature, sidebar or not.
+
+Still aim for 4–8 (`target-map.md`). If applying this puts you at ten, the list is too granular, not too honest.
+
+**Then walk the *second* user — the one who puts the content in.** People describe the app from the point of view of the person using it and never mention who fills it with exercises, lessons, templates or programmes. An authoring tool is a second application and is routinely 30–50% of a build while appearing nowhere in the feature list. Ask where the content comes from on day one, who adds more, whether it differs per user, who decides the order, and **what happens on day two** — the most-skipped question in app planning. `references/elicitation.md`.
+
+Script, follow-up questions, and what never to ask: `references/elicitation.md`.
+
+### 3a. Name every kind of user — including the owner
+
+Ask this **before the feature list is final**, because the answer adds features to it:
+
+> **"Who are all the different kinds of people who use this, what can each of them see and do, and who administers it?"**
+
+They will describe one user. There are usually four or five: the end customer; **their** customers, who often receive an output without ever logging in; staff; partners; and **the owner of the business running the app**.
+
+**Almost every app needs an admin surface for the owner** — see who has signed up, manage plans and access, and edit the data the app depends on. It is missed at planning time on nearly every project and it is expensive to retrofit, because it changes the permission model rather than adding a screen. Ask what **plans or tiers** exist and what each unlocks, because that decides whether entitlement is one column or a whole subsystem. And state the security rule plainly: **permissions are enforced at the database and on the server, never only in the interface** — hiding a button is not access control.
+
+Full list of actors people forget, and the owner-only data problem: `references/data-and-shape.md` §3.
+
+## 4. Pick the platform from what the app must do
+
+Do this **before** the feature list is final, because it changes what is buildable.
+
+Decide on **capability**, never on preference or fashion:
+
+| Needs | Points to |
+|---|---|
+| Camera + real-time local ML, filesystem access, background/menubar, true offline, heavy local compute | **Desktop (Mac)** |
+| Shared by link, signup funnel, SEO, "just send it to them", cross-platform from day one | **Web** |
+| Genuinely mobile-first — in a gym, in a field, out of the house | **Mobile** |
+
+**iOS is almost never right for a v1**: review latency, Apple's cut, and an older audience that mostly prefers a larger screen. Say so plainly and say why.
+
+Then state the consequences of the choice out loud, because they are what bite later: signing and notarization, how the thing gets distributed, how payment works, whether "offline" is real. Full decision table and the consequences of each: `references/platform-choice.md`.
+
+**Then ask the question that can overrule all of it: *what will they actually build it in, and who maintains it after you leave?*** Capability says what the app *needs*. This says what the person can *keep*. If they are committed to a tool that cannot produce the platform capability points at — an AI web-app builder cannot emit a native desktop app — you have a genuine conflict, and the resolution is a conversation, not a silent override in either direction. Do not quietly plan a platform they cannot build in, and do not quietly drop a capability because their tool is easier. Put both costs on the table and let them choose. `references/platform-choice.md` — *"the constraint that overrules capability"*.
+
+### 4a. Inherit the stack from an app they already own
+
+Once the platform is chosen, **ask whether they already have a working app on that platform** — theirs, or one you built for them. **Ask; do not go looking.** A codebase sitting in a neighbouring folder is not automatically a reference — it may be internal, abandoned, or on a platform this project has just ruled out. Confirm it is a deliberate template before reading a line of it, and drop it the moment the platform decision moves.
+
+If it is confirmed, read its manifest and mirror it: same language version, same dependencies, same database layer, same design-system target, same build and release scripts.
+
+This is not laziness, it is the single cheapest quality decision available:
+
+- The stack is **already proven to ship** on that platform, including the tedious parts — signing, notarization, auto-update, crash reporting.
+- The **design system already exists**, so the visual language is consistent and free.
+- **Components you were about to spec may already be built.** In a real run, a client wanted a glass-blurred panel with an inset white card; the reference app's design-system target already contained exactly those two components. That is a whole task that evaporated because someone looked.
+- The person maintaining both apps only has to know one stack.
+
+So: read the reference app's `Package.swift` / `package.json` / equivalent, its design-system folder, and its `scripts/`. Record the inherited stack on the map's tech-stack node, and **name the reference app in the notes** so the builder knows where to copy patterns from rather than inventing them.
+
+If there is no reference app, choose a boring, well-trodden stack and say why.
+
+## 5. Find the hard part, and find who already solved it
+
+**Every app has exactly one genuinely hard thing.** The rest is screens, forms and lists. A plan that has not named the hard thing is not a plan — it is a wish, and the build will discover it in week three.
+
+Say which part it is, out loud, then:
+
+1. **Search for prior art before designing anything custom.** Someone has almost certainly solved this. Use WebSearch/WebFetch; look for maintained libraries, platform-native frameworks (often the best answer and the most overlooked), and open-source repos.
+2. **Check the licence, every time.** The most googlable library in a field is frequently the one that cannot be used commercially. This kills projects late and expensively.
+3. **Prefer the platform-native framework** where one exists — no dependency, no licence question, better performance, and it survives OS updates.
+4. **The hard part becomes task #1**, as a throwaway spike that proves it works on real input before a single screen is designed.
+
+Method, the licence trap with worked examples, and how to write the spike: `references/hard-part-first.md`.
+
+## 5a. Run the systems checks — the questions nobody asks for
+
+Four more questions, asked out loud in the Think phase, before the v1 cut and before the gate. Nobody requests any of this and no user can describe it, but each one is **cheap as a decision and expensive as a retrofit**. The fifth — who the users are — was §3a, because it changes the feature list.
+
+1. **"What figures does this app rely on that somebody else publishes — and what happens on the day they change?"**
+   Tax and duty rates, statutory thresholds, interest or benefit rates, tariffs, postage, currency, compliance limits, licence fees, minimum wage. If there are any: **they belong in the database, not in the code**, as rows carrying **the dates they apply between**; the app resolves the value that applied **at the date of the thing being modelled** — including across a change already announced for a future date; anything saved **records which version produced it**; the app **knows when its data has expired** and says so. **Do not assume an API exists** — for many public datasets there is none, and scraping the publisher's site is more fragile than a maintained table because it fails by shipping wrong numbers rather than by stopping. Plan the honest version: a table, an import script, a dated review, and a written record of sources. And **give the owner a screen to edit it**, because they will need to model an announced-but-not-yet-legislated change before you can ship an update.
+2. **"Is this app one of several that will share the same core logic?"**
+   If yes, the shared part is **one package every product imports** — never copied, never reimplemented. It must be **pure**: no database, no network, no framework, no clock, no randomness; everything it needs is passed in. Give it a **version number**, and split it into **small files by topic**, because one huge file is what makes people copy a function out instead of importing it. Two copies always diverge, silently, until two parts of the business quote different numbers for the same thing.
+3. **"Does the organisation already have a database, and is another product — or another person — already working in it?"**
+   **Default to a separate database per product**, with the same ownership boundary in both so they can be merged later. Merging two well-shaped databases is a migration; unpicking one tangled database is a rebuild.
+4. **"Does the user need to know how current the data is, or prove where a figure came from?"**
+   If an output drives a financial, legal or medical decision it must show **what data it used and as at when**. Never assert currency the app cannot verify. Label estimates and assumptions **where they appear**, and let the user override them.
+
+Reasoning, the rules in full, and a worked example for each: `references/data-and-shape.md`.
+
+## 6. Cut it to a v1 that can actually ship
+
+They will describe the finished product. Your job is the **first version that delivers the job in §2 end to end** — one complete loop, working, sellable.
+
+- **One loop, whole.** A user opens it, does the main thing, and gets the outcome. Nothing half-present.
+- **Cut breadth, never depth.** Five features at 60% is a broken app. One feature at 100% is a product.
+- **Tracking features are not v1 features.** Anything whose value is "the user types in what they did" has near-zero pull and dies in week two. Features where the app *does something for them* are what people come back to. See `references/v1-scope.md` — this is the most common way an idea-plan goes wrong.
+- **The revenue gate:** if the person needs this to make money, ask *"how does someone pay for this?"* and make sure the answer exists in v1. A v1 with no way to take money cannot produce revenue no matter how good it is, and this gets missed on nearly every plan because it is not a feature anyone is excited about.
+- **Ask what the real cost is — it is often content, not code.** Apps that need a media library, a data set, an exercise catalogue or a document corpus are usually 20% software and 80% acquiring the content. If so, say it now and plan the pipeline, because it is the schedule risk. `references/v1-scope.md`.
+
+Name what is *not* in v1 as explicitly as what is — an unspoken cut is heard as a broken promise later.
+
+## 6a. THE GATE — read it back, get a yes
+
+**Nothing has been written yet. Do not proceed without an explicit go-ahead.**
+
+Narrate the plan back the way they described it in §3 — *"they open it, they see X, they click Y, then Z happens"* — then add the things they could not have supplied themselves:
+
+1. **The platform call and why** (one sentence, repeatable).
+2. **The hard part, and the named thing that solves it** — including its licence.
+3. **Every kind of user, and what the owner gets** — the admin surface, the plans, and what only the owner can edit (§3a).
+4. **Any figures somebody else publishes**, where they will live, who updates them and how often (§5a) — plus the database call, if there was one to make.
+5. **What v1 is, and explicitly what it is not.**
+6. **How someone pays**, if money is needed.
+
+Then ask, in these words: **"What did I get wrong, and what's missing?"**
+
+People correct a story. They rubber-stamp a feature list. This is the last cheap moment to be wrong — after §7 the plan exists as a map, notes and tasks, and changing it costs real work.
+
+Iterate here as many times as it takes. **Only when they say yes, continue.**
+
+## 7. Write the map
+
+Identical mechanics to `cs-build-import-codebase` §4 — the node model, the one-sentence card rule and the notes-are-root-only constraint all come from `target-map.md`. Do not re-derive them.
+
+```bash
+codespring mindmap set-info --title "..." --description "..."
+codespring mindmap tech-stack --replace --add '[{"id":"tech-...","title":"...","description":"Frontend"}, ...]'
+codespring mindmap features --add '[{"title":"Today","description":"..."}, ...]'   # CORE features; keep the returned ids
+codespring feature create --parent <coreId> --title "..." --description "..."       # sub-features
+codespring mindmap note <coreId> --title "How it works — X" --text "$(cat note.txt)"
+```
+
+**`codespring mindmap features --replace` does NOT replace — it appends and duplicates** (`pitfalls.md`). Diff by title and add only what is missing. Recovery: `codespring feature delete <id> --yes`.
+
+**The note is the whole deliverable on this path.** With no code to read, the note is the *only* context the PRD generator gets — a thin note here produces a thin PRD, and there is no repo to fall back on. Each core feature's note carries:
+
+1. **What this feature does**, in the user's own words wherever possible.
+2. **The screens and the journey** — what the user sees, clicks, and gets.
+3. **The decisions and why** — platform, chosen library and its licence, the data model in plain terms, and anything deliberately deferred with the reason.
+4. **The §5a answers that belong to this feature** — which published figures it uses and where they live, what it shares with another product, who is allowed to see and edit each thing, and what the interface has to show about how current the data is. These are invisible in a feature list and they are what the PRD and the tasks need in order to build the right shape.
+5. **What is explicitly not in v1**, so it does not get quietly built.
+
+Write the notes **before** generating any PRD.
+
+## 7a. Hand off to `cs-build-ui-mockup` — BEFORE the PRDs
+
+**Do not generate PRDs from a plan nobody has seen.** The map and notes are agreed in words, and words are not enough: a person will sign off a written plan they have not actually understood, because prose lets both sides fill the gaps differently and neither notices.
+
+**Run `cs-build-ui-mockup`.** It builds a throwaway clickable mockup from these notes, runs the review that surfaces what the plan could not express — screen order, hierarchy, position, and choices that turn out to be incomplete — and writes every correction back into the notes and tasks.
+
+A real run produced **eleven corrections in ten minutes** from a plan that had already passed the gate and looked complete. None had surfaced in written review.
+
+Come back here only if the review changes the feature set. Otherwise the chain continues: mockup → `cs-build-create-prd` → `cs-build-create-tasks`.
+
+## 8. Verify
+
+Run the check, don't eyeball it:
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-verify
+node ../codespring/scripts/check-map.mjs   /tmp/cs-verify --expect-core <the count you intended>
+```
+
+Core count matches; no sub-features flattened to top level (re-parent with `codespring feature update <subId> --parent <coreId>`); no duplicate titles; one note per core feature. A non-zero exit is a real failure — fix it before reporting. Then give the project link `https://v2.codespring.app/project/<projectId>`.
+
+## 9. Hand off
+
+**PRDs → `cs-build-create-prd`** (Both, per core feature). Never generate a PRD for a feature with no note.
+**Tasks → `cs-build-create-tasks`**, with the §5 spike as task #1.
+**Then → `cs-build-feature`.**
+
+## 10. Report what now exists
+
+One short close, because the person needs to know what they own: the project link, the core features by name, that every one has a note, and **the single next action** — normally *"task #1 is the spike that proves the hard part; do that before anything else."*
+
+---
+
+## What good looks like
+
+- The **job paragraph** exists and was agreed before any feature was named.
+- The feature list came out of a **walked journey**, not a brainstorm, and lands at 4–8 core features a user would recognise as sidebar items.
+- The **platform was chosen on capability** and the consequences were stated, not chosen by default or by fashion.
+- The **hard part is named**, has real prior art with a **checked licence** whose obligation was stated in one line, and is task #1 as a spike.
+- **Every kind of user was enumerated before the feature list closed**, the owner has an admin surface, and permissions are stated as enforced on the server and in the database.
+- **Every figure somebody else publishes was named**, lives in dated rows rather than in code, resolves by the date being modelled, and has a real plan for staying updated — with no assumption that an API exists.
+- Where the same logic runs in more than one place, it is **one pure, versioned package** rather than a second copy, and the database decision was **deliberate** rather than inherited.
+- The new project got **its own directory**, and no sibling project's link was clobbered.
+- Where a proven app on the same platform already existed, its **stack and design system were inherited** rather than reinvented.
+- **v1 is one complete loop**, and if the person needs money from it, there is a way to pay in v1.
+- If the real cost is **content rather than code**, that was said out loud and a pipeline exists.
+- The **notes are thick** — they are the only context a PRD will get on this path.
+- **Nothing was written to CodeSpring before the gate**, and the plan was read back as a story with *"what did I get wrong?"* asked out loud.
+- The plan contains **technical judgement they could not have supplied themselves.** If it is only their words tidied up, it is dictation.

--- a/.claude/skills/cs-build-plan-app/references/data-and-shape.md
+++ b/.claude/skills/cs-build-plan-app/references/data-and-shape.md
@@ -1,0 +1,139 @@
+# The systems questions — data that goes stale, and the shape the app has to be
+
+Five checks that decide whether the app survives its second year. The named examples are **labelled worked examples** from real runs, not assumptions about the app in front of you.
+
+## Why these belong in planning and nowhere else
+
+Nobody asks for any of this. They are not features, they never appear in a walked journey (`elicitation.md`), and a user cannot describe them because they are invisible until the day they go wrong. But each one is **cheap as a decision and expensive as a retrofit** — changing where a number lives, who is allowed to edit it, or which database it sits in means touching every screen that reads it, and in one case it means changing the permission model of the whole app.
+
+So they are asked **during the Think phase, before the plan is read back at the gate.** The actor question (§3 below) has to come earliest of all, because it adds features to the list.
+
+The five, in the words to ask them in:
+
+| # | The question to ask |
+|---|---|
+| 1 | **"What figures does this app rely on that somebody else publishes — and what happens on the day they change?"** |
+| 2 | **"Is this app one of several that will share the same core logic? Is the same calculation, ruleset or model going to run in more than one place?"** |
+| 3 | **"Who are all the different kinds of people who use this, what can each of them see and do, and who administers it?"** |
+| 4 | **"Does the organisation already have a database, and is another product — or another person — already working in it?"** |
+| 5 | **"Does the user need to know how current the data is? Would they ever need to prove where a figure came from?"** |
+
+---
+
+## 1. Reference data that goes stale
+
+> **"What figures does this app rely on that somebody else publishes — and what happens on the day they change?"**
+
+Follow-ups: *how often do they change, who publishes them, and does anything tell us when they have?*
+
+**Reference data** here means any number the app uses but does not own — someone else decides it, publishes it on a schedule, and it is wrong for everyone from the moment it changes until the moment the app is updated. It is far more common than people expect: tax and duty rates, statutory thresholds, interest or benefit rates, shipping tariffs, postage prices, currency conversions, compliance limits, licence fees, minimum wage, contribution caps, mileage allowances.
+
+If the answer to the question is "none", say so and move on. If it is anything else, these rules apply.
+
+### The rules
+
+- **Reference data belongs in the database, not in the code.** This is the whole decision, and it is one sentence long. If a rate is typed into the code, updating it is a developer editing a file and shipping a new version of the app. If it is a row in a table, updating it is a data change — someone edits a value and every user has the new number immediately. Same number, completely different cost, forever.
+- **Every row carries the dates it applies between, not just a current value.** Two extra columns — *applies from* and *applies until* — turn a single figure into a history. Without them the app can only ever answer "what is it now", and it silently forgets that it ever said anything different.
+- **The app resolves which value applied at the date of the thing being modelled, not "the current one".** This is the rule people skip, and it matters in both directions. Looking backward: a document produced for last year must use last year's figures. Looking forward: **a projection that crosses a known future change must use the new value after that date** — an app modelling ten years ahead, with a rate change already announced for next April, is wrong from year two onward if it uses today's number all the way through.
+- **Anything the app saves that used those figures records which version produced it.** Store the inputs, the result, and the identifier of the reference data set behind it. Otherwise correcting a figure later silently changes a document a customer has already received, printed, or sent to their accountant — and nobody can reconstruct what the app said at the time or explain the difference.
+- **The app knows when its own data has expired, and says so.** If today is past the end date of every row, the app must show that it can no longer verify these figures, rather than continuing to present them as current. Software asserting currency it cannot check is the thing that costs trust (§5).
+- **Do not assume an API exists.** For a great many public datasets there is no feed at all, free or paid, and there never has been. Scraping the publisher's website is *more* fragile than a maintained table, not less: it breaks silently whenever a page is redesigned, and it fails by shipping a wrong number rather than by stopping. The realistic pattern, and the one to plan for, is unglamorous and reliable: **a table, a small import script, a dated annual review, and a written record of where each figure came from and when it was last checked.** Say this out loud at plan time, because "can't it just fetch them automatically?" comes up in every one of these conversations and deserves a settled answer rather than a repeated one.
+- **Give the owner a way to edit it.** They will need to model a change that has been announced but not yet legislated, or to correct something you got wrong, before you can realistically ship an update. That is an editing screen for the owner and nobody else, which is §3's job — and it is the most common reason the admin surface gets discovered too late.
+
+### Where it lands in the plan
+
+The reference table is part of the data model in the note; the annual review is a real, recurring job that belongs in the plan rather than in someone's memory; the owner's editing screen is a feature on the map. None of the three appears unless the question is asked.
+
+> **Worked example.** A property-investment calculator covering eight jurisdictions. Every jurisdiction's tax and duty tables were typed directly into a web page — and the same tables existed in **five places across two repositories**, two of which had already drifted, so the same property produced different figures depending on which page the user opened. **No government API exists for any of it**, in any of the eight jurisdictions, so the automatic-fetch idea that everybody proposes was never available. The correct shape was one dated table per jurisdiction in the database, a resolver that picks the rows applying at the date being modelled, a stamped version on every saved report, an expiry warning, and a screen where the owner can enter next year's rates the week they are announced.
+
+---
+
+## 2. Shared logic across more than one product
+
+> **"Is this app one of several that will share the same core logic? Is the same calculation, ruleset or model going to run in more than one place?"**
+
+Ask it even when the answer looks obviously "no" — a web app plus its own admin tool is already two places, and "we'll do a mobile version later" is the same answer arriving a year late.
+
+If it is genuinely one product with one place the logic runs, skip the rest of this section.
+
+### The rules
+
+- **The shared part becomes one package that every product imports.** A *package* here just means a self-contained folder of code with a name, which other projects depend on the way they depend on any other library. Never copy-pasted between projects, never reimplemented in a second language because it was easier at the time.
+- **The shared part is pure.** *Pure* means: given the same inputs it always returns the same answer, and it touches nothing else. No database access, no network calls, no framework imports, no reading the clock, no randomness. Anything it needs — including today's date and the reference data from §1 — is **passed in as an argument.** That constraint is not tidiness; it is the only thing that makes the same code usable in a browser, on a server, in a background job, and in a second product, and it is what makes it testable without any of them.
+- **Give it a version number**, and let anything it produces record which version produced it. Paired with the reference-data version from §1, that means any saved output can be explained: these inputs, that data set, this version of the rules.
+- **Structure it as several small files by topic, not one large one.** A single enormous file is precisely what makes the next person copy one function out of it instead of importing the package — and that copy is where the divergence starts.
+
+### The failure this prevents
+
+**Two copies of the same logic always diverge, and the divergence is invisible.** Nobody edits both. There is no error, no crash and no failing test — just two parts of the business quoting different numbers for the same thing, usually discovered by a customer, and usually long after both numbers have been sent to people.
+
+> **Worked example.** The same property calculator had its calculation engine in two places. The copy the secondary pages used sat a full financial year behind for nine days, so the identical property produced different government charges depending on which page it was opened from. Nothing failed and nothing was logged; there were no tests to notice. One imported package, pure, with a version stamped onto every saved report, removes the entire class of problem.
+
+---
+
+## 3. Who uses it, and what each of them can reach
+
+> **"Who are all the different kinds of people who use this, what can each of them see and do, and who administers it?"**
+
+**Ask this before the feature list is final**, because the answer adds features to it. It belongs next to the walked journey in `elicitation.md` — that section finds the second user who *puts the content in*; this one finds every remaining actor and what each is allowed to reach.
+
+### The rules
+
+- **Enumerate every actor, including the ones people forget.** They will describe one. There are usually four or five: the end customer; **their** customers or clients, who often receive an output without ever logging in; staff or team members; partners, resellers or referrers; and **the owner of the business running the app**. Write the list down, and for each one write what they can see and what they can do.
+- **Almost every app needs an admin surface for the owner.** A place to see who has signed up, manage plans and access, and edit the data the app depends on. It is missed at planning time on nearly every project, and it is expensive to retrofit for a specific reason: **it changes the permission model**, so it is not a screen bolted on at the end but a distinction that has to run through the data from the first day.
+- **Some data must be editable by the owner and by nobody else.** The reference data in §1 is the classic case: every user reads it, exactly one person changes it. That is a different kind of ownership from "this row belongs to this user", and both have to exist in the data design from the start.
+- **Ask what plans or tiers exist and what each one unlocks.** The answer decides whether entitlement — what this account is allowed to do — is a single column on an account, or a whole subsystem with limits, counters and upgrade paths. Those are very different builds and the difference is settled by one question.
+- **Permissions are enforced at the database and on the server, never only in the interface.** Hiding a button is not access control. The rule to state plainly: every request re-checks who is asking and what they own, on the server, and the database itself refuses to return rows that belong to somebody else — regardless of what the screen showed.
+
+> **Worked example.** The same property calculator was described as a tool for financial advisers, and the plan on the table had exactly one kind of user. There were four. The adviser used it; **the adviser's client** received the report as a document and was the person whose trust the whole thing depended on; the adviser's **firm** wanted to see what its people were producing; and **the owner of the business selling the app** needed to see who had signed up, manage their plans, and update eight jurisdictions of tax tables himself the week the budgets landed. Only the first was in the plan. The fourth is the one that changes the permission model.
+
+---
+
+## 4. Where the data lives, and who else is in it
+
+> **"Does the organisation already have a database, and is another product — or another person — already working in it?"**
+
+The tempting answer is "we already have one, put it in there." It is almost always wrong.
+
+### The rules
+
+- **Sharing a database between two products is the fastest route to confusion.** Three predictable costs: a table count where most of the tables belong to something else, so nobody can see the shape of either product; **name collisions** between them, where both want a table or a column called the obvious thing and one of them has to be renamed into something misleading; and permission mistakes, where a rule written for one product exposes its data through the other.
+- **Default to a separate database per product.** Same shape in both — in particular the same **tenant boundary**, meaning every row carries which account or organisation owns it, expressed the same way in both places. That is what keeps a later merge possible.
+- **Merging two well-shaped databases is a migration. Unpicking one tangled database is a rebuild.** That asymmetry is the whole argument: separate is reversible, shared is not.
+- **The argument is strongest when a non-technical owner is actively working in the existing database.** Two people with different tooling in one database — one editing rows through a dashboard by hand, one shipping schema changes from code — will collide, and the collision usually destroys someone's work rather than raising an error.
+
+> **Worked example.** An owner had a database already in daily use by another product, and was editing rows in it himself through the provider's dashboard. Adding the new app's tables there would have put both products' tables in one list, put a hand-editing human and an automated migration in the same place, and made every permission rule twice as hard to reason about. Separate database, identical ownership column in both, merge later if it is ever actually wanted.
+
+---
+
+## 5. Freshness and provenance in the interface
+
+> **"Does the user need to know how current the data is? Would they ever need to prove where a figure came from?"**
+
+Checks 1 and 2 decide what the app *knows*. This one decides what it *says*, and it is the half that customers actually see.
+
+### The rules
+
+- **If an output is used to make a financial, legal or medical decision, show what data it used and as at when.** A line saying which figures were applied and the date they were current to, on the screen and on anything exported or printed. This is what makes an output defensible months later, when the numbers have moved and somebody asks why the document says what it says.
+- **Never present a figure as authoritative when the app cannot verify it is current.** A printed claim like *"rates current for this financial year"* sitting next to numbers that nothing checks is worse than printing no claim at all: it converts an ordinary staleness problem into a false statement the business has made in writing.
+- **If a value is an estimate or an assumption, say so where it appears, and let the user override it.** Not in a footnote, not in a help page — next to the number. The nastiest version of this failure is a field that is honestly labelled as estimated in one mode and loses the label in another, so the same guess is presented as a precise result.
+- Assumptions presented as precise results are **a trust problem, not a cosmetic one.** A user who catches one number that was quietly invented stops believing all the others, including the correct ones, and does not come back to check.
+
+> **Worked example.** A generated property report named its government source and financial year beside figures that nothing validated — including for an unrecognised location, where every government charge came out as zero and the report presented the zeros with the same confidence as everything else. The fix was not a bigger disclaimer: it was the app knowing which dated data set it used, printing that data set and its as-at date on the report, refusing to produce charges at all for a location it does not recognise, and labelling every estimated input as estimated at the point it is shown.
+
+---
+
+## What good looks like
+
+- [ ] Every figure the app relies on that **somebody else publishes** is named, with how often it changes and who publishes it.
+- [ ] That data lives in **dated rows in the database**, never in code, and the app resolves the value that applied **at the date being modelled** — including across a known future change.
+- [ ] Saved outputs record **which version of the data and which version of the logic** produced them.
+- [ ] The app can tell when its data has **expired**, and says so instead of asserting currency.
+- [ ] There is a plan for **keeping it updated** — a table, an import script, a dated review, a record of sources — and no assumption that an API exists.
+- [ ] If the same logic runs in more than one place, it is **one imported package, pure and versioned**, split into small files by topic.
+- [ ] **Every actor is listed** with what they can see and do — including the customer's customer, and the owner of the business.
+- [ ] There is an **admin surface for the owner**, including editing the reference data, and it was in the plan rather than added later.
+- [ ] **Plans and tiers** are settled, so entitlement is scoped as either a column or a subsystem deliberately.
+- [ ] Permissions are **enforced on the server and in the database**, and the plan says so in those words.
+- [ ] The database decision is **deliberate** — separate per product by default, with the same ownership boundary in both.
+- [ ] Anything used for a real decision shows **what data it used, as at when**, and every estimate is **labelled and overridable** where it appears.

--- a/.claude/skills/cs-build-plan-app/references/elicitation.md
+++ b/.claude/skills/cs-build-plan-app/references/elicitation.md
@@ -1,0 +1,156 @@
+# Getting the real app out of someone's head
+
+Applies whether the input is a live conversation, a sales-call recording, a voice note, or three screenshots and a paragraph. The named examples are **labelled worked examples** from real runs, not assumptions about the person in front of you.
+
+## The problem this solves
+
+> **They do not know what they don't know, and they do not know what they need.**
+
+A non-technical person describes an app in terms of things they have already seen. They will ask for the thing from the Instagram reel. That request is **evidence**, not a specification — it tells you what appealed to them, and your job is to find out *why* it appealed, because the why is the actual requirement.
+
+Two failure modes, and they are opposites:
+
+- **Dictation.** You write down what they said, tidied up. The plan contains no technical judgement, no platform reasoning, no prior art, and no cut list. It reads well and it is worthless — they could have written it themselves.
+- **Substitution.** You decide what the app should be, because you can see a better product. They nod along in the call and then never recognise the thing that gets built.
+
+The line: **they own the *what*, you own the *how*** — and you own telling them when the *what* costs more than they think.
+
+---
+
+## Mining a recording
+
+**Read or listen to all of it before you ask a single question.** Turning up with questions the recording already answered is the fastest way to lose a non-technical person's confidence — they told you, and now they think you weren't listening.
+
+Pull out, verbatim where you can:
+
+| Look for | Why it matters |
+|---|---|
+| Who it is for, in their words | The audience constrains everything — a 78-year-old beginner is a different app from a 30-year-old gym-goer |
+| Every screen, button, moment they described | This is the journey; you will replay it in the walkthrough |
+| Every **number** they said | Numbers are hard requirements in disguise: *"five minutes is the floor"*, *"up to twenty"*, *"three times a week"* |
+| Every constraint | Platform, offline, price, deadline, audience age, accessibility |
+| Every reference app or screenshot, **and what they liked about it** | The *what they liked* is the requirement; the app itself is just where they saw it |
+| **Anything they said twice** | Repetition marks what actually matters to them. This is the single highest-signal thing in a transcript |
+| Anything they rejected, and why | Prevents you proposing it back to them in an hour |
+| Their **own domain expertise** | Often the most valuable asset in the whole project and almost always under-used |
+
+**Extract, do not summarise.** Summarising is lossy in exactly the wrong direction — it keeps the features and drops the reasons.
+
+**Keep their phrasing all the way into the note.** *"Anything lower than five minutes is not worth the time"* survives into the note and eventually into the PRD, carrying its own justification. *"Configurable session duration"* is the same fact with the reason amputated, and the reason is what stops someone building a slider from 1 to 90.
+
+### What a transcript will not give you
+
+Recordings are full of *what* and empty of *why*. They also systematically miss:
+- what happens when it goes wrong
+- what brings someone back tomorrow
+- how anyone pays
+- what happens the very first time someone opens it, before there is any data
+
+Those are your questions.
+
+---
+
+## The walkthrough — the elicitation engine
+
+This works on people who cannot describe software:
+
+> *Close your eyes and imagine you're using it. It's open in front of you. What's the first thing you see? What do you click? What happens then?*
+
+Walk it as **a journey, not a feature list**:
+
+1. They open it. What is on screen?
+2. What do they click first?
+3. Now they are doing the main thing they came for — describe it, moment by moment.
+4. They finish. What do they see?
+5. What brings them back tomorrow?
+6. What happens the **first** time they ever open it, when there is nothing in there yet?
+
+Step 6 is the one everyone forgets, and it is where non-technical apps most often feel broken — an empty dashboard with no data reads as "this doesn't work."
+
+**Sidebar-first.** For desktop or web, ask literally: *"if there's a sidebar down the left, what's in it?"* This produces the core feature list almost directly, and it produces one the user recognises — which is exactly the 4–8 sidebar-item test in `target-map.md`. It is a much better question than *"what are your core features"*, which produces a wish list.
+
+### Questions that work
+
+- *"What happens today, without the app?"* — finds the real job and the real competitor, which is usually a notebook, a spreadsheet, or nothing.
+- *"Who is the person opening this, and what kind of day are they having?"* — surfaces the audience constraints they would never think to state.
+- *"What would make them close it and not come back?"* — finds the trust-breakers. Extremely high yield.
+- *"Show me the thing you saw that you liked. What specifically about it?"*
+- *"If it only did one thing brilliantly, which one?"* — the v1 cut, asked in a way they can answer.
+- *"How does somebody pay for this?"* — see `v1-scope.md`. Nearly always missing.
+- *"What do you already have that we should use?"* — audience, content, an email list, professional credibility, a domain. Usually under-used.
+
+### Questions that do not work
+
+- *"What are your core features?"* → a wish list, not a product.
+- *"Do you want it to be simple or powerful?"* → everyone says both.
+- *"Should it be a web app or a native app?"* → not their decision, and they will answer on vibes. Decide it on capability (`platform-choice.md`) and then **tell them the call and the reason**.
+- *"What's your tech stack preference?"* → they do not have one, and asking makes them feel stupid.
+- Anything with an acronym in it.
+
+---
+
+## Handling "I saw this on Instagram"
+
+Reference material is good — take it. Then interrogate it once:
+
+1. **What specifically did you like?** Usually one mechanic, not the whole app.
+2. **Would your person like it, or do you like it?** Not the same, especially across an age gap.
+3. **What does it do that yours must not do?**
+
+Then say plainly whether the thing is cheap or expensive to build. A reference that is one afternoon of work should be taken wholesale; one that is the entire product should be discussed now, not discovered in week three.
+
+**Worked example.** A client wanted a streak display copied from a cycling app — flame, day-of-week dots, the lot. Cheap to build, so take it. But the reference counted *consecutive days*, and the app was strength training for beginners over 50, where **rest days are physiologically required**. A daily streak would have punished correct behaviour and broken on week one. The fix was to keep the exact visual and change the unit to *weeks hitting a target* — which the reference screenshot was already showing anyway ("1 Weeks"). Same design, opposite behaviour. **Copy the look; re-derive the rule.**
+
+---
+
+## The second user nobody mentions — who puts the content in?
+
+People describe the app from the point of view of the person *using* it. They almost never describe the person who **fills it with content**, even when that person is themselves.
+
+If the app shows exercises, lessons, templates, recipes, programmes, questions, or any other catalogue, ask all of these:
+
+- **Where does the content come from on day one?** Shipped inside the app, or entered by someone?
+- **Who adds more later, and how?** Them, in a tool you have to build? You, by hand? Nobody?
+- **Does it differ per user?** A coach assigning different programmes to different clients is a **completely different app** from a fixed catalogue everyone gets — accounts, assignment, roles, a second interface.
+- **Who decides the order?** The app, on a rule? The user, freely? The coach, in advance?
+- **What happens on day two?** The single most-skipped question. *Is it the same as day one?* If not, something has to decide — and that decision rule is a feature nobody has mentioned yet.
+
+**Why this matters more than it sounds:** an authoring tool is a second application. It has its own screens, its own validation and its own testing, and it is routinely 30–50% of the build while appearing nowhere in the feature list. It is also the most common cause of *"I thought we were nearly done."*
+
+**The cheap answer is almost always the right v1 answer:** ship a fixed catalogue inside the app, authored by hand as data before release. No authoring UI, no accounts, no assignment. Add the tool later, once anyone has proved they want to change the content.
+
+**Worked example.** A coach's exercise app: the assumption was that she would need an admin app to record and add exercises. The v1 answer was a hand-authored catalogue file shipped in the bundle — nothing to build, nothing to film, nothing for her to learn. The admin tool became a v2 question to be answered by whether she ever actually asks for it.
+
+**Watch for the ordering rule specifically.** *"They shouldn't do the same thing every day"* sounds like a preference and is actually a scheduling feature with real edge cases — what if they skip a day, do half a session, or do it twice? Get the rule stated in one sentence at plan time (*"a cursor through the unlocked list that advances only on completion"*), because otherwise it gets invented during the build.
+
+---
+
+## When the input is one long ramble
+
+Common, and fine. Do this in order:
+
+1. **Separate ideas from the app.** People bring three or four ideas to a planning session. Get them listed and get one chosen before planning anything. The others are recorded and parked, not discussed.
+2. **Separate the app from the business.** *"I need money by September"* is a real constraint that shapes v1 scope, but it is not a feature. Note it under the job (§2 of the skill), where it belongs.
+3. **Separate what they want from what they have seen.**
+4. **Find the thing they said twice.** That is the centre of the app.
+
+---
+
+## Before you leave the interview
+
+You need all of these. If any is missing, ask now — it is cheap here and expensive later.
+
+- [ ] The job paragraph: **who**, **what they're trying to get done**, **what happens today without it**, **how we know it worked**.
+- [ ] The journey, walked start to finish, including the very first launch.
+- [ ] Every number they stated.
+- [ ] The audience's real constraints — age, ability, device, environment, how much patience they have.
+- [ ] What would make someone close it and never come back.
+- [ ] How money changes hands, if it needs to.
+- [ ] What they already have that the plan should use.
+- [ ] What they have explicitly rejected.
+
+## The test
+
+**Would they recognise this as their app, and does it contain at least one thing they could not have told you?**
+
+Both halves are required. The first alone is dictation. The second alone is substitution.

--- a/.claude/skills/cs-build-plan-app/references/hard-part-first.md
+++ b/.claude/skills/cs-build-plan-app/references/hard-part-first.md
@@ -1,0 +1,143 @@
+# Find the hard part, and find who already solved it
+
+## Every app has exactly one genuinely hard thing
+
+The rest is screens, forms, lists and buttons — well-understood work that an AI agent does quickly and reliably. One part is not, and it decides whether the app is possible at the quality the person imagines.
+
+**A plan that has not named the hard part is not a plan.** It is a wish with a feature list attached, and the build discovers the hard part in week three, which is the worst possible moment: after the screens are built around an assumption that turns out to be false.
+
+### Finding it
+
+Walk the journey from `elicitation.md` and ask at each step: *if I had to build only this, would I know how?*
+
+The hard part is usually one of:
+
+| Kind | Examples |
+|---|---|
+| **Real-time perception** | camera, pose, audio, video processing |
+| **Getting data out of a mess** | receipts, PDFs, faxes, handwriting, scraping |
+| **A domain rule nobody has written down** | tax logic, clinical scheduling, compliance |
+| **Sync, offline-first, or multi-user state** | conflict resolution is always harder than it looks |
+| **A content or data corpus that must exist** | see `v1-scope.md` — often the real cost, and it is not a coding problem at all |
+| **An integration you do not control** | a system with no API, or a hostile one |
+
+If you genuinely cannot find a hard part, the app is a CRUD app. Say so — that is **good news**, it means fast and cheap, and the person should hear it.
+
+---
+
+## Search for prior art before designing anything custom
+
+Somebody has solved this. Use WebSearch/WebFetch and look, in this order:
+
+1. **The platform's own framework.** The most overlooked answer and frequently the best one — no dependency, no licence question, better performance, maintained by the OS vendor, survives OS updates.
+2. **A maintained cross-platform library** with real adoption and recent commits.
+3. **An API** you can pay for — sometimes correct for v1, but check the per-user cost against the price of the app before committing.
+4. **A research repo.** Usually the worst option: unmaintained, undocumented, and see the licence trap below.
+
+Judge each candidate on: **licence**, **maintenance** (last commit, open issues), **platform fit**, **whether it runs locally or needs a server**, and **whether a non-expert can install it** — a dependency that needs Python, CUDA and a compiler is not viable for the audience these apps are built for.
+
+---
+
+## The licence trap — check it, every time
+
+**The most googlable library in a field is very often the one that cannot be used commercially.** This kills projects late, after the app is built around it, and the person planning has no idea it is a risk.
+
+Two patterns to recognise:
+
+- **Academic / non-commercial licences.** Free to try, illegal to sell. The author will license commercially for a fee, sometimes a large one.
+- **AGPL and other strong copyleft.** Legally usable, but the reciprocity obligations are usually incompatible with shipping a closed commercial app. Many popular ML repos are AGPL specifically to sell commercial exemptions.
+
+**Permissive (MIT, Apache-2.0, BSD) is what you want**, and a platform-native framework has no licence question at all.
+
+### Say the permissive part out loud — the fear is usually misplaced
+
+Non-technical people hear "open source" and assume selling is forbidden, then rule out a perfectly good library. A real client asked *"can I really sell using Apache-2.0?"* and was about to reject the correct answer over it. Three sentences fix it, so say them:
+
+| Licence | Can you sell a closed-source app with it? | What you must do |
+|---|---|---|
+| **MIT / BSD / Apache-2.0** | **Yes.** Commercial use and closed source are explicitly permitted | Include the licence text (an acknowledgements screen). Apache-2.0 also asks you to pass on any `NOTICE` file |
+| **LGPL** | Usually, if dynamically linked | Get advice if you are static-linking |
+| **GPL / AGPL** | **No**, not closed-source. AGPL extends this to network use | Buy a commercial exemption, or do not use it |
+| **Non-commercial / academic** | **No**, at any price without a negotiated deal | Contact the owner; expect real money |
+| **Platform framework** (Apple, Microsoft, Android) | **Yes** | Nothing — it is part of the OS |
+
+**The distinction that matters is permissive vs copyleft vs non-commercial, not open vs closed.** Say which bucket the chosen library is in and what the obligation is, in one line, in the note. It removes a blocker that has nothing to do with engineering.
+
+### Permissive still has obligations — make them a task
+
+"You can sell it" is not "you can ignore it". Every permissive licence asks for something small, and because it is small it gets skipped and then discovered at launch. **Write it as a real task on the board**, not as a line in a note nobody opens:
+
+- **Ship the licence text.** MIT, BSD and Apache-2.0 all require the copyright notice and licence text to travel with the distributed software. In an app that means an **Acknowledgements / Open Source Licences screen** — normally under Settings or About — listing each dependency, its copyright line and its full licence text.
+- **Apache-2.0 additionally requires passing on any `NOTICE` file** the project ships, and flagging files you modified.
+- **Keep a `LICENSES/` or `THIRD-PARTY-NOTICES` file in the repo** as the source of truth, generated from the dependency list rather than maintained by hand, so a new dependency cannot silently arrive without its notice.
+- **Model weights can carry a different licence from the code that loads them.** Check both. A permissively-licensed inference library shipping restrictively-licensed weights is a real and easy trap.
+- **Trademarks are not licensed by any of these.** You may use the code; you may not imply the project endorses your product.
+
+None of this is onerous — it is one screen and one generated file — but it belongs in the plan, because the moment to add it is while the app is being built and not the week it ships.
+
+### Worked example — human pose estimation
+
+Real research done for a follow-along exercise app. **The two most searchable options were both unusable.**
+
+| Option | Licence | Verdict |
+|---|---|---|
+| **Apple Vision** (`VNDetectHumanBodyPoseRequest`) | System framework, no separate licence | **Chosen.** On-device, no dependency, no install burden, ~19 joints, fast on Apple silicon |
+| **MediaPipe / BlazePose** (Google) | Apache-2.0 | Good fallback. More landmarks, cross-platform, has a browser build |
+| **MoveNet** (TensorFlow) | Apache-2.0 | Viable, very fast, fewer keypoints |
+| **OpenPose** (CMU) | **Non-commercial / academic** | **Cannot ship.** Commercial licence costs real money |
+| **Ultralytics YOLO-pose** | **AGPL-3.0** | **Cannot ship closed-source** without buying the commercial licence |
+
+The lesson generalises: **the top two search results were the two that would have ended the project**, and the right answer was the platform framework nobody searches for because it is not a GitHub repo.
+
+**Verify licences yourself at plan time.** The table above is a starting point and a demonstration of the risk, not a warranty — projects relicense, and a v1 answer can be wrong a year later.
+
+---
+
+## Make the hard part task #1
+
+**The spike comes before any screen.** It is a throwaway whose only job is to answer *does this actually work, on real input, at the quality we need?*
+
+A good spike:
+
+- runs on **realistic input**, not the library's demo video — the actual camera, the actual lighting, the actual crumpled receipt, the actual 70-year-old partly out of frame
+- measures the thing that matters — accuracy, latency, frame rate, error rate
+- has a **written pass/fail threshold decided in advance**, so the result cannot be argued with afterwards
+- is **thrown away**. It is not the foundation of the app.
+
+Write it as the first task with the threshold in the description, e.g. *"Prove pose tracking holds 15fps and correctly identifies elbow angle within 15° on a MacBook webcam, standing 2m back, in a normally lit living room."*
+
+**If the spike fails, the plan changes — and that is the spike doing its job**, cheaply, in week one, before the screens exist.
+
+## Design a fallback before you need one
+
+For anything perception- or AI-based, decide now what happens when it does not work: bad light, unusual body, occlusion, an old machine.
+
+**There must be a path where the user still gets the outcome.** An exercise app whose camera cannot see the user should still run the session with a timer and a manual rep count. A receipt scanner that cannot read the total should ask.
+
+The failure mode to design out is **the app confidently telling the user they are wrong when the app is the thing that is wrong** — that is the fastest way to lose trust permanently, and it is much worse than the app admitting it cannot see.
+
+### Make the feedback signal progress, not judgement
+
+The design move that removes this whole class of failure: **have the interface show how far through the action the user is, rather than whether they are doing it correctly.** Progress cannot be insulting when the sensor is wrong; a verdict can.
+
+**Worked example.** An exercise app was going to draw the tracked skeleton **red until the movement was correct, then green**. Red means *you are doing this wrong* — and on a 78-year-old, partly out of frame, in a dim living room, the app would say it constantly while being wrong itself. The fix kept the identical visual and changed its meaning: neutral while tracking, filling toward green through the range of motion, green flash on a completed rep, **and never red**. Same satisfying feedback loop, structurally incapable of shaming the user.
+
+**And when detection genuinely fails, the app blames itself in plain words** — *"I can't see you clearly, try stepping back"* — never the user. Pair this with the fallback path above so the user still gets the outcome.
+
+### When the client is a licensed professional
+
+If the person commissioning the app is a doctor, lawyer, accountant, therapist or similar, two rules apply and both belong in the notes:
+
+1. **The app must not appear to give professional advice.** Anything that reads as a prescription, a dose, a load, a diagnosis or a legal position is a liability the software should not carry. Have the app *remember and display what the user did last time* instead of *recommending what they should do next*, and put any real guidance in the expert's own words, attributed to them.
+2. **Expert review of the content is a required build step, not a formality.** They are the authority on every entry in the catalogue. Schedule it, name it as a task, and do not ship generated domain content they have not read.
+
+---
+
+## What good looks like
+
+- The hard part is **named in one sentence** the person understands.
+- Real prior art was **searched for**, with two or three candidates compared.
+- The **licence of the chosen option was checked and recorded in the note.**
+- The platform-native option was considered before any third-party dependency.
+- The hard part is **task #1 as a spike with a written pass/fail threshold**.
+- A **fallback path** exists for when it does not work.

--- a/.claude/skills/cs-build-plan-app/references/platform-choice.md
+++ b/.claude/skills/cs-build-plan-app/references/platform-choice.md
@@ -1,0 +1,114 @@
+# Choosing the platform — decide on capability, then state what it costs
+
+Decide this **before** the feature list is final, because it changes what is buildable and what a feature even means. Do not decide it on preference, on fashion, or by asking the user — they will answer on vibes, and it is not their call. Make the call, then **tell them the call and the reason** in one sentence they can repeat.
+
+## The decision
+
+Start from **what the app must physically be able to do**, not from what is trendy.
+
+| If it must | Platform | Why |
+|---|---|---|
+| Use the camera with **real-time local ML** | **Desktop (Mac)** | Native frameworks, real compute, no upload, believable privacy story |
+| Read/write real files, watch folders, run at login, live in the menubar | **Desktop** | The browser cannot, by design |
+| Work **genuinely offline** | **Desktop** | "Offline web app" is a service worker and a cache, and it is a lie in most cases (below) |
+| Be **shared by a link**, found by search, signed up for in one click | **Web** | Distribution is the product |
+| Be sold with a self-serve funnel from day one | **Web** | Payment, accounts and onboarding are solved and expected |
+| Be used **away from a desk** — in a gym, a field, a warehouse | **Mobile** | Nothing else is in their pocket |
+| Be usable on any machine the user happens to be at | **Web** | No install |
+
+**When both fit, pick web** — it is cheaper to distribute, cheaper to update, and easier to sell. Desktop must be *earned* by a capability the browser genuinely cannot provide.
+
+## iOS is almost never the right v1
+
+Say this plainly and say why:
+
+- **Review latency.** Every release, including the fix for the bug you shipped on Friday.
+- **Apple's cut** on in-app purchase.
+- **A developer account and the whole signing apparatus** before anyone can install anything.
+- **Small screen.** For an older audience or anything with a lot on screen at once, this is a real usability loss, not a preference.
+- **The hardest place to iterate**, which is the one thing a v1 must do well.
+
+Exception: the app is genuinely useless anywhere but in someone's hand.
+
+## The constraint that overrules capability — what will they actually build it in?
+
+Capability decides what the app *needs*. It does not decide what the person in front of you can **build and keep running after you leave**, and that second question can legitimately overrule the first.
+
+Ask it explicitly, before the platform is written down:
+
+> **"What are you going to build this in, and who maintains it after I'm gone?"**
+
+The common collision: someone is committed to an AI web-app builder (Base44, Lovable, v0, Replit) — it is what they have paid for, what they half-understand, and the only tool they can imagine still using in six months. **Those tools emit web apps. They cannot produce a native desktop or mobile app at all.** So a plan that says "Mac app" is a plan they cannot execute, however correct the capability argument was.
+
+### How to resolve it — a conversation, not a silent override
+
+Do not quietly plan a platform they cannot build in, and do not quietly drop a capability because their tool is easier. Both failures look like agreement in the room and surface weeks later. Instead, put the real trade on the table:
+
+1. **Name what is lost** by moving to the platform their tool supports. Be specific and technical: *"in a browser this runs at roughly half the frame rate and the privacy claim is harder to make credible."*
+2. **Check whether the loss is actually fatal**, by researching it rather than assuming. Browser capability moves fast and the intuition that "the browser can't do that" is often several years out of date. This is worth a real investigation, not a guess.
+3. **Name what is gained** — usually distribution, cross-platform reach, no signing or notarization, no install friction, payment already solved, and instant updates. These are not consolation prizes; for a v1 that has to be sold quickly they frequently outweigh the capability.
+4. **If the capability is genuinely load-bearing and their tool cannot reach it, say so plainly** and offer the two honest options: build it outside their tool, or change the product so it no longer needs that capability.
+
+### The maintenance question is the real one
+
+A technically better app the owner cannot touch is worse than a slightly worse app they can. Weight this heavily for non-technical owners — the platform they can still ship a fix to in a year usually wins, and that is a legitimate engineering judgement rather than a compromise.
+
+**Record the decision and the reason in the note**, including what was given up. Otherwise the next person reads "web app" and assumes nobody considered the alternative.
+
+---
+
+## "Offline" almost never means offline
+
+When someone says the app should work offline, find out which they mean:
+
+1. **"It shouldn't break on bad wifi"** — a web app with sensible caching is fine.
+2. **"It works on a plane"** — real offline. Desktop, or a serious PWA investment.
+3. **"My data doesn't go to a server"** — that is **privacy**, not offline, and it is a much stronger requirement. It usually forces desktop and it is usually worth a lot in the marketing.
+
+They are three different requirements and people use one phrase for all of them. **Video, in particular, kills naive offline claims** — a follow-along app that streams its content is online whatever the shell is built in.
+
+---
+
+## What each choice actually costs — state these out loud
+
+The platform decision is cheap. Its consequences are not, and they surface in week four.
+
+### Desktop (Mac)
+
+- **Signing and notarization.** Distributing outside the App Store still needs an Apple Developer account, a **Developer ID certificate**, and notarization on every build. Without it users get "cannot be opened because the developer cannot be verified" and they will not proceed. **This is a hard, calendar-time dependency — start it on day one, not at launch.**
+- **Distribution is manual by default** — a signed, notarized DMG on a download page. That is genuinely fine for the first few dozen customers and much faster than it sounds.
+- **Updates** need a mechanism (Sparkle or equivalent). If you defer it, you cannot ship a fix to anyone who already installed. Decide deliberately.
+- **Payment is not solved for you.** No store, no billing. A payment link plus a licence key checked at launch is the cheap answer, and **the licence check must exist from the first build** — it cannot be retrofitted onto customers who already have an unlocked copy.
+- **Mac-only excludes Windows users.** Fine for a design-led or Apple-heavy audience; check it is not half the market.
+
+### Web
+
+- **Accounts, hosting and a database from day one** — there is no local-only web app worth selling.
+- **Payment is solved** (Stripe Checkout, an afternoon).
+- **Updates are free** — everyone is on the latest version always.
+- **Capability ceiling.** Camera works; sustained real-time ML is harder, heavier and less believable on privacy; filesystem is limited; background work is limited.
+- **Distribution is the win.** A link. This is worth more than most capability arguments.
+
+### Mobile
+
+- Everything in iOS above, plus a second platform if Android matters.
+- The only correct answer when the use is genuinely away from a desk.
+
+---
+
+## The privacy angle can decide it
+
+If the app handles **camera video of the user, health data, or anything they'd be uncomfortable uploading**, desktop wins on credibility even where the browser is technically capable.
+
+*"This never leaves your computer"* is true, provable, and worth saying loudly in the UI of a native app. The same claim from a web page is technically achievable and **nobody believes it**. For an older, less technical audience — one that already suspects it is being watched — this is not a footnote, it is a selling point and possibly the deciding factor.
+
+---
+
+## Worked example — a follow-along exercise app for women over 50
+
+- **Camera + real-time pose estimation, every frame** → real compute, and Apple's Vision framework is on-device and free (`hard-part-first.md`).
+- **Video of a woman exercising in her living room** → the "this never leaves your computer" claim is the whole trust story, and it is only credible in a native app.
+- **Audience is 50–78 on laptops** → big screen wins, phone loses.
+- **She wants to sell within weeks** → App Store review is a schedule risk; a DMG on a page is not.
+- **Verdict: Mac app.** Not because Mac is nicer — because pose estimation and the privacy claim both need it.
+- **Consequences stated up front:** Developer ID certificate needed *now*; DMG distribution; payment via link + licence key, **with the licence check in the first build**; no Windows users in v1, accepted deliberately.

--- a/.claude/skills/cs-build-plan-app/references/v1-scope.md
+++ b/.claude/skills/cs-build-plan-app/references/v1-scope.md
@@ -1,0 +1,88 @@
+# Cutting to a v1 that can actually ship
+
+They will describe the finished product. You are planning **the first version that delivers the job end to end** — one complete loop, working, and sellable if it needs to be sold.
+
+## One loop, whole
+
+> A user opens it, does the main thing, gets the outcome, and has a reason to come back.
+
+Everything in v1 serves that sentence. Everything else is later, and *later* is a real place — it goes in the note as "explicitly not in v1", not on the map and not in Kanban.
+
+**Cut breadth, never depth.** Five features at 60% is a broken app that cannot be shown to anyone. One feature at 100% is a product. When the list is too long, remove whole features rather than shipping all of them half-done — this is the single most valuable instinct in scoping and the one people resist hardest.
+
+---
+
+## Tracking features are not v1 features
+
+The most common way an idea-plan goes wrong. It is worth being blunt about.
+
+Sort every proposed feature into two piles:
+
+| | The app does something **for** them | The user does something **for** the app |
+|---|---|---|
+| **Called** | a doing feature | a tracking feature |
+| **Examples** | runs the session, corrects the form, reads the receipt, makes the decision | log your sleep, type in your meals, rate your mood, tick the box |
+| **Pull** | high — they come back because it gives them something | near zero — it is a chore with a delayed, abstract payoff |
+| **Week-two retention** | good | close to nil |
+
+**Manual logging dies.** It dies fastest with older, busier and less technical audiences — exactly the people these apps are usually for. Every "and it'll track their X" feature should be challenged, and the challenge is: *what does the user get back, in the next ten seconds, for typing that in?* If the answer is "a chart, eventually", cut it.
+
+This matters most when someone has a **framework with several parts** and wants all of them in the app. Usually one part is a doing feature and the rest are tracking features wearing a costume.
+
+**Worked example.** A menopause coach with a five-pillar method — sleep, nutrition, movement, brain health, stress — wanted all five in the app. Four of the five would have been manual logging screens. **Only movement was a doing feature**: the app runs the session and corrects the form. Correct v1: build movement properly, alone. The other four are her *coaching*, and the plan says so, so nobody builds four dead screens.
+
+If the other parts genuinely must appear, the cheap shape is **one short daily check-in feeding one number**, not one tracker screen each.
+
+---
+
+## The revenue gate
+
+If the person needs this to make money — and they will have said so, usually early and emotionally — then ask, in these words:
+
+> **"How does somebody pay for this?"**
+
+Then confirm the answer exists in v1. This is missed on nearly every plan because it is not a feature anyone is excited about, and it is the difference between a product and a demo.
+
+Minimum viable answers, in order of cost:
+
+1. **Manual.** A payment link, then send the download or an invite by hand. Perfectly fine for the first few dozen customers, and it can be live tomorrow.
+2. **Payment link + licence key** checked on launch (desktop). Cheap, and **the check must be in the first build** — you cannot retrofit it onto people who already have an unlocked copy.
+3. **Stripe Checkout + accounts** (web). An afternoon, and the right answer if it is a web app.
+
+Also settle: **free trial or not**, and **what a paying user gets that a non-paying one does not.** These are product decisions that change the build, so they belong in the plan and not in a conversation three weeks later.
+
+---
+
+## Ask what the real cost is — it is often content, not code
+
+Some apps are 20% software and 80% acquiring the thing the software shows. If that is true here, **say it now**, because it is the schedule risk and it is invisible on a feature list.
+
+Signals: the app needs an exercise library, a media catalogue, a document corpus, a template set, a curriculum, a reference data set, or anything "we'll generate with AI."
+
+**Beware AI-generated content standing in for a real corpus.** For anything a domain expert or an experienced user will look at, current generation is often not good enough, and being *nearly* right is worse than being obviously wrong — it destroys trust in one glance and it does not come back.
+
+**Worked example.** An exercise app where AI generated an illustration of a bicep curl that was not a bicep curl. The client — a physician — immediately said *"anybody would say this is not a bicep curl, and you lose trust doing those kind of things."* The right plan filmed the expert doing each movement once, which was cheaper, correct by construction, and turned her credibility into the product's.
+
+**The best content pipelines fall out of the architecture.** If the exercise is stored as a sequence of joint positions, then recording the expert once produces the demonstration, the correction targets and the rep counting from a single capture — one artefact, three features. Look for that collapse before planning a content operation.
+
+Plan the pipeline explicitly: **who makes it, how much is needed for v1, how long it takes, and what the quality bar is.** Then cut the v1 content set to the smallest that still delivers the loop — a dozen items done properly beats sixty done badly, and nobody has ever churned because a library was too small at launch.
+
+---
+
+## Say what is not in v1
+
+Name the cuts as explicitly as the inclusions, and write them into the note. An unspoken cut is heard as a broken promise the moment they see the build.
+
+Say it as a sentence they can repeat: *"v1 is one thing done properly — the session, with the camera. Sleep, nutrition and the community come after we know people are using this one."*
+
+---
+
+## The v1 test
+
+- [ ] One complete loop — open, do the thing, get the outcome, reason to return.
+- [ ] Every feature is a **doing** feature.
+- [ ] If money is needed, there is a way to pay **in v1**.
+- [ ] The hard part (`hard-part-first.md`) is proven by a spike before screens are built.
+- [ ] If the real cost is content, there is a pipeline and a minimum viable set.
+- [ ] The **not-in-v1 list is written down** and was said out loud.
+- [ ] It can be shown to a real user in weeks, not months.

--- a/.claude/skills/cs-build-resync-codebase/SKILL.md
+++ b/.claude/skills/cs-build-resync-codebase/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: cs-build-resync-codebase
+description: >
+  Re-sync CodeSpring with the real code after building. Independently checks
+  whether the features, notes, and PRDs in CodeSpring still match what the code
+  actually does now (features drift from their plan once built), then updates
+  CodeSpring to match. Read-only on the codebase — it only reads code/git and
+  writes to CodeSpring. Use after a feature is finished, or periodically, to
+  keep the map from going stale. Triggers, "resync my codebase", "is CodeSpring
+  up to date", "check for stale PRDs", "update CodeSpring from the code", "my
+  plan drifted from the code".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(git:*) Bash(node:*) Bash(curl:*)
+metadata:
+  author: codespring
+  version: "0.1"
+---
+
+# Re-sync CodeSpring with the codebase
+
+Once a feature is built, it rarely matches the original plan exactly. This skill checks CodeSpring against the current code and brings the map/notes/PRDs back into line.
+
+**Guardrail: this is read-only on the codebase.** It reads code and git history and writes ONLY to CodeSpring (features, notes, PRDs). Never modify application code from this skill.
+
+Uses: `codespring` skill references (`analyze-codebase.md`, `mindmap-structure.md`, `prd-management.md`, `pitfalls.md`).
+
+## 0. Connect first
+`codespring auth status` + `codespring status` (LOCAL project; print it).
+
+## 1. Establish what changed
+- Read recent changes: `git log`, `git diff` since the last sync point (or a branch/tag the user names), and the current state of the relevant files. If a GitHub remote is set, the mindmap's `githubUrl` and the repo are the reference.
+- Focus on the feature(s) the user built, but scan for new routes, tables, jobs, env vars, and shared systems anywhere.
+
+## 2. Compare code ↔ CodeSpring
+For each affected feature, diff reality against what's documented:
+- **Features / sub-features** — any new capability in the code not represented as a feature/sub-feature? Any documented one that no longer exists?
+- **Notes** — does the "how it works" note still describe the real flow, files, and routes?
+- **PRDs** — do the Frontend/Backend PRDs still match? Especially the shared backend contracts (routes, data model, auth/RLS, jobs/cron, storage/buckets, payments/credits, env vars) and the dependency map.
+- **Tech stack** — any new dependency/service to add.
+
+## 3. Report first
+Summarize as: **up to date / minor tweaks / stale**, with a short list of concrete diffs (each with file/route/table references and a severity). Let the user confirm before large rewrites.
+
+## 4. Update CodeSpring (writes go here, not to code)
+- Add/adjust features & sub-features (`codespring feature create --parent ...`, `feature update ...`), keeping the `node-features` count correct (re-parent if flattened — see `pitfalls.md`).
+- Refresh notes (`codespring mindmap note ...`).
+- Refresh PRDs: regenerate via `cs-build-create-prd` where a PRD is materially stale, or `codespring prd sync <id> --file` for targeted content updates.
+- Update tech stack / project info if needed.
+
+## 5. Confirm
+List what was updated in CodeSpring and give the project link. Note anything you intentionally left (e.g. a planned-but-not-built task).
+
+## What good looks like
+- CodeSpring reflects what the code actually does now, not just the original plan.
+- Drift is reported by severity with exact references before anything is rewritten.
+- The codebase was never modified — only CodeSpring was updated.

--- a/.claude/skills/cs-build-ui-mockup/SKILL.md
+++ b/.claude/skills/cs-build-ui-mockup/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: cs-build-ui-mockup
+description: >
+  Turn a CodeSpring plan into a clickable local mockup the client can actually
+  look at — one screen per core feature, real copy, plausible data, a proper
+  token-driven design system with light and dark mode, and a style guide page
+  showing the branding. Then run the review that surfaces what the written plan
+  could not: screen order, hierarchy, position, and choices that turn out to be
+  incomplete. Feeds every correction back into the CodeSpring notes and tasks.
+  Runs AFTER the map and notes exist and BEFORE the PRDs are generated.
+  Triggers, "make a mockup", "mock up the UI", "show me what it looks like",
+  "build a prototype", "design the screens", "what would this app look like",
+  "create a UI mockup for this plan", "I want to show the client something".
+allowed-tools: Bash(codespring:*) Bash(npx @codespring-app/cli:*) Bash(bash:*) Bash(node:*) Bash(npm:*) Bash(npx:*) Bash(git:*) Bash(grep:*) Bash(rg:*) WebSearch WebFetch
+metadata:
+  author: codespring
+  version: "0.1"
+---
+
+# Build a clickable mockup from the plan
+
+**A written plan cannot express a focal point.** It cannot express screen order, position, hierarchy, or whether a set of choices is complete. Those are exactly the things that go wrong, and no amount of re-reading the notes will find them — the client agrees to the words and then sees the screens and says something quite different.
+
+This skill turns the plan into something they can look at, runs the review that surfaces the gap, and writes what it finds back into CodeSpring.
+
+**Where it sits in the chain:**
+
+```
+cs-build-plan-app  or  cs-build-import-codebase        (map + notes exist)
+        │
+        ▼
+   cs-build-ui-mockup   ← you are here
+        │            build it, show it, feed corrections back
+        ▼
+  cs-build-create-prd → cs-build-create-tasks → cs-build-feature
+```
+
+**Run it before the PRDs.** A PRD generated from a plan nobody has seen just encodes the misunderstanding in more detail and makes it more expensive to undo.
+
+Read: `codespring` skill `references/project-state.md`, `references/pitfalls.md`, and this skill's own references —
+
+| Reference | Read it when |
+|---|---|
+| `references/design-system.md` | **Before writing any CSS.** The token architecture, the scales, the radius relationships, brand-swapping, and light/dark. |
+| `references/review-method.md` | Before showing it to anyone. How to run the review without contaminating it, what mockups reliably catch, and how corrections get written back. |
+
+**Also load Anthropic's `frontend-design` skill if the runtime supports it** (`https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md`). It is the method for making the thing distinctive rather than templated; `design-system.md` here is the structure it hangs on. If skills cannot be installed in this environment, read that URL and follow it directly.
+
+---
+
+## 0. Check the plan is ready
+
+```bash
+bash ../codespring/scripts/fetch-project.sh --out /tmp/cs-state
+node ../codespring/scripts/state.mjs       /tmp/cs-state
+```
+
+You need **core features with notes**. Without notes there is nothing to draw — the note is where the screen's content, states and rules live.
+
+- **No map** → wrong skill. `cs-build-plan-app` (no code) or `cs-build-import-codebase` (existing code) first.
+- **Map but thin or missing notes** → say so and fix the notes first. A mockup built from card titles alone invents everything and tests nothing.
+- **PRDs already generated** → still worth doing, but say plainly that corrections will mean regenerating them.
+
+## 1. Get the brief straight before drawing anything
+
+From the notes and from the person, settle these. They are the inputs to every visual decision:
+
+- **Who uses it**, and what that constrains — age, ability, environment, device, how much patience they have.
+- **The single job of the main screen.**
+- **The one moment the product will be remembered by.** This is where the boldness gets spent; everything else stays quiet.
+- **Any brand that already exists** — colours, type, logo, an existing product to match.
+- **Any reference the client has supplied.** If they have pinned a direction, **follow it exactly** — their words win over any default you would otherwise reach for.
+- **Light or dark or both**, and which is the default.
+
+**If a reference image was supplied, extract from it explicitly** and write the extraction down: palette as named hex values, radius scale, type pairing, spacing rhythm, and the two or three structural patterns worth stealing. Then say what you are deliberately *not* taking from it, and why. A reference is evidence of what they liked, not a specification to copy wholesale — the reference's audience is often not their audience.
+
+## 2. Choose the smallest stack that throws away cleanly
+
+This is a **communication device with a lifespan of days**. It is not the app and it must never become the app by accident.
+
+Default: whatever gets a styled, routed, clickable page up fastest in the target platform's own idiom — usually a scaffolded web app with a utility CSS layer. Match the eventual stack where that is free, but **never let stack fidelity slow the mockup down.** A web mockup for a native app is fine and normal; the point is the screens.
+
+**No backend. No database. No auth. No real API calls.** Hardcoded sample data throughout.
+
+Put it in its own directory, clearly named `mockup/`, and say in one line that it is throwaway.
+
+## 3. Build the design system FIRST
+
+Do not write a screen before the tokens exist. `references/design-system.md` is the spec; the short version:
+
+- **Every value lives in one place.** No hex, no pixel value, no radius, no font stack appears in a component. Ever. A whole rebrand must be one file.
+- **Light and dark are both built from day one**, not retrofitted. Retrofitting dark mode means revisiting every screen.
+- **One spacing scale, one type scale, one radius scale.** Radii are chosen as a deliberate relationship — see the reference; the common failure is a card at 28, a button at 6 and an input at 12 for no reason anyone can state.
+- **Colour is semantic, not literal.** `--surface`, `--ink`, `--accent` — never `--blue`. Semantic names are what make a brand swap possible.
+
+Then run the **two-pass process** from Anthropic's frontend-design skill: plan the token set (4–6 named colours, display + body faces, a layout concept, and the one signature element), **critique that plan against the brief**, revise anything that reads as a generic default, and only then write code.
+
+## 4. Build the screens
+
+**One screen per core feature, plus the single most important flow.** Do not build every sub-feature — build enough that the shape of the product is legible.
+
+Non-negotiables, because each one has cost a real review:
+
+- **Real copy.** Never lorem ipsum. Wrong wording is one of the things you are trying to surface, and placeholder text hides it completely.
+- **Plausible sample data.** Real-looking names, real-looking numbers. "Sit-to-Stand Strength · 10 minutes · Level 2" surfaces problems that "Item 1" never will.
+- **Controls must visibly respond.** A chip that does nothing when clicked reads as **broken**, not as static, and you will lose review time to it. Hardcoded state that moves on click is enough.
+- **Draw the empty and first-run states.** They are the most-skipped screens and the ones that most often read as "this is broken" to a non-technical user.
+- **Every list item that has detail behind it must open.** A list you cannot open is a list nobody can trust, and "you'd click into it" is exactly the kind of assumption a mockup exists to expose.
+- **Every enumerated choice needs its escape hatch** — an "Other" or "Custom" option — unless the set is genuinely closed. Fixed lists die on contact with real users.
+
+## 5. Add a style guide page
+
+A `/styleguide` route showing the design system as an artefact the client can react to: the palette with names and values, the type scale in use, the spacing and radius scales, buttons and inputs in every state, cards, and the light/dark toggle.
+
+This does real work. It gives the client something concrete to approve or reject **at the token level**, which is a far cheaper conversation than arguing about it one screen at a time. It also documents the system for whoever builds the real thing.
+
+## 6. Check it yourself before showing anyone
+
+- The build passes and every route loads.
+- **Look at it.** Screenshot each screen and actually read them. Do not ship a mockup you have only verified with HTTP 200s.
+- Light and dark both work on every screen.
+- Nothing framework-branded is visible — dev badges, error overlays, placeholder favicons. A non-technical client reads any of that as "broken".
+- The quality floor: keyboard focus visible, sensible heading order, reduced motion respected, no horizontal scroll.
+- **Chanel's rule: find the one thing to remove.**
+
+## 7. Run the review
+
+Full method in `references/review-method.md`. The core of it:
+
+**Put it in front of them and shut up.** Do not narrate, do not explain your reasoning, do not pre-defend a choice. The moment you explain a screen you are measuring whether your explanation is convincing, not whether the screen is.
+
+Ask only open questions: *show me what you'd do first*, *what's confusing*, *what's missing*, *where would you look for X*.
+
+**Take the feedback literally and work out separately what it means.** "This looks blobby" is not actionable but the thing they are pointing at is real. "I don't know what that's showing" means a chart has no title. "Is that something I click?" means one screen is doing two jobs with no signposting.
+
+**Expect two rounds.** Stop when the feedback moves from "this is wrong" to "I'd prefer" — at that point you have the understanding you came for and the rest is taste that can be settled during the build.
+
+## 8. Write the corrections back into CodeSpring
+
+**This is the step that makes the skill worth running.** The review output is not a UI to-do list — it is plan corrections, and they belong where the build will read them.
+
+1. **The reason goes in the feature's note.** Not just the decision — the reason. *"The workout goes first, because asking two questions before showing anything is two decisions before she has seen anything."* The reason is what stops the next person reverting it.
+2. **A `DESIGN REVIEW` block goes on every affected task**, so whoever builds that screen sees the correction rather than rediscovering the original mistake.
+3. **Anything the review revealed as missing becomes a new task**, and a new sub-feature if it is genuinely a new thing the user does.
+4. **Name the mockup in the notes as the agreed UI reference**, with how to run it. It is now worth more than any written description of the same screens.
+
+```bash
+codespring mindmap note <coreFeatureId> --title "How it works — X" --text "$(cat note.txt)"
+codespring task update <taskId> --description "$(cat task.txt)"
+codespring task create --title "0.x.y — ..." --description "..." --feature <id> --priority high
+```
+
+## 9. Hand off
+
+**→ `cs-build-create-prd`**, now that the plan reflects something the client has actually seen.
+Then `cs-build-create-tasks`, then `cs-build-feature`.
+
+Tell them plainly what they have: the mockup and how to run it, the style guide, what changed in the plan because of the review, and what happens next.
+
+---
+
+## What good looks like
+
+- The mockup existed **before** the PRDs.
+- **The design system was built first**, all values live in one place, and light and dark both work.
+- A `/styleguide` route exists, so branding is a token-level conversation.
+- Real copy, plausible data, controls that respond, and empty states drawn.
+- Every list with detail behind it opens; every enumerated choice has an escape hatch.
+- It was shown **without narration**, with open questions.
+- **Every correction became a note reason and a task block** — not a private to-do list.
+- The mockup is named in the notes as the agreed UI reference.
+- **At least one thing surfaced that no amount of reading the plan had found.** If nothing did, the mockup was too vague to be useful.

--- a/.claude/skills/cs-build-ui-mockup/references/design-system.md
+++ b/.claude/skills/cs-build-ui-mockup/references/design-system.md
@@ -1,0 +1,233 @@
+# The design system — build this before any screen
+
+The single rule everything else follows from:
+
+> **No colour, size, radius, spacing value or font stack ever appears inside a component.** Every one of them is a named token defined in one file. A complete rebrand is one file changed.
+
+If a component contains `#DC5B42` or `padding: 18px`, the system has already failed — because the rebrand, the dark mode and the accessibility pass all become a hunt through every screen.
+
+---
+
+## Colour
+
+### Name colours by ROLE, never by appearance
+
+The most common failure in a mockup that later needs to change: `--blue-500`. When the brand becomes green, every name is a lie and every usage has to be re-read to work out what it meant.
+
+```
+--surface          the page behind everything
+--surface-raised   cards and panels sitting on it
+--surface-sunken   wells, inputs, chart tracks
+--ink              primary text
+--ink-soft         labels and secondary text
+--ink-faint        disabled, placeholder
+--accent           the brand colour — the ONE thing that changes on rebrand
+--accent-hover     pressed and hover states
+--accent-wash      tint behind icons and soft badges
+--rule             hairlines and borders
+--positive         success and confirmation
+--caution          warnings
+--critical         destructive and error
+```
+
+**Semantic names survive a rebrand; literal names do not.** With this set, changing `--accent` changes the product.
+
+### Keep the palette small
+
+**4–6 named values plus neutrals.** More than that and the mockup stops looking designed and starts looking assembled. If a seventh colour seems necessary, it is usually a job for a shade of an existing one.
+
+### Light and dark from day one
+
+Not a later pass. Retrofitting dark mode means revisiting every screen, and every hard-coded value you got away with becomes visible at once.
+
+```css
+:root { --surface: #FAF7F5; --ink: #1C1A19; --accent: #DC5B42; }
+
+@media (prefers-color-scheme: dark) {
+  :root { --surface: #171513; --ink: #F4F0ED; --accent: #E87059; }
+}
+
+:root[data-theme="dark"]  { /* explicit override wins over the media query */ }
+:root[data-theme="light"] { }
+```
+
+Support both the system preference **and** an explicit toggle, and let the explicit one win in both directions.
+
+**Dark is not inverted light.** Three things that always need adjusting:
+- **Lift the accent's lightness.** A colour that reads well on white is usually muddy on near-black.
+- **Never use pure black or pure white.** `#000` on `#FFF` is harsh; near-black and near-white are calmer and look intentional.
+- **Shadows barely work in dark.** Separate surfaces with a lighter raised colour and a subtle border instead of a drop shadow.
+
+### Contrast is a functional requirement
+
+WCAG AA — 4.5:1 for body text, 3:1 for large text and UI boundaries. **Check both themes.** For an older or low-vision audience, treat AA as the floor and aim higher on anything read at distance.
+
+---
+
+## Spacing
+
+**One scale, and everything snaps to it.** A 4px base is the standard choice:
+
+```
+--space-1: 4px    --space-4: 16px   --space-7: 40px
+--space-2: 8px    --space-5: 24px   --space-8: 64px
+--space-3: 12px   --space-6: 32px   --space-9: 96px
+```
+
+**No value outside the scale.** The moment `padding: 18px` appears, the rhythm is gone and nobody can tell why the page feels slightly wrong.
+
+**Space communicates grouping.** Related things sit closer than unrelated things, and that difference should be at least two steps of the scale or the eye will not read it. Most cramped-looking interfaces are not short of space overall — they use the *same* gap between related and unrelated elements.
+
+---
+
+## Radius — pick relationships, not numbers
+
+The failure this prevents: a card at 28px, a button at 6px, an input at 12px, chosen separately at different times. Nothing is wrong individually and the whole thing looks incoherent.
+
+**Define a scale and state the relationships:**
+
+```
+--radius-sm    6px    inputs, small controls, table cells
+--radius-md   12px    buttons, chips, badges
+--radius-lg   20px    cards nested inside other cards
+--radius-xl   28px    top-level cards, panels, modals
+--radius-full 999px   pills, avatars, circular buttons
+```
+
+**The two rules that keep it coherent:**
+
+1. **Nested corners get smaller, not bigger.** A card inside a card steps *down* the scale. A large radius inside a small one reads as a mistake even to people who cannot say why.
+2. **Concentric radii should relate**: an inner radius of roughly `outer − padding` keeps the curves parallel. A 28px card with 16px padding wants an inner radius near 12px.
+
+**Commit to a personality and hold it.** Fully round pills with 6px cards is a mixed message. Either the product is soft (large radii, pills everywhere) or it is precise (small radii, square-ish) — pick one and be consistent. If buttons are pills, chips should be pills too.
+
+---
+
+## Type
+
+**Two faces, three at most:**
+- **Display** — carries the personality. Used with restraint, at large sizes only.
+- **Body / UI** — chosen for legibility, not character. This is most of the product.
+- Optionally a **mono** for code, data, or timers where digit alignment matters.
+
+**One scale, and every size comes from it:**
+
+```
+--text-xs   13px    --text-lg    20px    --text-3xl  44px
+--text-sm   15px    --text-xl    24px    --text-4xl  56px
+--text-base 17px    --text-2xl   32px    --text-hero 96px+
+```
+
+**Set the base from the audience, not from habit.** 16px is a floor, not a default. An older or low-vision audience wants 17–19px body and everything else scaling from it.
+
+**Always set line height with size.** Tight for display (1.1–1.2), comfortable for body (1.5–1.6). Long body text at 1.2 is unreadable and it is the single most common type mistake.
+
+**Numbers that update need `font-variant-numeric: tabular-nums`** — otherwise a running timer visibly jitters as digit widths change.
+
+---
+
+## Elevation
+
+Pick **one** way to separate surfaces and use it consistently: shadow, border, or a background shift. Mixing all three is what makes a UI look assembled by different people.
+
+Three levels is plenty — flat, raised, floating (modals, menus). If a fourth seems necessary, the layout is probably too deep.
+
+Remember shadows barely read in dark mode; plan the border or surface-shift equivalent at the same time.
+
+---
+
+## Components — define once, use everywhere
+
+Build these before the screens, from tokens only:
+
+**Button** — primary, secondary, ghost, destructive; default, hover, active, focus, disabled, loading. **A button with no focus state is not finished.**
+**Input** — label, field, helper text, error state, disabled. Errors say what to do next.
+**Card** — the container everything sits in.
+**Chip / pill** — selected and unselected. Selected must be distinguishable **without relying on colour alone**.
+**Modal** — backdrop, panel, close, scrollable body, Escape to dismiss, focus trapped.
+**Table row** — including the hover and clickable states, if rows open.
+**Empty state** — an illustration or glyph, a line explaining what goes here, and the action that fills it. Design it once and reuse it.
+
+**Minimum target size 44×44px**, and larger for an audience with reduced dexterity.
+
+---
+
+## Navigation
+
+Pick the pattern from the shape of the product, not from fashion:
+
+- **Sidebar** — 4–8 top-level destinations, desktop-first, and the user moves between them often. Most tools.
+- **Top bar** — few destinations, or content-led and marketing-adjacent.
+- **Bottom bar** — mobile, 3–5 destinations, thumb reach matters.
+
+Whatever the pattern: **the current location must be unmistakable** (not a faint tint), destinations are named for what the user does there rather than how the system is built, and **full-screen modes are entered from a destination rather than being one.** A workout session, a video player, a canvas — these take over the screen but do not appear in the nav.
+
+---
+
+## Motion
+
+**Default to less.** Extra animation is one of the strongest signals that an interface was generated rather than designed.
+
+```
+--motion-fast   120ms   hover, focus, small state changes
+--motion-base   200ms   most transitions
+--motion-slow   320ms   modals, page-level changes
+```
+
+Ease-out for things entering, ease-in for things leaving. **Respect `prefers-reduced-motion` and mean it** — not a shorter animation, no animation.
+
+One orchestrated moment lands harder than movement scattered everywhere. And during any task where the user is concentrating, motion should stop entirely.
+
+---
+
+## Making the brand swappable
+
+The client will change their mind, or the same mockup will be shown to a second client. Build for it from the start:
+
+1. **Every visual value is a token**, no exceptions.
+2. **Colour tokens are semantic**, so `--accent` means "the brand colour" regardless of what colour it is.
+3. **Font families are two tokens**, `--font-display` and `--font-body`, referenced nowhere else.
+4. **The radius scale is one block** — softening or sharpening the whole product is five numbers.
+5. **Keep a themes block**, so an alternative brand is a set of overrides rather than an edit:
+
+```css
+:root[data-brand="alt"] {
+  --accent: #2F6F5E;
+  --font-display: "Some Other Face", serif;
+  --radius-xl: 8px;
+}
+```
+
+**Test it before you finish.** Change `--accent`, reload, and look at every screen. Anything that did not change is a hard-coded value you missed — and that is exactly the bug you are trying to prevent.
+
+---
+
+## The style guide page
+
+A `/styleguide` route rendering the system from the same tokens the app uses:
+
+- Palette swatches with token names and values, in both themes
+- The type scale, each size labelled and shown in use
+- The spacing and radius scales, drawn
+- Every component in every state
+- A light/dark toggle
+
+Two reasons it earns its place: the client can approve or reject the **branding at token level**, which is a much cheaper conversation than arguing screen by screen — and it documents the system for whoever builds the real thing.
+
+---
+
+## The checklist
+
+- [ ] No hex, px, or font stack in any component.
+- [ ] Colour tokens are **semantic**, not literal.
+- [ ] **Light and dark both work**, on every screen, and the toggle beats the system preference.
+- [ ] Contrast meets AA in **both** themes.
+- [ ] One spacing scale, and nothing off it.
+- [ ] Radius scale with **stated relationships**; nested corners step down.
+- [ ] Type scale with line heights; base size set from the audience.
+- [ ] Tabular numerals anywhere numbers change.
+- [ ] Every component has hover, focus, active and disabled.
+- [ ] Empty states designed.
+- [ ] Targets ≥ 44px.
+- [ ] Reduced motion respected.
+- [ ] **Changing `--accent` visibly rebrands every screen.**

--- a/.claude/skills/cs-build-ui-mockup/references/review-method.md
+++ b/.claude/skills/cs-build-ui-mockup/references/review-method.md
@@ -1,0 +1,88 @@
+# Building it, showing it, and feeding it back
+
+The method behind `cs-build-ui-mockup`. Learned the expensive way on a real client.
+
+## The problem it solves
+
+`elicitation.md` warns that a confident plan which does not match what is in the person's head **reads exactly like a good one**. Everything else in this skill fights that with words — read it back, ask what is wrong, get a yes at the gate.
+
+**Words are not enough.** A person will agree to a written plan they have not actually understood, because prose lets both sides fill the gaps differently and neither notices. The gap only becomes visible when someone can *look* at it.
+
+Real run: a plan was written, agreed at the gate, expanded into PRDs and sixty tasks. It looked complete. A clickable mockup was then built from it, and within ten minutes of the owner looking at the screens it produced **eleven corrections** — including a whole screen in the wrong order, a feature nobody could find, a control that had no source for its numbers, and a list nobody could open. None of those had surfaced in any amount of written review, and several would have been expensive to fix after the build.
+
+> **A mockup is the cheapest possible disagreement.**
+
+## When to build one
+
+**After the map and notes, before the PRDs.** That is the moment the plan is complete enough to draw and cheap enough to be wrong.
+
+Skip it only when there is genuinely no interface — a CLI, a library, a background job.
+
+The design system that the mockup is built from is a separate concern with its own rules: `design-system.md`. Build that first.
+
+## What to build
+
+**A static, clickable, throwaway front end.** Not the app. No backend, no real data, no auth, no camera, no API calls. Hardcoded sample values everywhere.
+
+- **One screen per core feature**, plus the single most important flow.
+- **Real copy**, not lorem ipsum. Wrong copy is one of the things you are trying to surface, and placeholder text hides it.
+- **Plausible sample data.** Numbers that could be real. "Sit-to-Stand Strength · 10 minutes · Level 2" surfaces problems that "Item 1" never will.
+- Enough interactivity that clicking a thing visibly does something. **A control that does not respond reads as broken, not as static**, and you will waste review time on it.
+
+Build it in whatever is fastest to throw away. It is a communication device with a lifespan of days.
+
+## How to run the review
+
+Put it in front of them and **shut up**. Do not narrate, do not explain the reasoning, do not pre-defend a choice. The moment you explain a screen you have contaminated the test — you are now measuring whether your explanation is convincing, not whether the screen is.
+
+Ask only:
+- *"Show me what you'd do first."*
+- *"What's confusing?"*
+- *"What's missing?"*
+- *"Where would you look for X?"*
+
+**Then take the feedback literally, and separately work out what it means.** "This looks blobby" is not actionable, but the thing they are pointing at is real. "I don't know what that's showing" means a chart has no title. "Is that something I click?" means one screen is doing two jobs with no signposting.
+
+## What a mockup reliably catches that prose does not
+
+Every one of these came from a real review, and every one had been invisible in a written plan that both parties had signed off:
+
+| What surfaced | The general lesson |
+|---|---|
+| The screen asked two questions before showing anything useful | **Screen ORDER is a decision, and prose does not encode it.** A note listing features says nothing about what is at the top. |
+| A summary line duplicated what the graphic already said | Redundancy is invisible in a list and obvious on a screen. |
+| A control had no source for its numbers | **"The user picks a level" hides the question of where the level's VALUES come from.** Prose accepts an unfinished thought; a form has to be filled in. |
+| A list of items could not be opened | **A list nobody can open is a list nobody can trust.** Detail views get planned as "obviously"; obviously never gets built. |
+| A fixed set of options had no escape hatch | **Every enumerated choice needs an "other".** A list of five equipment types dies on contact with a real user. |
+| An important secondary action was at the bottom of a long page | Position IS priority, and a note cannot express position. |
+| A screen in the nav had nothing behind it | Prose lists it as a feature; the mockup shows it is empty. |
+| Status was scattered across five floating elements | **"Show the round, the reps and the timer" reads fine as a sentence and fails as a screen.** |
+| Everything on a bar had equal weight | **A written plan cannot express a focal point.** Prose has no hierarchy; a screen is nothing but hierarchy. |
+| A real feature read as invented | If a feature's purpose is not legible on screen, it will be cut by whoever reviews it — including the person who asked for it. |
+
+Notice the pattern: **almost all of it is about hierarchy, order, position, and the completeness of a choice.** Those are exactly the properties a bulleted list cannot represent, which is why no amount of re-reading the plan finds them.
+
+## Feed it straight back into the plan
+
+The review output is not a UI to-do list — it is **plan corrections**, and they belong in CodeSpring where the build will read them:
+
+1. Write each decision into the relevant feature's **note**, with the reason. *"Order changed: the workout goes first because asking two questions before showing anything is two decisions before she has seen anything."* The reason is what stops it being reverted by the next person.
+2. Add a **DESIGN REVIEW** block to every affected **task**, so whoever builds that screen sees the correction and does not rediscover the original mistake.
+3. **Add tasks for what the review revealed was missing.** A detail view, a defaults table, an empty screen that was only ever a nav item.
+4. Add sub-features for anything genuinely new.
+5. Keep the mockup and **name it in the notes as the agreed UI reference.** It is now worth more than any written description of the same screens.
+
+## Expect more than one round
+
+The first revision will not be right either. The second review is cheaper and sharper because the obvious problems are gone and the person is now looking at hierarchy rather than content.
+
+**Two rounds is normal. Three is fine.** It is still radically cheaper than discovering any of it after the build. Stop when the feedback moves from "this is wrong" to "I'd prefer" — at that point you have the understanding you came for, and the rest is taste that can be settled during the build.
+
+## What good looks like
+
+- A clickable mockup existed **before** the PRDs were generated.
+- It used real copy and plausible data, and its controls visibly responded.
+- It was shown **without narration**, and the questions asked were open.
+- Every piece of feedback became a **note correction with its reason**, a **task addition**, or both — not a private to-do list.
+- The mockup is named in the notes as the agreed UI reference.
+- At least one thing surfaced that no amount of reading the plan had found. **If nothing did, the mockup was too vague to be useful.**

--- a/.claude/skills/cs-marketing-offer-creation/SKILL.md
+++ b/.claude/skills/cs-marketing-offer-creation/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: cs-marketing-offer-creation
+description: >
+  Design a paid-ads offer from evidence rather than opinion. Tears down what
+  competitors are already running in the Meta Ad Library, ranks offers by
+  survival and creative duplication, scrapes the landing pages behind the
+  winning ads, then writes the offer, its price ladder, its order bumps and its
+  back end into a durable teardown document. Use when designing or rewriting a
+  front-end offer, a webinar or event registration page, an order bump, or an
+  upsell. Triggers, "research offers", "what offers are working right now",
+  "tear down this funnel", "scrape the ad library", "design a front-end offer",
+  "what should our webinar promise be", "competitor ad research", "why is our
+  CPC so high".
+---
+
+# Offer creation from ad-library evidence
+
+## Overview
+
+Produce an offer backed by what the market is already paying to run. The output
+is a teardown document plus a specified offer, not a hunch. Consumes market
+context from `cs-marketing-research`; hands its offer to `cs-marketing-website`
+for the page build.
+
+**Approval boundaries.** This skill reads public data and writes documents. It
+must not launch ads, spend budget, publish pages, or contact competitors. It
+must not copy competitor copy into production — quote it as evidence only.
+Apify runs cost credits, so ask before using the paid route when a free one
+exists.
+
+## 1. Frame the decision
+
+State before researching: the product being sold, the avatar, the traffic
+source, the price the back end needs to support, and the CPC or cost-per-lead
+target. An offer designed without a back-end price is a guess.
+
+If any of these are missing, ask. Do not research generically.
+
+## 2. Pull the ads
+
+### Free route — the browser. Default to this.
+
+Drive `facebook.com/ads/library` directly. No credits, no API.
+
+```text
+active_status=active|inactive|all
+ad_type=all
+country=US|GB|ALL
+media_type=all
+q=<terms>
+search_type=keyword_exact_phrase | keyword_unordered
+```
+
+- `keyword_exact_phrase` — the literal phrase. Use for brand names, signature hooks, and measuring an angle's size.
+- `keyword_unordered` — **AND across all terms.** The workhorse for finding offers. Four to five terms; six or more returns zero.
+
+Parse by splitting `document.body.innerText` on `Library ID: `. Each chunk gives
+the start date, the advertiser (the line before `Sponsored`), the
+`N ads use this creative` count, `0:00 / 0:00` when the creative is video, and
+the display domain.
+
+Destination URLs are not in the text. Pull them from the DOM:
+
+```js
+[...document.querySelectorAll('a[href*="l.php"], a[href*="l.facebook.com"]')]
+  .map(a => decodeURIComponent(new URL(a.href).searchParams.get('u') || ''))
+```
+
+Pagination is a **"See more"** button, not infinite scroll. Click it in a loop.
+
+### Paid route — Apify MCP. Ask first; it spends credits.
+
+Server `apify` at `https://mcp.apify.com/`, header `Authorization: Bearer <APIFY_TOKEN>`.
+
+```text
+search-actors        find a Facebook Ad Library actor
+fetch-actor-details  read its input schema BEFORE calling
+call-actor           run it (waitSecs 0-45; 0 returns a runId immediately)
+```
+
+Results return storage IDs, not rows. Build the URL from the ID and read it as
+an MCP resource, paging with `limit`/`offset` because reads inline only to
+about 256 KB:
+
+```text
+http://api.apify.internal:3333/v2/datasets/{datasetId}/items?clean=true&format=json&limit=100
+```
+
+Use this route for volume, scheduled monitoring, or when the browser is
+unavailable.
+
+## 3. Read the numbers
+
+Five rules decide everything downstream.
+
+1. **A duplicated creative is a winner.** `N ads use this creative` means one creative across N ad sets. Nobody duplicates twenty-four times to test; they duplicate because it already won. This is the only free profitability signal that exists.
+2. **Many creatives with no duplication means still testing.** Judge nothing until it survives.
+3. **Mass inactivity kills an angle.** If an angle sits entirely in `active_status=inactive`, it was tried at volume and abandoned. Do not re-run it as though it were undiscovered.
+4. **Age beats volume.** One ad alive 150 days outranks ninety ads alive three weeks. Spend fakes volume; it cannot fake survival.
+5. **Durations are floors.** Meta resets the start date on material edits.
+
+Also compute `active ÷ (active + inactive)` per keyword for the survival rate of
+the space, and cross-check each operator's brand keyword against their personal
+name — the oldest ad is often a different, older offer.
+
+## 4. Scrape the pages behind the winners
+
+Fetch the destination URLs from step 2. Funnel pages are usually JS-rendered; if
+a fetch returns only the footer or a 403, load it in a browser instead.
+
+Capture verbatim, never paraphrased: headline, sub-headline, every bullet, form
+fields, CTA button text, countdown or date language, price, guarantee, and proof
+claims. Paraphrase destroys the evidence.
+
+**Evergreen tell:** a CTA reading "See The Next Workshop Time" or "STARTING 8PM
+TONIGHT" with a rolling countdown, rather than a fixed calendar date.
+
+**Also record the mechanics, not just the copy** — social-proof counters,
+incentivised phone capture, attendance bribes, and how many separate
+application pages sit behind one registration.
+
+## 5. Write the teardown
+
+One entry per offer. Name the offer so it can be argued about.
+
+| Field | Why it matters |
+|---|---|
+| Front-end format | webinar, evergreen, challenge, VSL, sales page |
+| Promise, verbatim | the words that actually buy the click |
+| Product sold | SaaS, agent, marketplace, course, community, coaching, DFY |
+| Price ladder | front end, order bumps, OTO, high-ticket |
+| Operators running it | one company, or a licensee/affiliate network |
+| Ads and duplication | total ads, and unique creatives |
+| Days live | from the oldest still-active ad |
+| Format mix | video versus static |
+
+## 6. Specify the offer
+
+Test the draft against what the teardown shows.
+
+- **Does the promise end at money?** Offers that stop at a capability die young. Offers that close the loop to revenue survive.
+- **Is the number in the first line?** Winning pages lead with a specific figure and make it the reader's future, not the founder's past.
+- **Is the front end in the proven band?** Free registration, or roughly $7–$97. Anything above needs a free front door in front of it.
+- **Is there an order bump?** A single front-end price rarely liquidates ad spend. Bumps should sell the half the core product does not deliver.
+- **Is the back end an outcome rather than more software?** Winning back ends sell the result; the software is the delivery mechanism.
+- **Is there one door per avatar?** Separate registration pages feeding one event beat one page trying to address everyone.
+- **Is the proof aggregate?** Customer averages travel further, and survive scrutiny better, than founder claims.
+
+## 7. Artifacts
+
+- A dated teardown document in the project's research folder.
+- A specified offer: promise, avatar, format, price ladder, bumps, back end.
+- A concise ingest into Atlas so later work inherits the decision.
+
+## 8. Verification
+
+Do not report completion without: the query strings used, ad and duplication
+counts per operator, at least one verbatim landing page per shortlisted offer,
+and an explicit statement of what was not covered.
+
+## 9. Status language
+
+Use `draft`, `dogfooding`, `proven`, `deprecated` exactly as defined in
+`docs/skill-governance-sop.md`. An offer that has not run traffic is `draft`,
+however good the research is.
+
+## Pitfalls
+
+- **Benchmarking against a dead funnel.** Confirm which of your own campaigns are actually live before comparing. A paused offer's creative is not your current positioning.
+- **Reading raw ad counts as spend.** Ad count without the duplication breakdown misreads eight winning creatives as eighty tests.
+- **Treating an empty lane as opportunity.** Usually it means unproven demand, not undiscovered demand. Say which you believe and why.
+- **Copying competitor copy.** Quote it as evidence; never ship it.
+- **Claiming conversion insight.** Longevity and duplication are profitability proxies. Nothing in the Ad Library measures conversion, and no spend data exists for US-targeted ads.
+- **Sampling silently.** Every sweep is impressions-sorted and sampled from the top. State what was left uncovered.
+
+## Handoff
+
+Feeds `cs-marketing-website` for the page build, and the offer's back-end
+definition into the relevant build or release planning.

--- a/.claude/skills/cs-marketing-research/SKILL.md
+++ b/.claude/skills/cs-marketing-research/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: cs-marketing-research
+description: >
+  Research a product idea before committing it to a CodeSpring build plan. Finds
+  direct competitors, open-source projects, substitutes, and relevant platform
+  capabilities; separates commodity features from a defensible wedge; then
+  records an evidence-backed recommendation and creates only the scoped feature
+  and tasks worth building. Use when the user asks whether an idea already
+  exists, requests market or competitor research, asks what would make a
+  product unique, or wants to validate an idea before creating a PRD or tasks.
+---
+
+# Market research for CodeSpring ideas
+
+## Overview
+
+Turn a vague product idea into a decision: do not build, use or integrate an
+existing solution, or pursue a focused wedge. Treat research as a planning
+gate, not as a way to justify building a duplicate.
+
+## 1. Frame the job to be done
+
+- Restate the desired outcome, target user, platform, and constraints.
+- Identify the smallest complete workflow, including the moment the user gets
+  value. Do not research a feature list before identifying that workflow.
+- Name the unproven assumptions that change the decision, such as whether an
+  API exists, whether an existing tool automates the workflow, and whether the
+  requested platform matters.
+
+## 2. Research the market and technical reality
+
+- Search for direct products, open-source repositories, platform-native
+  features, and adjacent substitutes. Prefer primary sources: product docs,
+  source repositories, release notes, and source code.
+- For each serious alternative, record: intended user, exact overlapping
+  workflow, interaction model, maturity signals, license or pricing, and
+  meaningful gaps. Verify claimed capabilities from the source; do not rely on
+  search snippets alone.
+- Check relevant platform and API documentation before proposing automation.
+  Flag unsupported, brittle, credential-scraping, or GUI-injection approaches.
+- Do not call an idea unique merely because its UI, programming language, or
+  name differs. It is only a wedge when it changes the outcome, audience,
+  distribution, or integration surface.
+
+## 3. Make a recommendation
+
+Choose one outcome and state it plainly:
+
+- **Do not build:** an existing solution directly satisfies the job.
+- **Adopt or integrate:** use an existing tool and build only the missing
+  integration or workflow layer.
+- **Build a wedge:** define one narrow user, outcome, and capability that the
+  alternatives do not offer.
+
+For a build recommendation, give a one-sentence positioning statement, MVP
+boundary, non-goals, risks, and the evidence behind the choice. Avoid a generic
+feature comparison dump.
+
+## 4. Sync the decision to CodeSpring
+
+- Read project context, relevant features, mindmap, PRDs, and existing tasks
+  before changing CodeSpring. Reuse a suitable existing feature where possible.
+- Add an evidence-backed mindmap note with research date, sources, decision,
+  alternatives considered, and explicitly rejected scope.
+- Create or update a feature only when the recommendation is to build a wedge
+  or an integration. Do not create a feature for a commodity clone.
+- Create a small dependency-linked task list only after the MVP boundary is
+  clear. Each task must state what it may touch, what it must not touch, and
+  how to verify it. Use existing CodeSpring task conventions.
+- If the recommendation is adoption, create a single evaluation or integration
+  task rather than pretending a new application needs to be built.
+
+## Output
+
+Return a short research memo with:
+
+- Decision and confidence.
+- Direct alternatives and exact overlap.
+- Proposed wedge or reason not to build.
+- MVP, non-goals, and top risks.
+- CodeSpring changes made, including task order.

--- a/.claude/skills/cs-marketing-research/agents/openai.yaml
+++ b/.claude/skills/cs-marketing-research/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Market Research"
+  short_description: "Validate a product idea before planning"
+  default_prompt: "Use $cs-market-research to assess this idea before we plan it in CodeSpring."

--- a/.claude/skills/cs-marketing-website/SKILL.md
+++ b/.claude/skills/cs-marketing-website/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: cs-marketing-website
+description: Use when an app needs its marketing pages set up and organised. Builds the site architecture, page inventory, proof map, conversion paths, and a founder-facing NOW/NEXT/LATER workboard.
+metadata:
+  author: codespring
+  version: "0.1"
+---
+
+# Website foundation for an app
+
+Use this skill when a founder has a finished or credible product but cannot reliably remember what each website page is for, what to build next or which marketing work is blocked. This is the coordinating marketing skill. It turns a scattered site and a list of ideas into a maintained page inventory and a dependency-aware workboard.
+
+Do not use it to publish content, make a production change, spend on ads or claim a page is live. Those actions require the appropriate follow-on skill and approval.
+
+## Required inputs
+
+Collect or explicitly mark missing:
+
+- product, buyer and job to be done;
+- primary conversion action and destination;
+- current production URL and source repository, if available;
+- approved proof: customer outcomes, screenshots, product demos, reviews or source data;
+- analytics and Search Console access status;
+- founder availability, decision owner and review cadence.
+
+If the live site or repository is unavailable, create a **DRAFT** inventory from supplied information and record the blocker. Do not infer technical state.
+
+## Step 1: inspect, inventory, and organise the site
+
+Inspect the actual website, routes, navigation, sitemap and conversion paths. Use `templates/page-inventory.csv` to record each existing and needed page.
+
+For every page capture: URL, page home, parent route, navigation label, page type, audience, job to be done, primary CTA, proof, indexation state, owner, status, dependency, success metric, next action and review date.
+
+Use these page homes by default:
+
+| Page purpose | Home |
+| --- | --- |
+| Product/category or use-case conversion | product, solution or use-case page |
+| Evergreen how-to answer | `/resources/guides/[slug]` |
+| Tool/approach decision | `/resources/comparisons/[slug]` |
+| Useful template, checklist or generator | `/resources/tools/[slug]` |
+| Approved customer evidence | `/resources/stories/[slug]` |
+| Company updates and launches | `/blog/[slug]` |
+| Product help | `/docs/[slug]` |
+
+A page must have one primary job. If it has several, split it or state the priority.
+
+### Required page architecture
+
+Before adding pages, define a compact hierarchy. Start with only the lanes the product can genuinely support:
+
+```text
+/                         # home: category, buyer, promise, primary CTA
+/product or /solutions    # product/use-case conversion pages
+/pricing                  # packaging and purchase path, if public
+/resources                # resource hub; not a dumping ground
+  /guides                 # evergreen how-to answers
+  /comparisons            # decision pages
+  /tools                  # useful templates, checklists, or generators
+  /stories                # approved customer evidence
+/docs                     # product help, not acquisition content
+/blog                     # announcements and time-bound updates
+```
+
+- Keep navigation to a small set of buyer-relevant top-level destinations. A resource subtype belongs in its own hub and is linked from the relevant product page; do not make every article a top-nav item.
+- A planned page gets a parent/home before it gets a slug. Do not create duplicate guides, comparisons, blog posts, and docs pages that answer the same job.
+- A resource lane stays out of the sitemap and is `noindex` until it has a useful hub and at least one complete, original page. Retired or duplicate pages need an explicit redirect/noindex decision.
+- Use `templates/page-brief.md` for every new material page before writing or building it.
+
+**Done when:** the inventory covers every route that matters to a buyer, customer or crawler; every page has a page home and primary job; and missing pages are ordered on the workboard rather than created ad hoc.
+
+## Step 2: establish truth and proof
+
+Write the product truth in `templates/website-context.md`:
+
+- audience, problem and category;
+- promise that can actually be supported;
+- what the product does not do;
+- approved proof and evidence gaps;
+- conversion action and objection each page must address.
+
+Mark any unapproved customer name, quote, metric or screenshot as **BLOCKED/AWAITING APPROVAL**. Never turn an anecdote into public proof.
+
+**Done when:** every planned page can point to a source of truth or is explicitly marked as research-needed.
+
+## Step 3: create the workboard
+
+Sort the inventory into `templates/website-workboard.md`:
+
+- **NOW**: the smallest set of unblocked actions that improves a broken conversion path, missing essential product page or high-intent question.
+- **NEXT**: work that becomes useful once NOW is complete.
+- **LATER**: worthwhile but not currently limiting growth.
+- **BLOCKED/AWAITING APPROVAL**: work waiting on a founder, customer consent, access, copy approval, production deploy or evidence.
+
+Every item requires an owner, concrete next action, dependency and evidence of done. Do not add vague cards such as "improve SEO".
+
+**Done when:** the founder can ask "what should we do this week?" and receive one clear NOW item plus the blocker or approval needed.
+
+## Step 4: establish the durable marketing system
+
+Create or confirm these records in the client repository or operating workspace:
+
+1. page inventory;
+2. marketing context brief;
+3. NOW/NEXT/LATER/BLOCKED workboard;
+4. content register for planned Resources pages;
+5. customer-story pipeline with consent and approval tracking;
+6. weekly and monthly review cadence.
+
+Use `references/status-language.md` exactly. A committed or locally built page is not LIVE.
+
+## Handoffs
+
+- Technical crawlability, canonical, sitemap and Search Console setup → `cs-marketing-seo`.
+- Answer-led, source-backed Resources content → `cs-marketing-aeo-content`.
+- Recurring briefs, publishing, review and founder updates → `cs-marketing-content`.
+- Customer interviews and approved story production → `cs-marketing-content` until a dedicated story/video skill is proven.
+
+## Common mistakes
+
+1. **Treating the blog as the entire website.** Product, resource, story and docs pages serve different jobs.
+2. **Publishing empty resource lanes.** Keep them noindex until there is useful, complete material.
+3. **Planning without an owner or review date.** It becomes an archive, not an operating system.
+4. **Confusing local completion with live.** Require public URL verification after deployment.
+5. **Inventing proof.** Unapproved claims destroy the trust the system is meant to build.
+
+## Verification checklist
+
+- [ ] Page inventory has a row for every material route and needed page.
+- [ ] Every row has a page home, job, audience, CTA, owner, status and next action.
+- [ ] Every material new page has a page brief, parent route, indexation decision, and a place in the navigation/internal-link plan.
+- [ ] Product truth and approved proof are separated from research gaps.
+- [ ] Workboard has NOW, NEXT, LATER and BLOCKED sections.
+- [ ] The highest-priority NOW item has its dependencies and approval boundary stated.
+- [ ] Next weekly check-in and monthly review dates are recorded.

--- a/.claude/skills/cs-marketing-website/references/page-inventory.md
+++ b/.claude/skills/cs-marketing-website/references/page-inventory.md
@@ -1,0 +1,20 @@
+# Website page inventory
+
+Use one row per live, planned or retired page. Keep this in the client repository or operating workspace, not in chat.
+
+| URL | Page home | Parent route | Navigation label | Page type | Audience | Job to be done | Primary CTA | Proof/source | Indexation | Owner | Status | Dependency | Success metric | Next action | Review date |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `/resources/guides/example` | resources/guides | `/resources/guides` | Guide title | guide | prospective builder | answer a real question | related product page | approved demo or source | noindex until complete, then index | owner | DRAFT | evidence review | qualified CTA clicks | write the brief | YYYY-MM-DD |
+
+## Status
+
+Use only: **DRAFT**, **READY**, **IN PROGRESS**, **AWAITING APPROVAL**, **QUEUED**, **SUBMITTED**, **LIVE / VERIFIED**, **BLOCKED**.
+
+Do not call a route live until its public URL is independently checked after deployment.
+
+## Page organisation rules
+
+- Give every page exactly one **page home** and one **parent route** before creating it.
+- Use product/solution pages for conversion, Resources for evergreen acquisition/helpful assets, Docs for product help, and Blog for announcements/time-bound updates.
+- Record an explicit `index`, `noindex`, `redirect`, or `retired` decision for every page. Do not add drafts or empty hubs to a sitemap.
+- A page that overlaps an existing page is an update, consolidation, redirect, or rejected idea — not a duplicate route.

--- a/.claude/skills/cs-marketing-website/references/status-language.md
+++ b/.claude/skills/cs-marketing-website/references/status-language.md
@@ -1,0 +1,10 @@
+# Status language
+
+- **DRAFT**: proposed but not approved or executed.
+- **READY**: prerequisites are present; work can begin.
+- **IN PROGRESS**: execution has started; required checks are incomplete.
+- **AWAITING APPROVAL**: blocked by a decision, credentials, spend, publication action, customer consent or production change.
+- **QUEUED**: scheduled for a future run; not live.
+- **SUBMITTED**: sent to a third party; not confirmed live.
+- **LIVE / VERIFIED**: public or production state independently checked with URL, ID, timestamp or test evidence.
+- **BLOCKED**: cannot proceed; state the dependency and owner.

--- a/.claude/skills/cs-marketing-website/templates/page-brief.md
+++ b/.claude/skills/cs-marketing-website/templates/page-brief.md
@@ -1,0 +1,37 @@
+# Page brief
+
+## Identity and placement
+- Proposed URL:
+- Page home:
+- Parent route / hub:
+- Navigation label (if any):
+- Page type:
+- Indexation decision: `index` / `noindex` / `redirect` / `retired`
+
+## Purpose
+- Primary audience:
+- Job to be done / search or product intent:
+- One-sentence page promise:
+- Primary CTA and destination:
+- Supporting CTA (optional):
+
+## Evidence and scope
+- Approved proof/source:
+- Claim requiring approval or source:
+- What this page does not cover:
+- Existing page to link from / avoid duplicating:
+
+## Structure
+- Proposed title and H1:
+- Required sections:
+- Internal links in:
+- Internal links out:
+- Schema decision, if any:
+
+## Delivery
+- Owner:
+- Status:
+- Dependency / approval:
+- Success metric:
+- Verification evidence:
+- Review date:

--- a/.claude/skills/cs-marketing-website/templates/page-inventory.csv
+++ b/.claude/skills/cs-marketing-website/templates/page-inventory.csv
@@ -1,0 +1,3 @@
+url,page_home,parent_route,navigation_label,page_type,audience,job_to_be_done,primary_cta,proof_or_source,indexation,owner,status,dependency,success_metric,next_action,review_date
+/,home,,Home,product,[buyer],[job],[CTA],[source],index,[owner],DRAFT,[dependency],[metric],[action],YYYY-MM-DD
+/resources/guides/[slug],resources/guides,/resources/guides,[guide title],guide,[reader],[question],[CTA],[source],noindex-until-complete,[owner],DRAFT,[dependency],[metric],[action],YYYY-MM-DD

--- a/.claude/skills/cs-marketing-website/templates/website-context.md
+++ b/.claude/skills/cs-marketing-website/templates/website-context.md
@@ -1,0 +1,21 @@
+# Website context
+
+## Product truth
+- Product:
+- Audience:
+- Job to be done:
+- Category and alternatives:
+- What it does not do:
+- Primary conversion action:
+
+## Approved proof
+- Product workflow or demo:
+- Customer-approved outcome:
+- Quote/metric and source:
+- Screenshot/video approved for use:
+
+## Evidence gaps and approvals
+- Claim needing source:
+- Customer permission needed:
+- Founder decision needed:
+- Analytics/Search Console access status:

--- a/.claude/skills/cs-marketing-website/templates/website-workboard.md
+++ b/.claude/skills/cs-marketing-website/templates/website-workboard.md
@@ -1,0 +1,18 @@
+# Website workboard
+
+## NOW
+- [ ] [Action] — owner: [name] — dependency: [none/what] — evidence of done: [URL/test/approval]
+
+## NEXT
+- [ ] [Action] — owner: [name] — dependency: [what must happen first]
+
+## LATER
+- [ ] [Action] — reason it is not currently limiting growth: [reason]
+
+## BLOCKED / AWAITING APPROVAL
+- [ ] [Action] — owner of blocker: [name] — needed decision/access/consent: [detail]
+
+## Cadence
+- Weekly website/content review:
+- Monthly performance and refresh review:
+- Next founder decision:

--- a/.claude/skills/cs-seo-website/SKILL.md
+++ b/.claude/skills/cs-seo-website/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: cs-seo-website
+description: "Use when growing CodeSpring site SEO, content, or listings."
+version: 0.5.0
+author: CodeSpring
+metadata:
+  tags: [codespring, seo, marketing-site, search-console, content, link-building]
+---
+
+# CodeSpring website SEO operator
+
+Use for CodeSpring marketing-site work: robots/sitemaps/canonicals, Search Console exports, docs/tutorials, the Vibe Code Library, product listings, referral links and organic-growth reporting.
+
+This skill covers **the CodeSpring website repo** (`VolkisAI/codespring-webinar`), not CodeSpring customer projects. Its goal is qualified organic traffic and conversions, not a vanity Domain Rating (DR) target.
+
+## Operating principle
+
+A third-party authority metric can be a diagnostic, but it does not itself make pages rank. Prioritise in this order:
+
+1. pages Google can crawl, index and understand;
+2. pages that satisfy a real search intent better than existing results;
+3. topical internal links and a clear conversion path;
+4. genuine mentions, reviews, integrations and editorial references;
+5. measurement of non-branded impressions, qualified visits and sign-ups.
+
+Never promise a DR/ranking result or buy/mass-submit links designed chiefly to manipulate rankings. A `nofollow` mention can still be valuable when it drives the right people.
+
+## Branch and release model
+
+Read the website repository `AGENTS.md` first. It is the operating contract and wins over this skill.
+
+- `main`: live branch and the only branch permitted to change shared SEO files such as `app/sitemap.ts`, `app/robots.ts`, `app/layout.tsx`, `lib/site-links.ts`, `templates/` and `docs/*.md`.
+- `blog`: only `app/blog/**`, `content/blog/**` and `public/blog/**`.
+- `library`: only Vibe Code Library-owned paths.
+- `docs`: only docs route/component paths.
+- `marketing`: only marketing-owned paths.
+
+Never recreate `dev`, never use an ad hoc `fix/seo-*` branch in the website repository, and never commit or push directly to `main`. Each area branch is cut from `origin/main`, keeps one draft PR into `main`, and begins every session by merging `origin/main` before any edits. A required shared SEO change is a separate, small main-only PR for human review.
+
+```bash
+git fetch origin --prune
+git switch blog  # or library, docs or marketing
+git merge origin/main
+git status --short --branch
+```
+
+For a new area branch that does not yet exist, create it from `origin/main` exactly as `AGENTS.md` instructs. Run `npx tsc --noEmit`, `rm -rf .next out && npm run build` and `node --test tests/*.mjs`; if an unchanged baseline test fails, report it exactly and do not claim the full suite passed. Push and verify the remote SHA before reporting completion.
+
+## 1. Technical SEO baseline
+
+Before creating content or seeking listings, inspect the live route **and** implementation on `origin/main`:
+
+- one canonical host, with the other host permanently redirected at CDN/hosting level;
+- valid `200 text/plain` `/robots.txt` with a sitemap declaration;
+- valid `200 XML` `/sitemap.xml` containing only canonical, intentionally indexable URLs;
+- server-rendered titles, meta descriptions, canonical URLs and meaningful body content;
+- intentional `noindex` for conversion-only, preview, account and duplicate routes;
+- internal links crawlers can follow without JavaScript;
+- accurate, visible-only structured data where applicable;
+- Search Console domain property, sitemap submitted, URL Inspection checked.
+
+For static Next.js exports, `app/robots.ts` and `app/sitemap.ts` generate the public files. A host redirect cannot be solved in Next.js source alone when S3/CloudFront serves static files; document and apply it at the delivery layer.
+
+Acceptance test after a production deployment:
+
+```bash
+curl -sSIL https://codespring.app/
+curl -sSIL https://www.codespring.app/     # expect 301 to the matching bare-host URL
+curl -sSI https://codespring.app/robots.txt
+curl -sSI https://codespring.app/sitemap.xml
+curl -sS https://codespring.app/robots.txt
+curl -sS https://codespring.app/sitemap.xml
+```
+
+## 2. Search Console → content loop
+
+Treat the Search Console query export as the backlog source. Do not choose page topics from generic keyword lists alone.
+
+1. Ingest the export and retain columns for query, page, clicks, impressions, CTR, average position, country and date range.
+2. Cluster queries by intent: brand, comparison, tutorial/problem, product/category, and support/docs.
+3. Prioritise terms with either:
+   - meaningful impressions and weak CTR/position; or
+   - clear commercial/problem intent matching CodeSpring’s product; or
+   - an existing page with a credible chance to be improved.
+4. For every page brief define: target intent, reader’s job, unique evidence/example, title, H1, outline, internal links, CTA, schema decision and success metric.
+5. Publish, request indexing only when the page is genuinely ready, then review at 14/28/56 days. Improve pages based on impressions, CTR and conversion—not publication count.
+
+Monthly scoreboard:
+
+`non-branded impressions | non-branded clicks | top-20 queries | indexed URLs | qualified organic sessions | organic sign-ups | referring domains | referral sign-ups`.
+
+## 3. Proactive daily content desk
+
+Run a founder-reviewable SEO desk at the start of each working day. The target output is **five distinct, fully written review pages**, not five briefs and never five automatically published URLs. Every page must independently have distinct intent, original value, demand evidence, no cannibalisation and a credible conversion path. If only three or four pages can honestly pass those gates, deliver those complete pages and explain why the remaining slots were withheld. This protects CodeSpring from scaled-content and doorway-page behavior while still creating a fast production rhythm.
+
+Use Search Console first, the cached monthly DataForSEO dataset second and live SERPs only for the short list. Treat Instagram, TikTok, YouTube and sales calls as qualitative sources for language, questions and objections—not as automatic one-video-per-landing-page instructions. Improve an existing canonical page whenever it already owns the intent.
+
+Each morning:
+
+1. rank five opportunities across commercial comparisons, problem-led guides, useful tools/templates, canonical-page refreshes and proof/docs/story work;
+2. build up to five complete, readable pages; withhold any slot that cannot pass the evidence and content gates;
+3. push a review branch and provide one verified, directly openable Vercel route per page—never localhost;
+4. send Sebastian a compact review packet with the target query, SERP gap, original value, CodeSpring position, CTA and one exact decision needed;
+5. select one or two pages where a founder YouTube video materially adds proof or teaching value;
+6. keep video demos simple by default: no authentication, database, backend, payments or deployment; use a single-screen utility, local-data interaction, one workflow or a current-interface comparison;
+7. create thumbnail candidates only after the page and video angle are approved;
+8. apply feedback, refresh previews and merge only with explicit approval; keep AWS production deployment separate.
+
+Track every opportunity and page through:
+
+`OPPORTUNITY → BRIEFED → REVIEW → REVISION → APPROVED → MERGED → AWAITING AWS DEPLOYMENT → LIVE / VERIFIED → 14/28/56-DAY REVIEW`.
+
+The morning run is incomplete without remote review URLs or explicit access blockers. Never call a Vercel preview published or live. Never let a page quota override distinct intent, usefulness, original evidence or quality.
+
+Use `references/daily-seo-content-desk.md` for the full selection, build, video, indexing and measurement workflow. Write the daily artifact with `templates/morning-seo-review.md`.
+
+## 4. Content systems
+
+### Tutorials and documentation
+
+Use tutorials for problems the product demonstrably solves: planning an AI-built app, turning requirements into PRDs, project/task sequencing, importing a codebase, and connecting coding agents. Lead with the reader’s outcome, give a real walkthrough/example, then use a direct CodeSpring CTA.
+
+Do not write generic AI filler or dozens of slight keyword variants. One high-quality tutorial with original examples and internal links beats a thin post farm.
+
+#### Write for beginners without flattening the meaning
+
+Plain English does not mean chopping every thought into the fewest possible words. Sentence length and reading-grade scores are checks, not quotas. Keep enough context for the reader to understand what changed, what broke and why the lesson matters.
+
+- Prefer ordinary language: say a feature is `done`, not that somebody can `call it finished`.
+- Keep the subject, action and result clear. Avoid compressed lines such as `The main screen worked. The blank form, failed save or next step did not.` Rewrite the full causal example.
+- Do not concatenate several states into one sentence merely to reduce word count. If three or more checks sit at the same level, introduce them and use bullets.
+- Use a real sequence: what was built, what initially worked, what changed later, what broke, and which acceptance check or test would catch the regression.
+- For example, explain that a CSV upload worked, a later data-processing change broke the upload, and the original upload tests should still pass after the new work.
+- Use paragraphs for explanation and bullets for parallel checks, edge cases, steps or outcomes. A long wall of prose is not beginner friendly.
+- Read the copy aloud. If a sentence is grammatically short but hard to understand without guessing the missing connection, rewrite it rather than shortening it further.
+- First-person founder lessons must come from Sebastian's feedback, first-party videos, call transcripts or recorded CodeSpring experience. Never invent the experience to make a page sound personal.
+
+### Editorial comparison and guide pages
+
+Treat a comparison page as an editorial article, not a landing-page feature grid.
+
+1. **Read the live SERP examples first.** Inspect the strongest ranking pages for structure, reader questions and missing evidence. Learn from them without copying text, images or unsupported claims.
+2. **Start with the reader.** Open with the situation, problem and decision they are trying to make. Do not introduce CodeSpring before answering the comparison intent.
+3. **Use article anatomy.** Include a visible founder byline/photo when Sebastian is the author, an updated date, reading time and linked chapter navigation for long pages.
+4. **Give each compared product its own section.** Explain what Claude Code, Codex, Cursor or another product does well, who it suits and what context it still needs. Put CodeSpring in its own later section, then summarise the choice in a fair table or decision path.
+5. **Use real visuals, not decorative substitutes.** For every third-party product, use a current screenshot captured from that product's first-party public product page or documentation. Store the optimised image locally, record the source URL/date, add meaningful alt text and link the caption to the official source. Never use search-result thumbnails, AI-redrawn interfaces or generic text-block diagrams when an authentic UI view is available.
+6. **Reuse real CodeSpring product assets.** Inspect the current homepage and `public/` library before inventing a diagram. Prefer the real mind map, generated PRD, journey/map or Kanban board screenshots already approved on the site. Replace placeholder architecture blocks with the relevant product UI.
+7. **Make comparison tables scannable.** Pair each product name with its official/approved logo at a consistent size. Keep supporting copy slightly smaller than article body copy and present each cell as a short bullet-style point rather than a dense paragraph. Logos identify products; they do not imply endorsement.
+8. **Build a visible internal-link map.** Link CodeSpring mentions to the homepage where the reader needs the product definition. Link topical phrases such as mind map, PRDs and Kanban board to their specific documentation pages. Links must look like links without requiring hover: use an accessible contrasting colour and underline, then verify every destination. Keep the final CTA direct. Link third-party screenshot captions and sources to their first-party pages.
+9. **Keep evidence honest.** Do not claim hands-on benchmark results unless the same task, environment and review method were documented. State when a page is a decision guide rather than a performance benchmark.
+10. **Verify the whole article.** Confirm screenshots load at natural dimensions, logos are legible, chapter anchors work, mobile/desktop layouts remain readable, metadata/canonical/schema are correct and every claim has visible support.
+
+For review, a Vercel PR preview is acceptable when it is actually accessible to the reviewer. Production remains the manual AWS workflow. Label the preview `REVIEW`, not `LIVE / VERIFIED`, and never imply that a Vercel preview changed AWS production.
+
+### Vibe Code Library
+
+Use the dedicated `feat/codespring-vibe-code-library` branch and strategy doc. An app page becomes indexable only when it has an original scoped verdict, realistic core loop, hard boundaries/exclusions, feature groups, original FAQs, sources/review date and meaningful related links. Draft pages stay out of the sitemap.
+
+The library’s conversion asset is not a generic directory listing: it is an honest plan/prompt/map for building a scoped substitute, with a real CTA destination.
+
+## 5. Listings and mentions
+
+Create one product-profile packet before using any directory:
+
+- product name and canonical URL;
+- 60-word and 160-character descriptions;
+- positioning/category;
+- logo, screenshots and approved demo link;
+- pricing/support/founder details that are true at submission time;
+- UTM-tagged referral URL;
+- owner, approval status and source evidence.
+
+### Qualification gate
+
+Use a listing only if at least one is true:
+
+- it reaches a relevant buyer/developer community;
+- it is a truthful review/integration/partner profile;
+- it can create editorial discovery or referral traffic;
+- it is a product launch with a real community response.
+
+Reject sites whose primary offer is selling “dofollow backlinks,” bulk link exchanges, spun descriptions or a large batch of low-quality submissions. Never create accounts, pay for placements, publish claims, or solicit reviews without approval and company-controlled credentials.
+
+Track every prospect in a ledger:
+
+`source | relevance | reason | proposed URL | rel | cost | owner | approval | submitted | live listing | referral sessions | sign-ups | review date`.
+
+Status labels are exact: **DRAFT**, **AWAITING APPROVAL**, **SUBMITTED**, **LIVE**, or **REJECTED**. Do not call a submission a live backlink until the public listing and outbound link are verified.
+
+## 6. Review and release checklist
+
+- [ ] Live and `origin/main` source inspected first.
+- [ ] Search intent and original evidence exist for each indexable page.
+- [ ] Daily desk targets five fully written review pages; every page independently passes the no-cannibalisation and original-value gates, and withheld slots have an explicit reason.
+- [ ] Every completed morning page has a directly openable, verified Vercel review route and one precise founder decision request.
+- [ ] Video briefs are limited to one or two high-value pages, use deliberately simple scope and do not block page review.
+- [ ] Canonical, title, description, server-rendered links and sitemap inclusion checked.
+- [ ] New Vibe Code pages pass the content gate.
+- [ ] Listing passes relevance/quality gate and has approval.
+- [ ] Editorial pages use article anatomy, first-party screenshots, approved logos, image provenance and real CodeSpring product assets.
+- [ ] Comparison tables are compact and scannable; internal links are visible without hover and point to the relevant homepage or documentation route.
+- [ ] Mobile/desktop and themes reviewed for UI changes.
+- [ ] `npx tsc --noEmit`, `npm run build` and `node --test tests/*.mjs` pass, or unchanged baseline failures are reported exactly.
+- [ ] Branch pushed, remote SHA verified and draft PR targets `main`.
+- [ ] Report review preview and AWS production status separately.
+- [ ] After approval and AWS verification, provide the sitemap/internal-link/Search Console indexing handoff; never imply a crawl request guarantees indexing.

--- a/.claude/skills/cs-seo-website/references/daily-seo-content-desk.md
+++ b/.claude/skills/cs-seo-website/references/daily-seo-content-desk.md
@@ -1,0 +1,153 @@
+# Daily SEO content desk
+
+Use this operating loop to prepare a founder-reviewable SEO packet each morning without turning volume into scaled-content spam.
+
+## Capacity rule
+
+The target is **five qualified opportunities and five fully written, review-ready page drafts** per working day.
+
+Five new indexable pages is a ceiling, not a quota. Build all five only when every page:
+
+- owns a distinct search intent and does not cannibalise an existing CodeSpring URL;
+- has current demand/SERP evidence and a credible CodeSpring conversion path;
+- contains original explanation, proof, product UI, example, tool or founder judgment;
+- passes the content, metadata, internal-link and visual verification gates independently.
+
+Five is a production target, not permission to lower the gate. If only three or four opportunities can become useful, non-overlapping pages, deliver those complete pages and state why the other slots were withheld. A slot may instead be an existing-page refresh, internal-link improvement, documentation expansion or customer-proof page when that is the better canonical answer. [Google defines scaled-content abuse](https://developers.google.com/search/docs/essentials/spam-policies#scaled-content) as generating many low-value or unoriginal pages primarily to manipulate rankings; speed never overrides usefulness.
+
+## Daily page mix
+
+Select from these lanes according to demand rather than forcing one of each every day:
+
+1. **Commercial comparison/category:** one substantial parent comparison or decision guide, not thin pairwise variants.
+2. **Problem-led guide:** answer a specific founder question with a real workflow, example or product proof.
+3. **Tool/template/checklist:** provide something immediately usable, with a truthful route into CodeSpring.
+4. **Refresh/internal-link slot:** improve an existing canonical page that already owns the intent.
+5. **Proof/docs/story slot:** deepen product documentation, customer evidence or a founder-led story only when the source material exists.
+
+Instagram, TikTok, YouTube and sales-call material are **inputs**, not automatic landing pages. Extract repeated questions, objections, language and hooks; then validate search demand and intent before choosing the correct canonical page. Consolidate overlapping clips into one strong resource instead of making one URL per clip.
+
+## Morning workflow
+
+### 1. Refresh the evidence backlog
+
+Use, in order:
+
+1. Search Console query/page performance and existing content gaps;
+2. the monthly cached DataForSEO demand/difficulty/SERP dataset;
+3. a live SERP check for only the shortlisted queries;
+4. recent sales-call objections and social-video topics as qualitative signals;
+5. the current Resources, Docs, Blog and Vibe Code inventories to detect cannibalisation.
+
+For every candidate record: query, country, intent, volume/date, difficulty signal, SERP composition, existing CodeSpring owner, product fit, original evidence, CTA and proposed lane.
+
+### 2. Rank five opportunities
+
+Score each opportunity on demand, commercial/problem intent, CodeSpring fit, ability to add original value, ranking feasibility, production effort and cannibalisation risk. Reject a candidate if its only distinction is a slight keyword variation.
+
+Attempt full production for all five in rank order. Withhold a candidate rather than turn it into a thin page when it fails a gate. The morning packet must say exactly which gate failed.
+
+### 3. Build complete review drafts
+
+For each selected page:
+
+- create or improve the canonical route in a review branch;
+- lead with the reader's answer, not a CodeSpring pitch;
+- include original examples, accurate product positioning and first-party proof;
+- add visible contextual links to the homepage and relevant documentation;
+- use authentic screenshots, meaningful alt text and source provenance;
+- set title, description, canonical, schema decision, sitemap/index state and CTA;
+- run contract tests and render the finished page.
+
+Before founder review, run a plain-language editing pass that protects meaning rather than chasing a low word count:
+
+- define the term with ordinary words such as `done`;
+- make each causal chain explicit: original feature → later change → regression → check or test;
+- replace compressed fragments or concatenated states with complete natural sentences;
+- use bullets for three or more parallel checks, edge cases, steps or outcomes;
+- break up dense prose with useful lists, examples, screenshots or diagrams, not decorative cards;
+- read the page aloud and rewrite any sentence whose subject, action or result is unclear;
+- verify every first-person experience against founder feedback or a first-party source.
+
+Do not publish filler, doorway pages, fake FAQs, fabricated benchmarks, copied SERP text or AI-redrawn product UI.
+
+### 4. Produce accessible review URLs
+
+Localhost is internal verification only. Push the review branch and create a Vercel PR preview for every page. Verify the latest deployment is ready and that the supplied route resolves. If Vercel authentication blocks the founder, label the packet **BLOCKED: REVIEW ACCESS** rather than pretending the page was reviewed.
+
+The morning packet must include one directly openable review URL per completed page. Label these **REVIEW**, never **LIVE / VERIFIED**. AWS remains production and is a separate approved deployment step.
+
+### 5. Send the founder review packet
+
+Use `templates/morning-seo-review.md`. The Telegram message itself stays within five short bullets and links to the durable packet when detail exceeds that limit.
+
+For each page show:
+
+- status and review URL;
+- target query, audience intent and why this page now;
+- what was written or changed;
+- CodeSpring positioning and CTA;
+- evidence/assets still needed;
+- the exact founder decision or correction requested.
+
+### 6. Assign one or two video briefs
+
+Choose the pages where a founder video adds proof, trust or demonstration value. A video is optional; it must not delay pages that stand on their own.
+
+Every video brief includes:
+
+- working YouTube title and thumbnail promise;
+- one-sentence hook;
+- three teaching beats;
+- exact screen/demo sequence;
+- CodeSpring positioning and CTA;
+- maximum build scope and estimated filming effort.
+
+Keep demonstrations intentionally small. Default to no authentication, database, backend, payments, deployment or multi-user state. Prefer a single-screen utility, static interaction, local-data example, one workflow or a screen-led comparison. For comparisons, demonstrate current interfaces and decision criteria without inventing a benchmark or winner.
+
+### 7. Produce thumbnails only after the angle is approved
+
+After the page and video angle are accepted, create one or more thumbnail candidates. Use a short promise, one focal idea and authentic CodeSpring/product evidence where the claim needs it. Never redraw readable product UI or fabricate results. Deliver the thumbnail as a review asset, not as a published YouTube asset.
+
+### 8. Publish only after approval
+
+Apply founder feedback, rerun tests and refresh previews. Merge only the approved pages. AWS deployment, sitemap verification, Search Console indexing request and public URL checks remain separate explicit actions.
+
+Track exact states:
+
+`OPPORTUNITY → BRIEFED → REVIEW → REVISION → APPROVED → MERGED → AWAITING AWS DEPLOYMENT → LIVE / VERIFIED → 14/28/56-DAY REVIEW`
+
+### 9. Hand off indexing after approval and production verification
+
+Google can discover pages automatically through crawlable internal links and the XML sitemap, but discovery and indexing are not guaranteed. Do not request indexing while a page is only on Vercel or merely merged.
+
+After Sebastian approves the page and the AWS production deployment is independently verified:
+
+1. verify the public URL returns `200`, renders the approved content, uses the intended self-canonical and is not `noindex`;
+2. verify the URL appears in `https://codespring.app/sitemap.xml` and has crawlable internal links from the relevant hub/related pages;
+3. verify the sitemap is already submitted in the correct Search Console property; submit or refresh the sitemap only when needed rather than repeatedly every day;
+4. for a small number of priority URLs, open URL Inspection in Search Console, test the live URL and use **Request indexing**;
+5. record the request date and monitor the Page indexing/URL Inspection status—do not repeatedly resubmit the same URL;
+6. report separately: `AWS LIVE / VERIFIED`, `SITEMAP VERIFIED`, `SEARCH CONSOLE REQUESTED`, and `INDEXED / VERIFIED`.
+
+[Google's recrawl guidance](https://developers.google.com/search/docs/crawling-indexing/ask-google-to-recrawl) says crawling can take from a few days to a few weeks, individual URL requests have quotas, repeated requests do not make crawling faster, and a crawl request does not guarantee inclusion. For many URLs, the sitemap is the discovery mechanism; URL Inspection is for a small priority set.
+
+The founder handoff must say exactly what happens next: approve revisions → merge → AWS deploy → production QA → sitemap/internal-link verification → Search Console request for priority URLs → monitor indexing and performance.
+
+## Durable daily register
+
+Keep one row per candidate/page with:
+
+`date | source signal | query | country | intent | volume/date | difficulty | SERP shape | existing owner | lane | route | original evidence | CTA | branch | PR | review URL | status | video priority | video URL | thumbnail path | AWS status | live URL | Search Console request | 14/28/56-day outcome`
+
+Use the register to prevent duplicate pages, lost review URLs and unmeasured publishing.
+
+## Completion criteria
+
+A morning run is complete only when:
+
+- five evidence-backed opportunities are ranked;
+- up to five complete pages have verified remote review URLs, with explicit reasons for every withheld slot;
+- one or two video briefs are selected when video materially helps;
+- no page is called published or live;
+- the durable register and founder review packet are updated.

--- a/.claude/skills/cs-seo-website/templates/morning-seo-review.md
+++ b/.claude/skills/cs-seo-website/templates/morning-seo-review.md
@@ -1,0 +1,72 @@
+# Morning SEO review — {{date}}
+
+**Packet status:** {{REVIEW | PARTIAL / BLOCKED}}
+**Production status:** AWS unchanged unless a separately verified deployment is recorded.
+
+## Today's ranked opportunities
+
+| Rank | Target query / intent | Lane | Existing owner | Evidence | Decision |
+|---|---|---|---|---|---|
+| 1 |  |  |  |  | BUILD / REFRESH / BRIEF |
+| 2 |  |  |  |  | BUILD / REFRESH / BRIEF |
+| 3 |  |  |  |  | BUILD / REFRESH / BRIEF |
+| 4 |  |  |  |  | BUILD / REFRESH / BRIEF |
+| 5 |  |  |  |  | BUILD / REFRESH / BRIEF |
+
+## Review pages
+
+### 1. {{page title}}
+
+- **Status:** REVIEW
+- **Review URL:** {{direct Vercel route}}
+- **Target query:** {{query, country, volume/date and intent}}
+- **Why this page:** {{SERP gap + CodeSpring fit}}
+- **What is original:** {{example, proof, screenshots, tool or founder judgment}}
+- **CodeSpring position:** {{truthful role in this topic}}
+- **Internal links:** {{homepage + relevant docs/resources}}
+- **CTA:** {{destination and user action}}
+- **Needs from Sebastian:** {{one precise decision/correction}}
+
+Repeat for each completed page.
+
+## Video assignments
+
+### Video 1 — {{working title}}
+
+- **Supports page:** {{review URL}}
+- **Thumbnail promise:** {{3–6 words}}
+- **Hook:** {{one sentence}}
+- **Three beats:**
+  1. {{beat}}
+  2. {{beat}}
+  3. {{beat}}
+- **Demo:** {{simple screen sequence}}
+- **Scope guard:** No authentication, database, backend, payments or deployment unless explicitly approved.
+- **CTA:** {{one next step}}
+- **Estimated filming effort:** {{minutes}}
+
+Repeat only when a second video materially improves the day's pages.
+
+## Blockers and approvals
+
+- {{missing proof, source, product claim approval, screenshot, review access or deployment dependency}}
+
+## Indexing handoff — after approval and AWS deployment
+
+- **Public URL:** {{production URL}}
+- **AWS production QA:** {{AWAITING DEPLOYMENT | LIVE / VERIFIED}}
+- **Canonical/noindex:** {{verified result}}
+- **Sitemap:** {{present / missing / submitted}}
+- **Internal discovery links:** {{verified hub/related URLs}}
+- **Search Console:** {{NOT REQUESTED | REQUESTED on date | INDEXED / VERIFIED}}
+- **Next action:** {{exact owner/action}}
+
+Do not request indexing for a Vercel preview or merged-but-undeployed page. For a few priority pages, use Search Console URL Inspection after production verification. Do not repeatedly request the same URL; Google states this does not make crawling faster and indexing is not guaranteed.
+
+## After feedback
+
+1. Apply requested revisions.
+2. Refresh each remote preview and verify it is ready.
+3. Request explicit approval to merge.
+4. Keep AWS deployment separate.
+5. Record live URL and Search Console request only after verification.

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ graphify-out/
 # Playwright
 test-results/
 playwright-report/
+
+# CodeSpring local config
+.codespring/

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -21,6 +21,12 @@
       "sourceType": "github",
       "computedHash": "b3f2de87bbd2e0fe97792cc45ee33c9fa38b161980ccf05d7f6d7ee8952c2382"
     },
+    "codespring": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/codespring/SKILL.md",
+      "computedHash": "3e3c60f8c9e104917fbea344032ed90cfdb07d14229f34e591ac051fbf08527b"
+    },
     "convex": {
       "source": "get-convex/agent-skills",
       "sourceType": "github",
@@ -50,6 +56,90 @@
       "source": "get-convex/agent-skills",
       "sourceType": "github",
       "computedHash": "36d7a5c86a60a2eb75a5590e16ac5a92a93dc010681ad8c7dbc9d456dc426895"
+    },
+    "cs-build-audit-codebase": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-build-audit-codebase/SKILL.md",
+      "computedHash": "6da01236879dc0e3d52bfffca3eaf16d748723089a5b6622a56dd0ccde324b07"
+    },
+    "cs-build-create-prd": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-build-create-prd/SKILL.md",
+      "computedHash": "cadfcde65cf334022580b97022db175762dea51feb4bc74d3b7daa93e44350a5"
+    },
+    "cs-build-create-tasks": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-build-create-tasks/SKILL.md",
+      "computedHash": "39fbfddb7f126be3606e872930c98f4bbb3875d70fc7f9d751975426b7bdbfcb"
+    },
+    "cs-build-feature": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-build-feature/SKILL.md",
+      "computedHash": "7b1023451444bd03675b4e6cb2920036ad7efd47c9849308fcecf48abe184062"
+    },
+    "cs-build-getting-started": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-build-getting-started/SKILL.md",
+      "computedHash": "046f5ac170eee7875da7d3524c03275b94e5443a7ce1abb805af56e0da6d6bf9"
+    },
+    "cs-build-handoff": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-build-handoff/SKILL.md",
+      "computedHash": "08af4c2239da8a915bad1974fccf25786dc42a1f4fed881c459e4cdf02e2d1c2"
+    },
+    "cs-build-import-codebase": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-build-import-codebase/SKILL.md",
+      "computedHash": "22350a4403cd5f4bc31e3f1883e96e5168a00c93d5052f756fd4ec168f48bc7c"
+    },
+    "cs-build-plan-app": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-build-plan-app/SKILL.md",
+      "computedHash": "fefa818c1398e29fb90cd4301a88d9c93685377d9a9ef46e6e20a0eb11b0f5cd"
+    },
+    "cs-build-resync-codebase": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-build-resync-codebase/SKILL.md",
+      "computedHash": "a046a7b4e93e6c2e3874a78367ad26dd9c8958a43f2f6d892599f69a0748981b"
+    },
+    "cs-build-ui-mockup": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-build-ui-mockup/SKILL.md",
+      "computedHash": "982de23623d8f5d1ca3e14a61a23d8f1057ac2ea420ba2dff38410924e594dfe"
+    },
+    "cs-marketing-offer-creation": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-marketing-offer-creation/SKILL.md",
+      "computedHash": "3a017ab9a12c316a6cc47334c9bf662953739da6fdeb4e941c10af1001c15a30"
+    },
+    "cs-marketing-research": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-marketing-research/SKILL.md",
+      "computedHash": "1f38b0f00152a1b28efa12f9dcf6c8cf55691ea461b9442b442955eb0032ac83"
+    },
+    "cs-marketing-website": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-marketing-website/SKILL.md",
+      "computedHash": "8036ce2e26e0eabff624da0203145289d9ab6d9cbbafcfe29831b96b3207f714"
+    },
+    "cs-seo-website": {
+      "source": "CodeSpringApp/codespring-skills",
+      "sourceType": "github",
+      "skillPath": "skills/cs-seo-website/SKILL.md",
+      "computedHash": "877e29ddc300462f2d069a5527cba1400a1cc0bc04fcfe906d6f194ccdcd99c9"
     },
     "deep-research": {
       "source": "199-biotechnologies/claude-deep-research-skill",


### PR DESCRIPTION
## Summary

Installs the CodeSpring skill pack so Tempo Flow can be mapped into a CodeSpring project (core features, sub-features, notes, PRDs, Kanban tasks). This is the tooling half of that setup — the map itself is created against the CodeSpring API and lands no code in this repo.

Two commits:

1. Adds 15 skills under `.agents/skills/` with matching copies in `.claude/skills/`, and records their sources and content hashes in `skills-lock.json`.
2. Adds `.codespring/` to `.gitignore`. `codespring init` writes `.codespring/config.json` containing the linked project id and a local timestamp — per-machine state, not shared configuration. The CLI added this entry itself during linking.

No application code, dependencies or schema are touched. The only config change is the one `.gitignore` line above.

## Linked task(s)

Task: none — no `T-XXXX` ticket exists for CodeSpring setup. This was requested directly rather than picked off the board. Happy to add a row to `docs/TASKS.md` if you'd rather it were tracked.

Note: `CLAUDE.md` points at `docs/brain/TASKS.md`, but `docs/brain` is the private `tempo-brain` submodule and is not checked out in this environment. The reachable board is `docs/TASKS.md`.

## Screenshots / screen recording

N/A — no user-visible surface. All added files are agent-facing markdown, templates and one ignore rule.

## Test plan

- [x] Local `bun run typecheck` passes — passed in CI on `3870d30` ([Typecheck](https://github.com/Division6066/tempo-rhythm/actions/runs/32855789592/job/97827310970))
- [x] Local `bun run lint` passes — passed in CI on `3870d30` ([Lint](https://github.com/Division6066/tempo-rhythm/actions/runs/32855789592/job/97827311174))
- [x] Relevant unit / integration tests added or updated — N/A, no executable application code added
- [x] Manual QA steps performed (listed below)
- [x] Reproduces the acceptance criteria below

All 9 check runs are green on the current head `3870d30`: Typecheck, Lint, Test, Scans (forbidden-tech / ram-only-audit / design-tokens), Third-party notices, Secret scan (gitleaks), Secret scan (trufflehog), Secret scan self-test, Vercel Preview Comments.

The Vercel deployment on `3870d30` shows **Ignored**, which is expected: the second commit touches only `.gitignore`, outside the `apps/web` root directory Vercel builds from, so it correctly skips the build. The preview deployed successfully on the first commit (`cfe769c`).

To be precise about provenance: typecheck and lint were **not** run on the authoring machine — `node_modules` was not installed there, and the diff contains no TypeScript. They are ticked here on the strength of the CI runs linked above, not a local run.

Manual QA performed:

- `skills-lock.json` parses as valid JSON; diff is additive only (90 insertions, 0 deletions).
- All 15 skills have a `SKILL.md` present under `.claude/skills/`.
- `diff -rq` confirms byte parity between `.agents/skills/` and `.claude/skills/` copies.
- Local secret scan over added files for `sk-*`, `csk_*`, `AKIA*` and PEM private-key headers: no matches. Independently confirmed by the repo's own gitleaks and trufflehog jobs in CI.
- `.codespring/` confirmed ignored after the rule was added; no CodeSpring config or credentials appear in the diff.

## Acceptance criteria

No `T-XXXX` row to copy from. Criteria taken from the request:

1. CodeSpring CLI installed and available.
2. CodeSpring skill pack added to the repo via `npx skills add CodeSpringApp/codespring-skills`.
3. Install matches existing repo conventions and is safe to check out on every platform the repo supports.

Items 2 and 3 are covered by this PR. Item 1 is a global npm install and leaves no trace in the repo.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2) — no runtime dependencies added at all; the diff is markdown, templates, one lock file and one ignore rule. Confirmed by the forbidden-tech scan job in CI.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6) — N/A, no AI-originated state changes in app code.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5) — N/A, `convex/schema.ts` untouched. Confirmed by the ram-only-audit scan in CI.
- [x] Styling uses design tokens from `packages/ui` (§7) — N/A, no styling changes. Confirmed by the design-tokens scan in CI.
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8) — N/A, no UI.
- [x] No secrets committed; new env vars documented in `.env.example` (§13) — no secrets, no new env vars. Confirmed by gitleaks and trufflehog in CI.
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9) — N/A, no user-facing copy.

## Owner tag (§14)

- [ ] `cursor-ide`
- [ ] `cursor-cloud-1`
- [ ] `cursor-cloud-2`
- [ ] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

**Deliberately left unticked.** This PR was authored by Claude Code, and §14 says to only claim a tag matching your own agent identity. None of the eight tags is Claude Code, and ticking someone else's would misattribute the work. If Claude Code should have a tag, the list needs a new entry — otherwise reassign this to whichever tag you consider correct.

## Reviewer

Amit (`human-amit`).

## Implementation note worth a look

The `skills` CLI installs `.claude/skills/` entries as **symlinks** into `.agents/skills/`. The 37 skills already in the repo are committed as **real directories** in both locations. This PR follows the existing convention and commits real directories.

The reason is not just consistency: on a Windows checkout without symlink support, git materialises a symlink as a plain text file containing its target path, which would silently break all 15 skills. The repo carries Windows tooling (`apps/mobile/check-node.bat`, `expo-start-windows.js`, `docs/LOCAL_DEV_WINDOWS.md`), so this seemed the safer default. The cost is duplicated content, matching what the repo already does. Say the word if you'd rather adopt symlinks and migrate the other 37 the other way.