### PR TITLE
test(coverage): RevenueCat event map and Today due-window filters

### DIFF
--- a/apps/web/lib/localDay.test.ts
+++ b/apps/web/lib/localDay.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import {
+  endOfLocalDayMs,
+  endOfLocalWeekMondayMs,
+  startOfLocalDayMs,
+  startOfLocalWeekMondayMs,
+} from "./localDay";
+
+describe("startOfLocalDayMs / endOfLocalDayMs", () => {
+  test("end is exactly 24h after start", () => {
+    const sample = new Date(2026, 5, 18, 15, 45, 0);
+    expect(endOfLocalDayMs(sample) - startOfLocalDayMs(sample)).toBe(
+      24 * 60 * 60 * 1000,
+    );
+  });
+
+  test("start aligns to local midnight", () => {
+    const sample = new Date(2026, 5, 18, 23, 59, 59);
+    const start = new Date(startOfLocalDayMs(sample));
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getDate()).toBe(18);
+  });
+});
+
+describe("startOfLocalWeekMondayMs", () => {
+  test("Thursday maps back to Monday 00:00 local", () => {
+    const thu = new Date(2026, 5, 18, 12, 0, 0);
+    const monday = new Date(startOfLocalWeekMondayMs(thu));
+    expect(monday.getDay()).toBe(1);
+    expect(monday.getDate()).toBe(15);
+    expect(monday.getHours()).toBe(0);
+  });
+
+  test("Sunday maps back to previous Monday", () => {
+    const sun = new Date(2026, 5, 21, 10, 0, 0);
+    const monday = new Date(startOfLocalWeekMondayMs(sun));
+    expect(monday.getDay()).toBe(1);
+    expect(monday.getDate()).toBe(15);
+  });
+});
+
+describe("endOfLocalWeekMondayMs", () => {
+  test("week window is exactly 7 days", () => {
+    const sample = new Date(2026, 5, 18, 9, 0, 0);
+    expect(endOfLocalWeekMondayMs(sample) - startOfLocalWeekMondayMs(sample)).toBe(
+      7 * 24 * 60 * 60 * 1000,
+    );
+  });
+});

--- a/convex/lib/revenuecat_events.test.ts
+++ b/convex/lib/revenuecat_events.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { mapRevenueCatEventToUserType } from "./revenuecat_events";
+
+describe("mapRevenueCatEventToUserType", () => {
+  test("maps purchase lifecycle events to paid", () => {
+    for (const eventType of [
+      "INITIAL_PURCHASE",
+      "RENEWAL",
+      "PRODUCT_CHANGE",
+      "UNCANCELLATION",
+    ]) {
+      expect(mapRevenueCatEventToUserType(eventType)).toBe("paid");
+    }
+  });
+
+  test("maps churn events to free", () => {
+    for (const eventType of ["EXPIRATION", "CANCELLATION", "SUBSCRIBER_ALIAS"]) {
+      expect(mapRevenueCatEventToUserType(eventType)).toBe("free");
+    }
+  });
+
+  test("defaults unknown or missing events to free", () => {
+    expect(mapRevenueCatEventToUserType(undefined)).toBe("free");
+    expect(mapRevenueCatEventToUserType("BILLING_ISSUE")).toBe("free");
+  });
+});

--- a/convex/lib/revenuecat_events.ts
+++ b/convex/lib/revenuecat_events.ts
@@ -1,0 +1,27 @@
+export type RevenueCatUserType = "free" | "paid";
+
+const PAID_EVENT_TYPES = new Set([
+  "INITIAL_PURCHASE",
+  "RENEWAL",
+  "PRODUCT_CHANGE",
+  "UNCANCELLATION",
+]);
+
+const FREE_EVENT_TYPES = new Set([
+  "EXPIRATION",
+  "CANCELLATION",
+  "SUBSCRIBER_ALIAS",
+]);
+
+/**
+ * Map a RevenueCat webhook event type to the Convex userType tier.
+ * Unknown event types default to "free" (no upgrade).
+ */
+export function mapRevenueCatEventToUserType(
+  eventType: string | undefined,
+): RevenueCatUserType {
+  if (!eventType) return "free";
+  if (PAID_EVENT_TYPES.has(eventType)) return "paid";
+  if (FREE_EVENT_TYPES.has(eventType)) return "free";
+  return "free";
+}

