### PR TITLE
docs: align developer docs with Bun, Mistral, CI, and EAS

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,6 +1,6 @@
 # Tempo Flow — Cursor rules
 
-Tempo Flow is an open-source, overwhelm-first AI daily planner. Next.js PWA + Expo mobile + Convex + OpenRouter. See `README.md` for the project overview.
+Tempo Flow is an open-source, overwhelm-first AI daily planner. Next.js PWA + Expo mobile + Convex + Mistral API. See `README.md` for the project overview.
 
 ## Read these first (every session)
 
@@ -34,7 +34,7 @@ Before writing code:
 - Prisma, Drizzle, TypeORM, any other ORM
 - Auth0, Clerk, NextAuth, BetterAuth (we use Convex Auth)
 - Stripe direct SDK (we use RevenueCat)
-- OpenAI, Anthropic, Google AI direct SDKs (we use OpenRouter)
+- OpenAI, Anthropic, Google AI direct SDKs (we use the Mistral API via native `fetch` in Convex actions)
 - Redux, Zustand, Jotai, Recoil, MobX (Convex is reactive by default)
 - Axios or any fetch wrapper
 - MongoDB, Postgres (any direct DB client)
@@ -55,8 +55,8 @@ Before writing code:
 
 - Every new Convex mutation gets at least one test in `convex/*.test.ts`.
 - Every React component with non-trivial logic gets a render test.
