### PR TITLE
fix(ci): point Dependabot at bun so bun.lock stays in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,10 @@ updates:
       - dependencies
       - automation
 
-  - package-ecosystem: npm
+  # Use bun, not npm: the npm updater rewrites package.json and leaves
+  # bun.lock stale, so `bun install --frozen-lockfile` fails in CI.
+  # The bun ecosystem updates the lockfile in the same PR (bun@1.3.9 / lockfile v1).
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly

--- a/docs/merge-runbook.md
+++ b/docs/merge-runbook.md
@@ -65,6 +65,18 @@ same PR that removes a violation.
 2. Purge it from history only after rotation (history rewrite is Amit's call).
 3. Add a gitleaks rule or fixture if the pattern was missed.
 
+## Dependabot + `bun.lock`
+
+Dependabot is configured with `package-ecosystem: bun` (not `npm`) in
+`.github/dependabot.yml`. The npm updater used to bump workspace
+`package.json` files and leave `bun.lock` unchanged, which made
+`bun install --frozen-lockfile` fail before lint/typecheck/test ran.
+
+If a Dependabot PR still arrives without a lockfile update, do not merge it.
+Regenerate with bun@1.3.9 (`bun install`), commit `bun.lock`, and only then
+re-run CI. Do not paste an older `bun.lock` from a stacked branch — that
+desyncs the lockfile from the manifests on `integration`.
+
 ## Convex deployments
 
 Schema/function changes do not deploy from CI. After merging a `convex/`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI Lint failed on Dependabot workspace bumps because the **npm** updater rewrote `package.json` files and left `bun.lock` stale, so `bun install --frozen-lockfile` exited before lint. This switches grouped workspace updates to `package-ecosystem: bun` so the lockfile is regenerated in the same PR, and documents the recovery path in `docs/merge-runbook.md`.

This is the landable form of **#330**. The original #330 head (`copilot/fix-ci-lint-error`) is a 47-file stack on a Dependabot branch: it would overlay an outdated snapshot of schema/tasks/calendar/CI plus a 35-package major bump (Expo 54→57, TypeScript 5→7, Tailwind 3→4 on mobile) onto current `integration`. `bun install --frozen-lockfile` already succeeds on `integration`. Merging the original stack would regress files that already landed.

## Linked task(s)

Task: N/A — CI hygiene for Dependabot + bun.lock. `docs/brain/TASKS.md` unavailable (private submodule); no T-XXXX invented. Original PR: #330.

## Screenshots / screen recording

N/A — no user-visible surface

## Test plan

- [x] Local `bun install --frozen-lockfile` on `integration` succeeds (no lockfile changes)
- [x] Local `bun run typecheck` — not required for this docs/config change; CI will run the full suite
- [x] Relevant unit / integration tests added or updated — N/A (Dependabot config + runbook)
- [x] Manual QA: compared original #330 three-dot diff vs `integration` (47 files / +3727); confirmed it is not a lockfile-only fix
- [x] Reproduces the acceptance criteria below

## Acceptance criteria

- Dependabot workspace updates use `package-ecosystem: bun`, not `npm`
- `docs/merge-runbook.md` states the frozen-lockfile recovery path
- Original #330 stack is **not** merged onto `integration`

## HARD_RULES compliance checklist

Read @docs/HARD_RULES.md before ticking. Unchecked boxes must have a note.

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). — N/A
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). — N/A
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7). — N/A
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8). — N/A
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13).
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9). — N/A

## Owner tag (§14)

- [ ] `cursor-ide`
- [x] `cursor-cloud-1`
- [ ] `cursor-cloud-2`
- [ ] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

## Reviewer

human-amit

## Graph / task contradiction

AGENTS.md points at `docs/brain/TASKS.md` (private submodule; empty here). Used in-repo `docs/HARD_RULES.md` + `docs/merge-runbook.md` + current `integration` lockfile as ground truth. Graph not rebuilt this change (config/docs only; blast radius is Dependabot + runbook).

## Refused

- Did **not** merge original #330 as written — file-scope gate fails (lockfile ticket vs 47 files including `convex/schema.ts`) and the diff would regress `integration`.
- Did **not** land the 35-package Dependabot bump (Expo 57 / TS 7 / mobile Tailwind 4) as a "lockfile fix".
- Did **not** modify `.github/workflows/**`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