--- a/convex/lib/task_filters.test.ts
+++ b/convex/lib/task_filters.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { filterTasksDueInRange } from "./task_filters";
+
+const tasks = [
+  { id: "a", dueAt: 100, status: "todo" },
+  { id: "b", dueAt: 199, status: "todo" },
+  { id: "c", dueAt: 200, status: "todo" },
+  { id: "d", status: "todo" },
+  { id: "e", dueAt: 150, status: "cancelled" },
+];
+
+describe("filterTasksDueInRange", () => {
+  test("includes tasks in half-open [start, end) window", () => {
+    const result = filterTasksDueInRange(tasks, 100, 200);
+    expect(result.map((t) => t.id)).toEqual(["a", "b"]);
+  });
+
+  test("excludes tasks without dueAt", () => {
+    const result = filterTasksDueInRange(tasks, 0, 1000);
+    expect(result.some((t) => t.id === "d")).toBe(false);
+  });
+
+  test("excludes cancelled tasks by default", () => {
+    const result = filterTasksDueInRange(tasks, 100, 200);
+    expect(result.some((t) => t.id === "e")).toBe(false);
+  });
+
+  test("can include cancelled tasks when configured", () => {
+    const result = filterTasksDueInRange(tasks, 100, 200, {
+      excludeCancelled: false,
+    });
+    expect(result.map((t) => t.id)).toEqual(["a", "b", "e"]);
+  });
+
+  test("end boundary is exclusive", () => {
+    const result = filterTasksDueInRange(tasks, 100, 200);
+    expect(result.some((t) => t.id === "c")).toBe(false);
+  });
+});

--- a/convex/lib/task_filters.ts
+++ b/convex/lib/task_filters.ts
@@ -1,0 +1,20 @@
+export type TaskDueRow = {
+  dueAt?: number;
+  status: string;
+};
+
+/** Half-open due window [startMs, endMs) used by Today and calendar views. */
+export function filterTasksDueInRange<T extends TaskDueRow>(
+  tasks: T[],
+  startMs: number,
+  endMs: number,
+  options?: { excludeCancelled?: boolean },
+): T[] {
+  const excludeCancelled = options?.excludeCancelled ?? true;
+  return tasks.filter((task) => {
+    if (task.dueAt === undefined) return false;
+    if (task.dueAt < startMs || task.dueAt >= endMs) return false;
+    if (excludeCancelled && task.status === "cancelled") return false;
+    return true;
+  });
+}

--- a/convex/revenuecat.ts
+++ b/convex/revenuecat.ts
@@ -1,5 +1,6 @@
 import { httpAction } from "./_generated/server";
 import { api } from "./_generated/api";