-- PRs run: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm convex:schema-guard`, `pnpm scan:forbidden-tech`.
-- PRs must target a feature branch, never `main` directly.
+- PRs run: `bun run lint`, `bun run typecheck`, `bun run test`, `bun run scan:forbidden-tech`, `bun run scan:ram-only-audit`, `bun run scan:design-tokens`, `bun run check:notices` (see `docs/CI.md`).
+- Branch from `integration`. Open the PR against `integration`. Never push to `master`.
 
 ## Commit style
 

--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ Tempo Flow is an open-source, overwhelm-first AI daily planner and personal oper
 ## Tech stack (this repository — MVP target)
 
 - **Web:** Next.js 16 (App Router, Turbopack) deployable on Vercel, Progressive Web App–ready
-- **Mobile:** Expo SDK 53 (React Native) for iOS and Android, NativeWind 4
+- **Mobile:** Expo SDK 54 (React Native) for iOS and Android, NativeWind 4
 - **Backend:** Convex at repo root `convex/` (queries, mutations, actions, HTTP routes, scheduled jobs, file storage)
 - **Auth:** Convex Auth (`@convex-dev/auth`)
 - **Payments:** RevenueCat on mobile; Polar (`@polar-sh/nextjs`) for web checkout in this repo — align with PRD over time
-- **AI routing (target):** OpenRouter — Gemma / Mistral per `docs/brain/PRDs/PRD_Phase_1_MVP.md` (router package planned)
+- **AI routing:** Mistral API via native `fetch` in Convex actions — `convex/lib/ai_router.ts` (`fast` / `balanced` / `deep` tiers with escalation)
 - **Styling:** Tailwind CSS v4 + PostCSS in `apps/web`; NativeWind + Tailwind 3.x in `apps/mobile`
 - **Shared packages:** `packages/types`, `packages/utils`, `packages/ui` (tokens and shared UI to grow here)
 - **Typography (target):** Newsreader, Inter, IBM Plex Mono, OpenDyslexic toggle per PRD
 - **Compliance (target):** GetTerms.io
 - **Analytics (target):** PostHog (opt-in)
 - **Observability (target):** Sentry + PostHog
-- **Package manager:** pnpm
+- **Package manager:** Bun (`bun@1.3.9`, `bun.lock` at repo root)
 - **Monorepo:** Turborepo (`apps/*`, `packages/*`)
 
 See [`docs/HARD_RULES.md`](./docs/HARD_RULES.md) for the full non-negotiables list and [`docs/brain/PRDs/PRD_Phase_1_MVP.md`](./docs/brain/PRDs/PRD_Phase_1_MVP.md) for the full MVP spec.
@@ -42,16 +42,16 @@ git clone https://github.com/<your-org>/tempo-flow.git
 cd tempo-flow
 
 # 2. Install dependencies
-pnpm install
+bun install
 
 # 3. Start Convex dev backend (runs in a separate terminal; keep it running)
-pnpm convex:dev
+bun run convex:dev
 
 # 4. Start the web app (Next.js)
-pnpm dev:web
+bun run dev:web
 
 # 5. (Optional) Start the mobile app
-pnpm dev:mobile
+bun run dev:mobile
 ```
 
 Required environment variables are documented in `.env.example` at the repo root. Copy to `.env.local` and fill in values from your own Convex, Mistral, RevenueCat, and GetTerms accounts before running.
@@ -66,6 +66,9 @@ All project documentation lives under [`./docs/`](./docs/).
 - [`docs/CURSOR_PROMPTS.md`](./docs/CURSOR_PROMPTS.md) — prompt library for Cursor IDE and Cursor Cloud agents.
 - [`docs/brain/TASKS.md`](./docs/brain/TASKS.md) — master task list, owner-tagged.
 - [`docs/SESSION_WORKFLOW.md`](./docs/SESSION_WORKFLOW.md) — `/whats-next` / `/tick-task` session flow.
+- [`docs/CI.md`](./docs/CI.md) — GitHub Actions jobs, required checks, frozen lockfile.
+- [`docs/MOBILE_EAS.md`](./docs/MOBILE_EAS.md) — Expo/EAS project, build profiles, secrets.
+- [`docs/REVENUECAT_SETUP.md`](./docs/REVENUECAT_SETUP.md) — subscription webhook and env vars.
 - [`docs/brain/PRDs/`](./docs/brain/PRDs/) — one PRD per public phase (1.0, 1.1, 1.5, 2.0, 3.0).
 - [`docs/brain/AGENT_SETUP/`](./docs/brain/AGENT_SETUP/) — Tempo-specific setup guides for Zo Computer, Twin.so, Pokee AI, and the overall agent handoff map.
 

--- a/docs/AGENT_AUTOMATION_RUNBOOK.md
+++ b/docs/AGENT_AUTOMATION_RUNBOOK.md
@@ -25,7 +25,7 @@ Remaining dashboard/secret items are listed in
 1. Confirm the runtime switch or agent host is online.
 2. Confirm GitHub remote access works with `git ls-remote origin master`.
 3. Confirm the repo branch is clean with `git status --short`.
-4. Confirm the correct base branch is `master`.
+4. Confirm the correct base branch is `integration` (never open agent PRs against `master`).
 5. Confirm no dashboard-only action is being hidden inside a code task.
 6. Confirm Convex local dev is bound with `bunx convex function-spec`.
 7. Run the batch checks:
@@ -41,6 +41,8 @@ bun run build
 Do not use `bun run check` as a verification-only command until the repo fixes
 that script. On 2026-06-02 it was observed to run `biome check --write` in the
 mobile package and to fail on pre-existing web formatter diagnostics.
+
+See `docs/CI.md` for which GitHub Actions jobs are blocking.
 
 ## Cyrus worktree setup
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,76 @@
+# Continuous integration
+
+GitHub Actions workflows live under `.github/workflows/`. All jobs use **Bun**
+(`bun install --frozen-lockfile`, `bun run …`) per root `package.json`
+(`packageManager: "bun@1.3.9"`). Workflow-level `BUN_VERSION` is `1.3.9`.
+
+## Workflows
+
+| Workflow | File | Triggers | Purpose |
+|---|---|---|---|
+| **CI** | `.github/workflows/ci.yml` | PR → `master` or `integration`, `workflow_dispatch` | Typecheck, lint, tests, policy scans, notices, Playwright e2e |
+| **Security** | `.github/workflows/security.yml` | PR / push → `master` or `integration`, `workflow_dispatch` | Secret scanning (Gitleaks + TruffleHog) |
+
+Agents open PRs against **`integration`**. Amit promotes `integration` → `master`.
+See `docs/merge-runbook.md`.
+
+## CI jobs (blocking)
+
+These jobs **must pass** on every PR. None carry `continue-on-error`.
+
+| Job | Command | Notes |
+|---|---|---|
+| **Typecheck** | `bun run typecheck` | Turborepo across `apps/*` and `packages/*` |
+| **Lint** | `bun run lint` | Biome via Turborepo |
+| **Test** | `bun run test` | `bun test convex apps/web/lib tests/unit` |
+| **Scans** | `scan:forbidden-tech`, `scan:ram-only-audit`, `scan:design-tokens` | HARD_RULES §2 / §5 / §7 ratchets |
+| **Third-party notices** | `bun run check:notices` | TF-OSS-00 — every runtime dep in `THIRD-PARTY-NOTICES.md` |
+| **E2E** | `bunx playwright test` | Playwright Chromium |
+| **Secret scan** | Gitleaks + TruffleHog | Security workflow; a finding fails the job |
+
+## Local pre-PR checklist
+
+```bash
+bun install --frozen-lockfile
+bun run typecheck
+bun run lint
+bun run test
+bun run scan:forbidden-tech
+bun run scan:ram-only-audit
+bun run scan:design-tokens
+bun run check:notices
+```
+
+**Avoid** `bun run check` as a read-only verification step on mobile — some
+workspaces run `biome check --write`, which mutates files.
+
+## Convex in CI
+
+Convex functions are typechecked as part of the monorepo `typecheck` task.
+There is no `convex deploy` step in CI and no `convex:schema-guard` script in
+root `package.json`. Preview/production deploys happen via Vercel + Convex
+dashboard keys (see `docs/ENVIRONMENTS.md`). After merging a `convex/` change
+into `integration`, deploy explicitly (`bun x convex deploy`) with the deploy
+key — that is a `human-amit` action.
+
+## Dependabot
+
+Workspace version bumps use `package-ecosystem: bun` in
+`.github/dependabot.yml` so `bun.lock` updates in the same PR. If a bump
+arrives without a lockfile change, regenerate with bun@1.3.9 and do not merge
+until `bun install --frozen-lockfile` succeeds. See `docs/merge-runbook.md`.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Typecheck / lint fails only in CI | Lockfile drift | Run `bun install` locally, commit `bun.lock` |
+| Lint fails on Tailwind class order | Biome does not sort Tailwind classes (intentional) | Fix real Biome errors; ignore cross-app sort conflicts |
+| Notices job fails | New runtime dependency with no notices row | Add the package to `THIRD-PARTY-NOTICES.md` |
+| Secret scan fails | Real or test credential in the diff | Remove it, rotate if it was ever real, use env vars |
+
+## Related
+
+- `docs/HARD_RULES.md` §11 (testing) and §12 (git + PR)
+- `docs/merge-runbook.md` — three-gate integration flow
+- `docs/AGENT_AUTOMATION_RUNBOOK.md` — pre-flight checks for long agent runs

--- a/docs/CURSOR_RULES.md
+++ b/docs/CURSOR_RULES.md
@@ -50,7 +50,7 @@ For the hard non-negotiables, see [`HARD_RULES.md`](./HARD_RULES.md). This file 
 | ORM | Prisma, Drizzle, TypeORM, Mongoose | Convex `v.*` validators |
 | Auth | Auth0, Clerk, NextAuth, BetterAuth | Convex Auth |
 | Payments | Stripe direct SDK | RevenueCat (mobile); web may use Polar in this repo — converge on PRD |
-| AI SDKs | `openai`, `@anthropic-ai/sdk`, `@google/generative-ai` | OpenRouter |
+| AI SDKs | `openai`, `@anthropic-ai/sdk`, `@google/generative-ai`, `@mistralai/mistralai` | Mistral API via native `fetch` in Convex actions (`convex/lib/ai_router.ts`) |
 | Client state | Redux, Zustand, Jotai, Recoil, MobX | Convex reactive queries |
 | HTTP | Axios, ky, got | Native `fetch` |
 | Direct DB | `mongodb`, `pg`, `mysql2` | Convex |
@@ -63,7 +63,7 @@ For the hard non-negotiables, see [`HARD_RULES.md`](./HARD_RULES.md). This file 
 - **ORMs:** Convex's schema + validators are the ORM. Adding Prisma or Drizzle would duplicate the schema definition and introduce a second source of truth.
 - **Auth libraries:** Convex Auth is designed for Convex. Third-party auth forces a user table in a second system, which fights against the tenant-isolation model.
 - **Stripe direct:** RevenueCat wraps App Store, Play Store, and Stripe in a single SDK with subscription state management. Going direct means building three parallel billing systems.
-- **AI SDKs:** OpenRouter routes between many providers behind one API. Direct SDKs lock us into one provider and break the OpenRouter-first cost optimization.
+- **AI SDKs:** Direct provider SDKs lock us into one vendor and add bundle weight. Convex actions call the Mistral API with native `fetch`; routing tiers live in `convex/lib/ai_router.ts`.
 - **Client state libraries:** Convex queries are reactive. A Redux store on top of reactive queries is a performance and consistency problem in waiting.
 - **Axios:** native `fetch` works everywhere we ship. Axios adds weight and an abstraction that is not needed.
 - **Direct DB clients:** Convex is the database. We do not open direct DB connections.
@@ -123,9 +123,9 @@ If you think you need a forbidden dependency, open an issue first with the justi
 
 ## 10. Design tokens only
 
-**Rule.** Prefer design tokens and theme variables over one-off colors. No arbitrary hex in new UI unless a token already exists. For web Tailwind v4, extend tokens via CSS variables / `@theme` in `apps/web/app/globals.css` (and eventually `packages/ui`). When `pnpm scan:design-tokens` exists, it must pass on changed UI.
+**Rule.** Prefer design tokens and theme variables over one-off colors. No arbitrary hex in new UI unless a token already exists. For web Tailwind v4, extend tokens via CSS variables / `@theme` in `apps/web/app/globals.css` (and eventually `packages/ui`). `bun run scan:design-tokens` must pass on changed UI.
 
-**Rationale.** Arbitrary values are how design systems erode. Once one file uses `#ff7a00` instead of `text-accent`, the next agent copies it, and within two weeks you have 17 orange-ish oranges and no way to theme. The design-token enforcer (`pnpm scan:design-tokens`) fails the build on arbitrary values.
+**Rationale.** Arbitrary values are how design systems erode. Once one file uses `#ff7a00` instead of `text-accent`, the next agent copies it, and within two weeks you have 17 orange-ish oranges and no way to theme. The design-token enforcer (`bun run scan:design-tokens`) fails the build on arbitrary values.
 
 ---
 
@@ -179,7 +179,7 @@ If you think you need a forbidden dependency, open an issue first with the justi
 
 ## 17. PR hygiene
 
-**Rule.** One logical change per PR. PR description references the `TASKS.md` ID. PR body includes a summary (2–3 sentences, *why* not *what*), screenshots or screen recording for UI changes, test plan (checkable boxes), and acceptance criteria copied from `TASKS.md`. No direct pushes to `main`. Conventional Commits in titles.
+**Rule.** One logical change per PR. PR description references the `TASKS.md` ID. PR body includes a summary (2–3 sentences, *why* not *what*), screenshots or screen recording for UI changes, test plan (checkable boxes), and acceptance criteria copied from `TASKS.md`. Branch from `integration`; never push to `master`. Conventional Commits in titles.
 
 **Rationale.** Small PRs review quickly and revert cleanly. Large PRs sit for days and produce merge conflicts. The structured description is the minimum information a reviewer needs to evaluate the change without going archaeological on the diff.
 
@@ -195,9 +195,9 @@ If you think you need a forbidden dependency, open an issue first with the justi
 
 ## 19. Kill-switches
 
-**Rule.** Every integration with a third party (RevenueCat, OpenRouter, GetTerms, PostHog, Pokee) has a feature flag in Convex `flags` table that disables the integration path in an emergency. The flag is checked on every request, not just at startup.
+**Rule.** Every integration with a third party (RevenueCat, Mistral, GetTerms, PostHog, Pokee) has a feature flag in Convex `flags` table that disables the integration path in an emergency. The flag is checked on every request, not just at startup.
 
-**Rationale.** If OpenRouter has an outage, we need to disable AI features gracefully rather than stacking failed requests. If RevenueCat has a billing incident, we need to pause paywall enforcement rather than lock users out. Startup-only flags do not help when a dev server has been running for a week.
+**Rationale.** If Mistral has an outage, we need to disable AI features gracefully rather than stacking failed requests. If RevenueCat has a billing incident, we need to pause paywall enforcement rather than lock users out. Startup-only flags do not help when a dev server has been running for a week.
 
 ---
 

--- a/docs/HARD_RULES.md
+++ b/docs/HARD_RULES.md
@@ -153,7 +153,7 @@ Any ingestion of third-party content (email, WhatsApp, Telegram, ChatGPT export,
 - The scanner extracts structured candidates (task, event, commitment, person mention), surfaces them for user approval via the accept-reject flow, and discards the source bytes when the action returns.
 - Only the approved, derived records persist.
 - If a user re-connects an integration, the scanner re-runs on the live source; there is no "historical cache" of raw content.
-- Document the scanner entry point with a `// RAM-ONLY` comment and include a linter check (`pnpm scan:ram-only-audit`) that fails if a scanner function persists raw content.
+- Document the scanner entry point with a `// RAM-ONLY` comment and include a linter check (`bun run scan:ram-only-audit`) that fails if a scanner function persists raw content.
 
 ### 6.5 Coach personality setting
 
@@ -245,15 +245,15 @@ The "Soft Editorial" palette is defined in **`packages/ui`** and **`apps/web/app
 - Every new Convex mutation gets at least one test (`convex/<module>.test.ts`) — happy path + one error case minimum.
 - Every React component with meaningful logic gets a render test with `@testing-library/react` (web) or `@testing-library/react-native` (mobile).
 - Every AI routing function (`route-by-task`, `confidence-router`) is unit-tested with a golden fixture set.
-- PRs run: `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm scan:forbidden-tech`, `pnpm convex:schema-guard`, `pnpm scan:ram-only-audit`, `pnpm scan:design-tokens`.
+- PRs run: `bun run lint`, `bun run typecheck`, `bun run test`, `bun run scan:forbidden-tech`, `bun run scan:ram-only-audit`, `bun run scan:design-tokens`, `bun run check:notices` (see `docs/CI.md`). There is no `convex:schema-guard` script in root `package.json` today.
 - All of these must pass before merge.
 
 ---
 
 ## 12. Git and PR rules
 
-- **Never push to `main` directly.** All changes through PR.
-- **`main` is always deployable.** If a PR would break `main`, fix the PR or revert.
+- **Never push to `master`.** All work lands through a pull request against `integration`. Amit merges `integration` into `master`.
+- **`master` is always deployable.** If a PR would break `master` once promoted, fix the PR or revert.
 - **One logical change per PR.** Large features land as a stack of PRs.
 - **PR description** must reference the `TASKS.md` task ID and include:
   - Summary (2–3 sentences, *why* not *what*)
@@ -271,7 +271,7 @@ See `docs/ENVIRONMENTS.md` for the full four-mode contract (dev / test / preview
 
 - **No secrets in the repo.** Ever. Use `.env.local` locally (git-ignored) and Vercel / EAS env var config for deployed environments.
 - **`.env.example`** is the canonical list. Every new env var is added there with a placeholder and a one-line comment.
-- **Secret scanning** runs in CI (`pnpm scan:secrets`). Never merge a PR where the scan fires.
+- **Secret scanning** runs in CI (Gitleaks + TruffleHog in `.github/workflows/security.yml`). Never merge a PR where the scan fires.
 - **Mistral keys** are scoped per environment and rotated quarterly.
 - **RevenueCat** public keys are safe to ship client-side. Secret keys only in server-side Convex actions.
 - **Four-mode contract.** Dev, test, preview, and deployment are different environments with different trust gates. See `docs/ENVIRONMENTS.md`.

--- a/docs/MOBILE_EAS.md
+++ b/docs/MOBILE_EAS.md
@@ -1,0 +1,78 @@
+# Mobile — Expo & EAS
+
+The mobile app lives in `apps/mobile/` (Expo SDK 54, Expo Router, NativeWind).
+Production builds use **EAS Build**; local dev uses Expo Go or a dev client.
+
+## EAS project
+
+Configured in `apps/mobile/app.json`:
+
+| Field | Value |
+|---|---|
+| **Owner** | `amitlevin` |
+| **Slug** | `tempi` |
+| **Project ID** | `90dfac90-0baa-461b-946c-351d2306e607` |
+| **iOS bundle ID** | `com.temporhythm.app` |
+| **Android package** | `com.temporhythm.app` |
+| **Scheme** | `tempo-rhythm` |
+
+The EAS project is `@amitlevin/tempi` on expo.dev. CI agents and cloud runners
+need access to this Expo account (or a team invite) to run `eas build`.
+
+## Build profiles
+
+`apps/mobile/eas.json`:
+
+| Profile | Distribution | Notes |
+|---|---|---|
+| `development` | internal | `developmentClient: true` — dev client with native modules |
+| `preview` | internal | Ad-hoc / internal testing APK/IPA |
+| `production` | store | `autoIncrement: true` for store version codes |
+
+CLI minimum version: `>= 16.28.0`. App version source: `remote` (EAS manages
+build numbers).
+
+## Common commands
+
+From `apps/mobile/` (after `bun install` at repo root):
+
+```bash
+# Local dev (Windows-safe wrapper)
+bun run dev
+
+# EAS login (once per machine)
+bunx eas login
+
+# Internal preview build
+bunx eas build --profile preview --platform all
+
+# Production build (requires store credentials)
+bunx eas build --profile production --platform ios
+```
+
+Secrets (RevenueCat keys, Convex URL overrides) belong in **EAS Secrets**, not
+in the repo:
+
+```bash
+bunx eas secret:create --name EXPO_PUBLIC_CONVEX_URL --value https://...
+```
+
+## Environment variables
+
+Mobile reads Convex via `EXPO_PUBLIC_CONVEX_URL` (not `NEXT_PUBLIC_*`). See
+`apps/mobile/.env.example`.
+
+`bun x convex dev` at the repo root writes deployment URLs; copy the cloud URL
+into `apps/mobile/.env.local` as `EXPO_PUBLIC_CONVEX_URL`.
+
+## Cyrus / cloud agent setup
+
+`cyrus-setup.sh` at the repo root installs Bun and runs
+`bun install --frozen-lockfile` in Cyrus-created worktrees. It does **not**
+run EAS builds or write EAS secrets — those are `human-amit` / `twin` actions.
+
+## Related
+
+- `docs/ENVIRONMENTS.md` — EAS secrets scope and four-mode contract
+- `docs/REVENUECAT_SETUP.md` — subscription keys for mobile builds
+- `docs/LOCAL_DEV_WINDOWS.md` — Windows-specific Expo/Bun setup

--- a/docs/REVENUECAT_SETUP.md
+++ b/docs/REVENUECAT_SETUP.md
@@ -1,0 +1,85 @@
+# RevenueCat setup
+
+RevenueCat is the subscription layer for iOS, Android, and (eventually) web.
+Server-side entitlement sync runs through a Convex HTTP webhook; client SDK
+keys are public and ship in app env vars.
+
+**Ship state:** webhook handler is coded (`convex/revenuecat.ts`, mounted at
+`POST /api/revenuecat-webhook` in `convex/http.ts`); dashboard products and
+client keys are not yet wired for production. See `docs/SHIP_STATE.md`.
+
+## Architecture
+
+```
+Mobile / Web client
+  → RevenueCat SDK (public API keys)
+  → App Store / Play Store / web checkout
+
+RevenueCat dashboard
+  → POST https://<deployment>.convex.site/api/revenuecat-webhook
+  → convex/revenuecat.ts (httpAction)
+  → api.users.updateSubscriptionStatus (mutation)
+```
+
+The webhook validates `Authorization` against `REVENUECAT_WEBHOOK_SECRET`
+(Convex env var). On lifecycle events (`INITIAL_PURCHASE`, `RENEWAL`,
+`EXPIRATION`, etc.) it updates the user's `userType` and entitlement list in
+Convex.
+
+## Environment variables
+
+### Convex dashboard (server)
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `REVENUECAT_WEBHOOK_SECRET` | Yes (production) | Must match the Authorization header RevenueCat sends to the webhook |
+| `REVENUECAT_API_KEY` | Deferred | Server-side RevenueCat REST calls (not yet used in code) |
+
+Set in Convex → Settings → Environment Variables for each deployment
+(dev / prod). Placeholders live in the repo-root `.env.example`.
+
+### Web (`apps/web/.env.local` / Vercel)
+
+Public client keys will live here when the web paywall ships. Root
+`.env.example` documents deferred `REVENUECAT_*` vars.
+
+### Mobile (`apps/mobile/.env.local` / EAS secrets)
+
+| Variable | Scope | Purpose |
+|---|---|---|
+| `EXPO_PUBLIC_REVENUECAT_TEST_STORE_API_KEY` | Dev only | RevenueCat Test Store |
+| `EXPO_PUBLIC_REVENUECAT_IOS_API_KEY` | iOS builds | `appl_…` public SDK key |
+| `EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY` | Android builds | `goog_…` public SDK key |
+
+See `apps/mobile/.env.example` for placeholders.
+
+## Webhook configuration (RevenueCat dashboard)
+
+1. Open your RevenueCat project (linked to Expo app slug `tempi`, owner `amitlevin`).
+2. **Integrations → Webhooks → Add**.
+3. **URL:** `https://<your-deployment>.convex.site/api/revenuecat-webhook`
+   - Dev: use your `dev:*` deployment URL from `CONVEX_DEPLOYMENT`.
+   - Prod: use the production Convex site URL.
+4. **Authorization header:** generate a long random secret; set the same value as `REVENUECAT_WEBHOOK_SECRET` in Convex.
+5. Enable events: `INITIAL_PURCHASE`, `RENEWAL`, `CANCELLATION`, `EXPIRATION`, `PRODUCT_CHANGE`, `UNCANCELLATION`.
+
+The handler returns HTTP 200 even on internal mutation errors so RevenueCat
+does not retry indefinitely — check Convex logs for `[RevenueCat Webhook]`
+errors.
+
+## App user ID
+
+RevenueCat `app_user_id` should match the Convex user's email (or stable
+subject) so `api.users.updateSubscriptionStatus` can resolve the account. See
+`convex/users.ts` for the lookup path.
+
+## Local development
+
+- Without RevenueCat keys, the app runs in free-tier mode; paywall UI may be hidden or stubbed per feature flags.
+- Test webhooks with RevenueCat's sandbox and a dev Convex deployment; never point sandbox webhooks at production Convex.
+
+## Related docs
+
+- `docs/MOBILE_EAS.md` — EAS build profiles and secrets
+- `docs/ENVIRONMENTS.md` — four-mode env contract
+- `docs/HARD_RULES.md` §6 (payments) — RevenueCat only; no Stripe direct SDK

--- a/docs/design/screen-inventory.md
+++ b/docs/design/screen-inventory.md
@@ -3,6 +3,19 @@
 **Source:** `docs/design/claude-export/design-system/` (Tempo Flow Design System v1.0, April 2026).
 **Router map source:** `design-system/app.html` lines 60–109 (`SCREENS` object).
 
+## Web route groups
+
+Next.js App Router groups under `apps/web/app/`:
+
+| Group | Layout | Purpose |
+|---|---|---|
+| `(tempo)` | `TempoShell` — sidebar + coach dock | Primary product screens (42 screens below) |
+| `(bare)` | Minimal chrome — focus / builder flows | Daily note, onboarding, template builder/run, trial-end |
+| `(app)` | Grain background shell | Legacy/dashboard experiments (`dashboard`) |
+| `(auth)` | Auth gate wrapper | Sign-in/up flows that share auth layout |
+
+Marketing and legal pages (`/about`, `/privacy`, `/sign-in`, etc.) sit outside these groups at the app root.
+
 ## Web — 42 screens
 
 Target base: `apps/web/app/(tempo)/`

--- a/docs/knowledge/_INDEX.md
+++ b/docs/knowledge/_INDEX.md
@@ -13,6 +13,11 @@
 | Understand what "done" means for Phase 1 MVP | [`prds/README.md`](prds/README.md) → `docs/brain/PRDs/PRD_Phase_1_MVP.md` |
 | Know what you absolutely must not do | [`rules/README.md`](rules/README.md) → `docs/HARD_RULES.md` |
 | Run a 45-minute multi-agent session | [`agents-playbook/workflow-sunday-morning.md`](agents-playbook/workflow-sunday-morning.md) |
+| Understand CI / pre-PR checks | [`../CI.md`](../CI.md) |
+| Configure mobile EAS builds | [`../MOBILE_EAS.md`](../MOBILE_EAS.md) |
+| Wire RevenueCat webhooks | [`../REVENUECAT_SETUP.md`](../REVENUECAT_SETUP.md) |
+| Run Cursor background automations (CI fix, docs, merge steward) | [`../AGENT_AUTOMATION_RUNBOOK.md`](../AGENT_AUTOMATION_RUNBOOK.md) + `.cursor/agents/` |
+| File merge-agent evidence reports | [`../QA/agent-runs/README.md`](../QA/agent-runs/README.md) |
 | Know when to stop and ask Amit | [`agents-playbook/checkpoints.md`](agents-playbook/checkpoints.md) |
 | Understand each sub-agent's job | [`agents-playbook/sub-agents.md`](agents-playbook/sub-agents.md) |
 

--- a/docs/knowledge/agents-playbook/checkpoints.md
+++ b/docs/knowledge/agents-playbook/checkpoints.md
@@ -7,7 +7,7 @@
 | Trigger | Why |
 |---|---|
 | About to ship a proposed ticket batch to parallel agents (`/whats-next` has picked 3) | Amit confirms the scope before work starts. |
-| About to merge any PR to `main` | HARD_RULES §12 — `main` must be deployable, and no agent auto-merges. |
+| About to merge any PR to `master` | HARD_RULES §12 — `master` must be deployable. Agents land on `integration`; Amit promotes to `master`. |
 | About to add a new dependency | HARD_RULES §2 forbidden list + license check. Even when a skill suggests it. |
 | About to modify `convex/schema.ts` in a way that changes an existing table | Data migration risk. Amit approves the migration plan first. |
 | About to add a new env var | HARD_RULES §13 — must be added to `.env.example` + Vercel/EAS env config. |

--- a/docs/knowledge/agents-playbook/sub-agents.md
+++ b/docs/knowledge/agents-playbook/sub-agents.md
@@ -1,6 +1,6 @@
 # Tempo sub-agents — roles and invocation
 
-**Sub-agents** are scoped, single-purpose agents invoked by the main Cursor agent or the orchestrator during a feature build. They do verification, not implementation. Each lives at `.cursor/agents/<name>/` (scaffolded in Phase 3).
+**Sub-agents** are scoped, single-purpose agents invoked by the main Cursor agent or the orchestrator during a feature build. They do verification, not implementation. Definitions live at `.cursor/agents/<name>.md` (see also `docs/AGENT_AUTOMATION_RUNBOOK.md` for background automation agents).
 
 ## Roster
 
@@ -11,7 +11,7 @@
 | `tempo-accept-reject-checker` | yes | after any diff that mentions `action`, `mutation`, AI calls, or `convex/proposals.ts` | Confirms no AI-originating mutation bypasses the proposals flow. |
 | `tempo-hard-rules-auditor` | yes | on every PR | Runs through all 17 HARD_RULES sections against the diff. Produces a report. |
 | `tempo-brand-validator` | yes | on diffs touching UI copy or components | Checks copy against `docs/brain/brand/voice.md` pattern library. Flags violations and proposes on-brand replacements. |
-| `tempo-test-runner` | **no** | after build completes | Runs `pnpm typecheck`, `pnpm test`, `pnpm scan:forbidden-tech`, `pnpm scan:ram-only-audit`, `pnpm scan:design-tokens`. Reports pass/fail per suite. |
+| `tempo-test-runner` | **no** | after build completes | Runs `bun run typecheck`, `bun run test`, `bun run scan:forbidden-tech`, `bun run scan:ram-only-audit`, `bun run scan:design-tokens`. Reports pass/fail per suite. |
 
 ## How the orchestrator uses them
 

--- a/docs/knowledge/rules/README.md
+++ b/docs/knowledge/rules/README.md
@@ -15,7 +15,7 @@ All live in `.cursor/rules/` and each one references HARD_RULES with `@docs/HARD
 |---|---|---|
 | `tempo-hard-rules.mdc` | `alwaysApply: true` | The top-of-session primer: shame-proof, accept-reject, undo, forbidden tech. |
 | `tempo-convex-schema.mdc` | `globs: convex/**/*.ts` | Schema shape — `userId` optional, soft delete, indexes, generic tables. |
-| `tempo-openrouter.mdc` | `agentRequested` | All LLM calls go through OpenRouter; no direct provider SDKs. |
+| `tempo-hard-rules.mdc` (AI section) | `alwaysApply` | LLM calls via Mistral API (`convex/lib/ai_router.ts`); no direct provider SDKs. |
 | `tempo-accept-reject.mdc` | `agentRequested` | AI mutations must flow through `convex/proposals.ts`. |
 | `tempo-design-tokens.mdc` | `globs: packages/ui/**`, `apps/web/app/globals.css` | Token usage, no arbitrary hex. |
 | `tempo-brand.mdc` | `alwaysApply` when touching UI files | Auto-attaches the brand knowledge base to any UI session. |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Developer docs still said `pnpm`, OpenRouter, and `main`. That contradicts `packageManager: bun@1.3.9`, `convex/lib/ai_router.ts`, and the integration→master branch flow. This is the landable form of **#129**, rebased onto current `integration` and rewritten so CI/EAS/RevenueCat runbooks match the workflows and `app.json` that already landed (blocking Test/Scans/Notices, PRs to `integration`, Expo SDK 54).

Original #129 targeted `master`, is a draft, and its `docs/CI.md` still described notice-only scans and `continue-on-error` tests — both false on current `integration`.

## Linked task(s)

Task: N/A — docs alignment. `docs/brain/TASKS.md` unavailable (private submodule); no T-XXXX invented. Original PR: #129.

## Screenshots / screen recording

N/A — no user-visible surface

## Test plan

- [x] Local `bun install --frozen-lockfile` already green on `integration`
- [ ] CI Typecheck / Lint / Test / Scans / Notices on this docs-only PR
- [x] Verified EAS fields against `apps/mobile/app.json` + `eas.json`
- [x] Verified webhook path against `convex/http.ts` + `convex/revenuecat.ts`
- [x] Verified web route groups exist: `(tempo)`, `(bare)`, `(app)`, `(auth)`

## Acceptance criteria

- README quick start and package-manager line use Bun
- HARD_RULES / CURSOR_RULES / `.cursorrules` say Mistral via `fetch`, not OpenRouter
- Git rules say land on `integration`, never push `master`
- `docs/CI.md`, `docs/MOBILE_EAS.md`, `docs/REVENUECAT_SETUP.md` exist and match current code

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI accept/reject — N/A
- [x] Schema — N/A
- [x] Design tokens — N/A
- [x] Accessibility — N/A
- [x] No secrets committed; env var **names** only (already in `.env.example`)
- [x] Voice — N/A

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

human-amit

## Graph / task contradiction

AGENTS.md points at `docs/brain/TASKS.md` (private submodule; empty here). Used in-repo HARD_RULES + current workflows/app.json as ground truth. Original #129 `docs/CI.md` contradicted current `ci.yml` (scans and tests are enforcing).

## Refused

- Did not retarget and merge original #129 as-is — it would document a CI posture that no longer exists.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

