### PR TITLE
feat(mobile): breathwork cue timer

### DIFF
--- a/apps/mobile/app/(tempo)/routines.tsx
+++ b/apps/mobile/app/(tempo)/routines.tsx
@@ -6,15 +6,21 @@
  * @summary: Mobile routines.
  * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
  */
+import { BreathworkTimer } from "@/components/breathwork/BreathworkTimer";
 import { Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Screen() {
   return (
     <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Routines</Text>
-        <Text className="text-sm text-muted-foreground">Mobile routines.</Text>
+      <View className="flex-1 p-6 gap-5">
+        <View className="gap-3">
+          <Text className="text-2xl font-semibold text-foreground">Routines</Text>
+          <Text className="text-sm text-muted-foreground">
+            A gentle breathwork timer is ready when a reset would help.
+          </Text>
+        </View>
+        <BreathworkTimer />
         <Text className="text-xs text-muted-foreground font-mono">
           scaffold · port from mobile/mobile-screens-b.jsx
         </Text>

--- a/apps/mobile/components/breathwork/BreathworkTimer.tsx
+++ b/apps/mobile/components/breathwork/BreathworkTimer.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Text, View } from "react-native";
+
+import {
+  createBreathworkTimerController,
+  defaultBreathworkCueHandlers,
+  defaultBreathworkPattern,
+  type BreathworkCueHandlers,
+  type BreathworkPattern,
+  type BreathworkTimerController,
+} from "@/lib/breathwork-timer";
+
+type BreathworkTimerProps = {
+  autoStart?: boolean;
+  cues?: BreathworkCueHandlers;
+  pattern?: BreathworkPattern;
+};
+
+export function BreathworkTimer({
+  autoStart = true,
+  cues = defaultBreathworkCueHandlers,
+  pattern = defaultBreathworkPattern,
+}: BreathworkTimerProps) {
+  const controllerRef = useRef<BreathworkTimerController | null>(null);
+
+  if (controllerRef.current === null) {
+    controllerRef.current = createBreathworkTimerController({
+      cues,
+      pattern,
+    });
+  }
+
+  const [phase, setPhase] = useState(() => {
+    return controllerRef.current?.currentPhase ?? pattern.phases[0];
+  });
+  const [boundaryIndex, setBoundaryIndex] = useState(0);
+
+  const advancePhase = useCallback(async () => {
+    const controller = controllerRef.current;
+
+    if (controller === null) {
+      return;
+    }
+
+    const nextPhase = await controller.advancePhase();
+    setPhase(nextPhase);
+    setBoundaryIndex(controller.boundaryIndex);
+  }, []);
+
+  useEffect(() => {
+    if (!autoStart) {
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      void advancePhase();
+    }, phase.durationMs);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [advancePhase, autoStart, phase.durationMs]);
+
+  const phaseSeconds = Math.round(phase.durationMs / 1_000);
+
+  return (
+    <View
+      accessibilityLabel={`Breathwork timer. Current phase: ${phase.label}.`}
+      accessible={true}
+      className="rounded-3xl border border-border bg-card p-5 gap-4"
+    >
+      <View className="gap-1">
+        <Text className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          Breathwork
+        </Text>
+        <Text className="text-2xl font-semibold text-foreground">
+          {phase.label}
+        </Text>
+      </View>
+
+      <View className="rounded-full bg-muted px-4 py-3">
+        <Text className="text-center text-sm text-muted-foreground">
+          {phaseSeconds} seconds - cue {boundaryIndex}
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/lib/breathwork-timer.ts
+++ b/apps/mobile/lib/breathwork-timer.ts
@@ -1,0 +1,117 @@
+export type BreathworkPhaseId = "inhale" | "hold" | "exhale";
+
+export type BreathworkPhase = {
+  id: BreathworkPhaseId;
+  label: string;
+  durationMs: number;
+};
+
+export type BreathworkPattern = {
+  phases: [BreathworkPhase, ...BreathworkPhase[]];
+};
+
+export type BreathworkCueKind = "audio" | "haptic";
+
+export type BreathworkCueHandler = (
+  phase: BreathworkPhase,
+  boundaryIndex: number,
+) => Promise<void> | void;
+
+export type BreathworkCueHandlers = {
+  audio: BreathworkCueHandler;
+  haptic: BreathworkCueHandler;
+};
+
+export type BreathworkTimerController = {
+  readonly boundaryIndex: number;
+  readonly currentPhase: BreathworkPhase;
+  advancePhase: () => Promise<BreathworkPhase>;
+};
+
+type CreateBreathworkTimerControllerOptions = {
+  cues: BreathworkCueHandlers;
+  pattern: BreathworkPattern;
+};
+
+export const defaultBreathworkPattern: BreathworkPattern = {
+  phases: [
+    { id: "inhale", label: "Breathe in", durationMs: 4_000 },
+    { id: "hold", label: "Hold gently", durationMs: 7_000 },
+    { id: "exhale", label: "Let it out", durationMs: 8_000 },
+  ],
+};
+
+export const defaultBreathworkCueHandlers: BreathworkCueHandlers = {
+  audio: (phase, boundaryIndex) => {
+    dispatchBreathworkCueEvent("audio", phase, boundaryIndex);
+  },
+  haptic: (phase, boundaryIndex) => {
+    const navigatorWithVibrate = globalThis.navigator as
+      | (Navigator & {
+          vibrate?: (pattern: number | number[]) => boolean;
+        })
+      | undefined;
+
+    navigatorWithVibrate?.vibrate?.(18);
+    dispatchBreathworkCueEvent("haptic", phase, boundaryIndex);
+  },
+};
+
+export function createBreathworkTimerController({
+  cues,
+  pattern,
+}: CreateBreathworkTimerControllerOptions): BreathworkTimerController {
+  let currentPhaseIndex = 0;
+  let boundaryIndex = 0;
+
+  return {
+    get boundaryIndex() {
+      return boundaryIndex;
+    },
+    get currentPhase() {
+      return getPhaseAt(pattern, currentPhaseIndex);
+    },
+    async advancePhase() {
+      currentPhaseIndex = (currentPhaseIndex + 1) % pattern.phases.length;
+      boundaryIndex += 1;
+
+      const nextPhase = getPhaseAt(pattern, currentPhaseIndex);
+      await Promise.all([
+        cues.audio(nextPhase, boundaryIndex),
+        cues.haptic(nextPhase, boundaryIndex),
+      ]);
+
+      return nextPhase;
+    },
+  };
+}
+
+function dispatchBreathworkCueEvent(
+  kind: BreathworkCueKind,
+  phase: BreathworkPhase,
+  boundaryIndex: number,
+): void {
+  if (
+    typeof globalThis.dispatchEvent !== "function" ||
+    typeof CustomEvent !== "function"
+  ) {
+    return;
+  }
+
+  globalThis.dispatchEvent(
+    new CustomEvent("tempo:breathwork-cue", {
+      detail: {
+        boundaryIndex,
+        kind,
+        phaseId: phase.id,
+      },
+    }),
+  );
+}
+
+function getPhaseAt(
+  pattern: BreathworkPattern,
+  phaseIndex: number,
+): BreathworkPhase {
+  return pattern.phases[phaseIndex % pattern.phases.length] ?? pattern.phases[0];
+}

--- a/tests/unit/breathwork-timer.test.ts
+++ b/tests/unit/breathwork-timer.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createBreathworkTimerController,
+  defaultBreathworkPattern,
+  type BreathworkCueKind,
+  type BreathworkPhaseId,
+} from "../../apps/mobile/lib/breathwork-timer";
+
+type CueCall = {
+  kind: BreathworkCueKind;
+  phaseId: BreathworkPhaseId;
+  boundaryIndex: number;
+};
+
+const expectedBoundaryPhases = ["hold", "exhale", "inhale"] as const;
+
+describe("createBreathworkTimerController", () => {
+  test("starts on the inhale phase", () => {
+    const calls: CueCall[] = [];
+    const controller = createBreathworkTimerController({
+      pattern: defaultBreathworkPattern,
+      cues: {
+        audio: (phase, boundaryIndex) => {
+          calls.push({ kind: "audio", phaseId: phase.id, boundaryIndex });
+        },
+        haptic: (phase, boundaryIndex) => {
+          calls.push({ kind: "haptic", phaseId: phase.id, boundaryIndex });
+        },
+      },
+    });
+
+    expect(controller.currentPhase.id).toBe("inhale");
+    expect(controller.boundaryIndex).toBe(0);
+    expect(calls).toEqual([]);
+  });
+
+  test("fires audio and haptic on every phase boundary", async () => {
+    const calls: CueCall[] = [];
+    const controller = createBreathworkTimerController({
+      pattern: defaultBreathworkPattern,
+      cues: {
+        audio: (phase, boundaryIndex) => {
+          calls.push({ kind: "audio", phaseId: phase.id, boundaryIndex });
+        },
+        haptic: (phase, boundaryIndex) => {
+          calls.push({ kind: "haptic", phaseId: phase.id, boundaryIndex });
+        },
+      },
+    });
+
+    for (const [index, phaseId] of expectedBoundaryPhases.entries()) {
+      const next = await controller.advancePhase();
+      expect(next.id).toBe(phaseId);
+      expect(controller.boundaryIndex).toBe(index + 1);
+      expect(controller.currentPhase.id).toBe(phaseId);
+    }
+
+    expect(calls).toEqual([
+      { kind: "audio", phaseId: "hold", boundaryIndex: 1 },
+      { kind: "haptic", phaseId: "hold", boundaryIndex: 1 },
+      { kind: "audio", phaseId: "exhale", boundaryIndex: 2 },
+      { kind: "haptic", phaseId: "exhale", boundaryIndex: 2 },
+      { kind: "audio", phaseId: "inhale", boundaryIndex: 3 },
+      { kind: "haptic", phaseId: "inhale", boundaryIndex: 3 },
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Port the #197 breathwork cue timer onto current `integration`. Routines shows a 4-7-8 timer that fires audio and haptic cue handlers on every phase boundary. No new dependencies and no bun.lock churn — those extras were why the original Test job failed.

## Linked task(s)

`docs/brain/TASKS.md` is a private submodule and is empty in this cloud checkout. Did not invent a `T-XXXX` id. Public board: original #197.

## Screenshots / screen recording

N/A for this port — mobile Routines now mounts the timer; visual QA belongs on a device. Logic coverage is in `tests/unit/breathwork-timer.test.ts`.

## Test plan

- [x] Local `bun test tests/unit/breathwork-timer.test.ts` — 2 pass
- [ ] CI Typecheck / Lint / Test / Scans / Notices / E2E
- [x] No new packages; no lockfile change
- [x] Copy is anti-shame: "A gentle breathwork timer is ready when a reset would help."

## Acceptance criteria

- Phase order is inhale → hold → exhale → inhale
- Each `advancePhase` fires both audio and haptic cues
- Default pattern is 4s / 7s / 8s
- Routines screen mounts the timer

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI-originated state changes N/A
- [x] Schema unchanged
- [x] Styling uses existing `border-border` / `bg-card` / `text-foreground` / `text-muted-foreground` tokens
- [x] Accessibility: `accessible` + `accessibilityLabel` on the timer
- [x] No secrets committed
- [x] Voice rules honored

## Owner tag (§14)

- [x] `cursor-cloud-3`

## Reviewer

Amit (`human-amit`). Authorized Phase 1 merge once CI is green.

## Skipped from #197

- Root / mobile `package.json` and `bun.lock` (expo-web / e2e deps). Current mobile already has `react-native-web`.
- Playwright hybrid under `apps/mobile/e2e/` — CI Playwright only runs `tests/e2e`. Replaced with bun:test.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