+import { mapRevenueCatEventToUserType } from "./lib/revenuecat_events";
 
 /**
  * RevenueCat webhook handler.
@@ -40,21 +41,7 @@ export const revenueCatWebhook = httpAction(async (ctx, request) => {
   // RevenueCat sends entitlement identifiers in the event
   const activeEntitlements = (event.entitlement_ids as string[] | undefined) ?? [];
 
-  let userType: "free" | "paid" = "free";
-  if (
-    eventType === "INITIAL_PURCHASE" ||
-    eventType === "RENEWAL" ||
-    eventType === "PRODUCT_CHANGE" ||
-    eventType === "UNCANCELLATION"
-  ) {
-    userType = "paid";
-  } else if (
-    eventType === "EXPIRATION" ||
-    eventType === "CANCELLATION" ||
-    eventType === "SUBSCRIBER_ALIAS"
-  ) {
-    userType = "free";
-  }
+  const userType = mapRevenueCatEventToUserType(eventType);
 
   if (appUserId) {
     try {

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { requireUser } from "./lib/requireUser";
+import { filterTasksDueInRange } from "./lib/task_filters";
 import { fetchCurrentUser } from "./users";
 
 const taskStatusValidator = v.union(
@@ -78,12 +79,9 @@ export const list = query({
       );
     }
     if (args.dueFrom !== undefined && args.dueTo !== undefined) {
-      rows = rows.filter(
-        (t) =>
-          t.dueAt !== undefined &&
-          t.dueAt >= args.dueFrom! &&
-          t.dueAt < args.dueTo!,
-      );
+      rows = filterTasksDueInRange(rows, args.dueFrom, args.dueTo, {
+        excludeCancelled: false,
+      });
     }
     rows.sort((a, b) => (b.updatedAt ?? b.createdAt) - (a.updatedAt ?? a.createdAt));
     return rows;
@@ -103,13 +101,10 @@ export const listDueInRange = query({
       .query("tasks")
       .withIndex("by_userId", (q) => q.eq("userId", user._id))
       .collect();
-    return rows.filter(
-      (t) =>
-        t.dueAt !== undefined &&
-        t.dueAt >= args.startMs &&
-        t.dueAt < args.endMs &&
-        t.deletedAt === undefined &&
-        t.status !== "cancelled",
+    return filterTasksDueInRange(
+      rows.filter((t) => t.deletedAt === undefined),
+      args.startMs,
+      args.endMs,
     );
   },
 });
@@ -260,16 +255,11 @@ export const listToday = query({
       .query("tasks")
       .withIndex("by_userId", (q) => q.eq("userId", user._id))
       .collect();
-    return rows
-      .filter(
-        (t) =>
-          t.dueAt !== undefined &&
-          t.dueAt >= args.dueFrom &&
-          t.dueAt < args.dueTo &&
-          t.deletedAt === undefined &&
-          t.status !== "cancelled",
-      )
-      .sort((a, b) => (a.dueAt ?? 0) - (b.dueAt ?? 0));
+    return filterTasksDueInRange(
+      rows.filter((t) => t.deletedAt === undefined),
+      args.dueFrom,
+      args.dueTo,
+    ).sort((a, b) => (a.dueAt ?? 0) - (b.dueAt ?? 0));
   },
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Port the unique test coverage from #130 onto current `integration` APIs. RevenueCat event→tier mapping and the half-open Today due-window filter are now pure helpers with regression tests. Web `localDay` week helpers were untested; they have coverage now.

**Skipped from #130 (intentionally):** `convex/lib/beta_access.ts` and the `auth.ts` rewrite. Landing those would undo #348 open signup / max-tier grant. `parsePlanFromModelContent` and web task-view filters already exist on `integration`.

## Linked task(s)

`docs/brain/TASKS.md` is a private submodule and is empty in this cloud checkout. Did not invent a `T-XXXX` id. Public board: original #130.

## Screenshots / screen recording

N/A — no user-visible surface.

## Test plan

- [x] Local `bun test convex/lib/revenuecat_events.test.ts convex/lib/task_filters.test.ts apps/web/lib/localDay.test.ts` — 13 pass
- [ ] CI Typecheck / Lint / Test / Scans / Notices / E2E
- [x] `list` still includes cancelled tasks in an optional due window (`excludeCancelled: false`) so behavior does not change
- [x] `listDueInRange` / `listToday` still exclude cancelled + soft-deleted rows

## Acceptance criteria

- RevenueCat webhook still maps INITIAL_PURCHASE / RENEWAL / PRODUCT_CHANGE / UNCANCELLATION → paid, EXPIRATION / CANCELLATION / SUBSCRIBER_ALIAS → free, unknown → free
- Today / due-range queries still use a half-open `[start, end)` window
- Open signup from #348 is unchanged (no beta allowlist)

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI-originated state changes N/A
- [x] Schema unchanged
- [x] Styling N/A
- [x] Accessibility N/A
- [x] No secrets committed
- [x] Voice rules N/A (no user-facing copy)

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`). Authorized Phase 1 merge once CI is green.

## Graph note

Ticket text asked for beta-auth coverage. Current `convex/auth.ts` is open signup. The graph/code wins; the allowlist extract is not ported.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

