### PR TITLE
fix(convex): close auth, payment bypass, and account-deletion bugs

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -3,6 +3,7 @@ import { Password } from "@convex-dev/auth/providers/Password";
 import { convexAuth } from "@convex-dev/auth/server";
 import type { GenericMutationCtx } from "convex/server";
 import type { DataModel, Id } from "./_generated/dataModel";
+import { isInactiveAccount } from "./lib/accountDeletion";
 import {
   buildReturningUserPatch,
   GRANTED_SUBSCRIPTION,
@@ -125,7 +126,16 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
         // undefined here is what stripped entitlementTier, betaAccess,
         // isGodTier and userType on a returning user's SECOND sign-in --
         // Convex reads undefined in a patch as "delete this field".
-        await db.patch(existingUserId, buildReturningUserPatch(existing ?? {}, profile, now));
+        //
+        // Soft-delete recovery is the one intentional undefined: clearing
+        // `deletedAt` brings the row back to live so beforeSessionCreation
+        // can issue a session.
+        await db.patch(existingUserId, {
+          ...buildReturningUserPatch(existing ?? {}, profile, now),
+          ...(existing && isInactiveAccount(existing)
+            ? { deletedAt: undefined, isActive: true }
+            : {}),
+        });
         await ensureGrantedSubscription(db, existingUserId, now);
 
         return existingUserId;

--- a/convex/lib/accountDeletion.test.ts
+++ b/convex/lib/accountDeletion.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { isInactiveAccount, USER_OWNED_TABLES } from "./accountDeletion";
+
+describe("isInactiveAccount", () => {
+  test("live accounts are active", () => {
+    expect(isInactiveAccount({})).toBe(false);
+    expect(isInactiveAccount({ isActive: true })).toBe(false);
+  });
+
+  test("soft-deleted or deactivated accounts are inactive", () => {
+    expect(isInactiveAccount({ deletedAt: 1 })).toBe(true);
+    expect(isInactiveAccount({ isActive: false })).toBe(true);
+  });
+});
+
+describe("USER_OWNED_TABLES", () => {
+  test("covers current user-owned schema tables with by_userId", () => {
+    expect([...USER_OWNED_TABLES].sort()).toEqual(
+      [
+        "calendarEvents",
+        "goals",
+        "habits",
+        "memories",
+        "notes",
+        "taskRepeatCfgs",
+        "tasks",
+      ].sort(),
+    );
+  });
+});

--- a/convex/lib/accountDeletion.ts
+++ b/convex/lib/accountDeletion.ts
@@ -1,0 +1,109 @@
+import type { Id } from "../_generated/dataModel";
+import type { MutationCtx } from "../_generated/server";
+
+/** User-owned tables that carry `by_userId` + `deletedAt`. */
+export const USER_OWNED_TABLES = [
+  "tasks",
+  "notes",
+  "habits",
+  "goals",
+  "memories",
+  "calendarEvents",
+  "taskRepeatCfgs",
+] as const;
+
+type UserOwnedTable = (typeof USER_OWNED_TABLES)[number];
+
+export function isInactiveAccount(user: {
+  deletedAt?: number;
+  isActive?: boolean;
+}): boolean {
+  return user.deletedAt !== undefined || user.isActive === false;
+}
+
+/** Soft-delete a user account and owned rows (GDPR grace window per HARD_RULES §9). */
+export async function softDeleteUserAccount(
+  ctx: MutationCtx,
+  userId: Id<"users">,
+  now = Date.now(),
+): Promise<{ deletedCount: number }> {
+  const user = await ctx.db.get(userId);
+  if (!user) {
+    return { deletedCount: 0 };
+  }
+
+  let deletedCount = 0;
+
+  if (user.deletedAt === undefined) {
+    await ctx.db.patch(userId, {
+      deletedAt: now,
+      isActive: false,
+      updatedAt: now,
+    });
+    deletedCount += 1;
+  }
+
+  for (const table of USER_OWNED_TABLES) {
+    deletedCount += await softDeleteRowsByUserId(ctx, table, userId, now);
+  }
+
+  const conversations = await ctx.db
+    .query("conversations")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .collect();
+
+  for (const conversation of conversations) {
+    if (conversation.deletedAt === undefined) {
+      await ctx.db.patch(conversation._id, { deletedAt: now, updatedAt: now });
+      deletedCount += 1;
+    }
+
+    const messages = await ctx.db
+      .query("messages")
+      .withIndex("by_conversationId", (q) => q.eq("conversationId", conversation._id))
+      .collect();
+
+    for (const message of messages) {
+      if (message.deletedAt === undefined) {
+        await ctx.db.patch(message._id, { deletedAt: now });
+        deletedCount += 1;
+      }
+    }
+  }
+
+  const subscription = await ctx.db
+    .query("subscriptionStates")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .unique();
+
+  if (subscription && subscription.status !== "inactive") {
+    await ctx.db.patch(subscription._id, {
+      status: "inactive",
+      updatedAt: now,
+    });
+    deletedCount += 1;
+  }
+
+  return { deletedCount };
+}
+
+async function softDeleteRowsByUserId(
+  ctx: MutationCtx,
+  table: UserOwnedTable,
+  userId: Id<"users">,
+  now: number,
+): Promise<number> {
+  const rows = await ctx.db
+    .query(table)
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .collect();
+
+  let count = 0;
+  for (const row of rows) {
+    if (row.deletedAt === undefined) {
+      await ctx.db.patch(row._id, { deletedAt: now, updatedAt: now });
+      count += 1;
+    }
+  }
+  return count;
+}

--- a/convex/lib/requireUser.ts
+++ b/convex/lib/requireUser.ts
@@ -1,5 +1,6 @@
 import type { Doc } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { isInactiveAccount } from "./accountDeletion";
 
 /**
  * Resolve the authenticated app user (users table row) from Convex Auth identity.
@@ -29,6 +30,9 @@ export async function requireUser(ctx: QueryCtx | MutationCtx) {
 
   const subjectUser = await resolveUserFromSubject(ctx, identity.subject);
   if (subjectUser) {
+    if (isInactiveAccount(subjectUser)) {
+      throw new Error("This account is not active");
+    }
     return subjectUser;
   }
 
@@ -44,6 +48,10 @@ export async function requireUser(ctx: QueryCtx | MutationCtx) {
 
   if (!user) {
     throw new Error("User not found");
+  }
+
+  if (isInactiveAccount(user)) {
+    throw new Error("This account is not active");
   }
 
   return user;

--- a/convex/lib/subscriptionGuards.test.ts
+++ b/convex/lib/subscriptionGuards.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  assertClientMaySetUserType,
+  isMockPaymentsEnabled,
+} from "./subscriptionGuards";
+
+describe("subscriptionGuards", () => {
+  const originalMockPayments = process.env.MOCK_PAYMENTS;
+
+  afterEach(() => {
+    if (originalMockPayments === undefined) {
+      delete process.env.MOCK_PAYMENTS;
+    } else {
+      process.env.MOCK_PAYMENTS = originalMockPayments;
+    }
+  });
+
+  test("isMockPaymentsEnabled is true only when env is exactly 'true'", () => {
+    process.env.MOCK_PAYMENTS = "true";
+    expect(isMockPaymentsEnabled()).toBe(true);
+
+    process.env.MOCK_PAYMENTS = "false";
+    expect(isMockPaymentsEnabled()).toBe(false);
+
+    delete process.env.MOCK_PAYMENTS;
+    expect(isMockPaymentsEnabled()).toBe(false);
+  });
+
+  test("assertClientMaySetUserType allows free downgrades without mock payments", () => {
+    delete process.env.MOCK_PAYMENTS;
+    expect(() => assertClientMaySetUserType("free")).not.toThrow();
+  });
+
+  test("assertClientMaySetUserType blocks paid upgrades unless mock payments enabled", () => {
+    delete process.env.MOCK_PAYMENTS;
+    expect(() => assertClientMaySetUserType("paid")).toThrow(/RevenueCat/i);
+
+    process.env.MOCK_PAYMENTS = "true";
+    expect(() => assertClientMaySetUserType("paid")).not.toThrow();
+  });
+});

--- a/convex/lib/subscriptionGuards.ts
+++ b/convex/lib/subscriptionGuards.ts
@@ -1,0 +1,10 @@
+/** Server-side guard for client-initiated paid upgrades (MOCK_PAYMENTS in Convex env). */
+export function isMockPaymentsEnabled(): boolean {
+  return process.env.MOCK_PAYMENTS === "true";
+}
+
+export function assertClientMaySetUserType(userType: "free" | "paid"): void {
+  if (userType === "paid" && !isMockPaymentsEnabled()) {
+    throw new Error("Paid upgrades must go through RevenueCat checkout.");
+  }
+}

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -68,6 +68,10 @@ export const create = mutation({
       throw new Error('Conversation not found or access denied');
     }
 
+    if (args.role !== 'user') {
+      throw new Error('Only user messages can be created from the client');
+    }
+
     const messageId = await ctx.db.insert('messages', {
       conversationId: args.conversationId,
       role: args.role,

--- a/convex/revenuecat.ts
+++ b/convex/revenuecat.ts
@@ -1,5 +1,5 @@
 import { httpAction } from "./_generated/server";
-import { api } from "./_generated/api";
+import { internal } from "./_generated/api";
 import { mapRevenueCatEventToUserType } from "./lib/revenuecat_events";
 
 /**
@@ -17,7 +17,12 @@ export const revenueCatWebhook = httpAction(async (ctx, request) => {
   const authHeader = request.headers.get("Authorization");
   const webhookSecret = process.env.REVENUECAT_WEBHOOK_SECRET;
 
-  if (webhookSecret && authHeader !== webhookSecret) {
+  if (!webhookSecret) {
+    console.error("[RevenueCat Webhook] REVENUECAT_WEBHOOK_SECRET is not configured");
+    return new Response("Webhook not configured", { status: 503 });
+  }
+
+  if (authHeader !== webhookSecret) {
     return new Response("Unauthorized", { status: 401 });
   }
 
@@ -35,7 +40,6 @@ export const revenueCatWebhook = httpAction(async (ctx, request) => {
 
   const eventType = event.type as string | undefined;
   const appUserId = event.app_user_id as string | undefined;
-  const entitlements = event.subscriber_attributes as Record<string, unknown> | undefined;
 
   // Determine new user tier from entitlements
   // RevenueCat sends entitlement identifiers in the event
@@ -45,7 +49,7 @@ export const revenueCatWebhook = httpAction(async (ctx, request) => {
 
   if (appUserId) {
     try {
-      await ctx.runMutation(api.users.updateSubscriptionStatus, {
+      await ctx.runMutation(internal.users.updateSubscriptionStatus, {
         userId: appUserId,
         userType,
         activeEntitlements,

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,8 +1,11 @@
 import { v } from "convex/values";
 import type { Doc } from "./_generated/dataModel";
 import type { QueryCtx } from "./_generated/server";
-import { mutation, query } from "./_generated/server";
+import { internalMutation, mutation, query } from "./_generated/server";
+import { isInactiveAccount, softDeleteUserAccount } from "./lib/accountDeletion";
 import { buildReturningUserPatch, newUserFields } from "./lib/entitlements";
+import { requireUser } from "./lib/requireUser";
+import { assertClientMaySetUserType } from "./lib/subscriptionGuards";
 
 /** Shared resolver for the authenticated app user document. */
 export async function fetchCurrentUser(ctx: QueryCtx): Promise<Doc<"users"> | null> {
@@ -17,7 +20,10 @@ export async function fetchCurrentUser(ctx: QueryCtx): Promise<Doc<"users"> | nu
     const userId = subjectParts[1] as import("./_generated/dataModel").Id<"users">;
     try {
       const user = await ctx.db.get(userId);
-      if (user) return user;
+      if (user) {
+        if (isInactiveAccount(user)) return null;
+        return user;
+      }
     } catch {
       // invalid ID, fall through to email lookup
     }
@@ -28,7 +34,10 @@ export async function fetchCurrentUser(ctx: QueryCtx): Promise<Doc<"users"> | nu
       .query("users")
       .withIndex("by_email", (q) => q.eq("email", identity.email ?? ""))
       .unique();
-    if (user) return user;
+    if (user) {
+      if (isInactiveAccount(user)) return null;
+      return user;
+    }
   }
 
   return null;
@@ -56,16 +65,28 @@ export const getProfile = query({
 
 export const getById = query({
   args: { userId: v.id("users") },
-  handler: async (ctx, { userId }) => ctx.db.get(userId),
+  handler: async (ctx, { userId }) => {
+    const currentUser = await requireUser(ctx);
+    if (currentUser._id !== userId && currentUser.role !== "admin") {
+      throw new Error("Access denied");
+    }
+    return ctx.db.get(userId);
+  },
 });
 
 export const listActive = query({
   args: {},
-  handler: async (ctx) =>
-    ctx.db
+  handler: async (ctx) => {
+    const currentUser = await requireUser(ctx);
+    if (currentUser.role !== "admin") {
+      throw new Error("Access denied");
+    }
+    const rows = await ctx.db
       .query("users")
-      .filter((q) => q.eq(q.field("isActive"), true))
-      .collect(),
+      .withIndex("by_deletedAt", (q) => q.eq("deletedAt", undefined))
+      .collect();
+    return rows.filter((user) => user.isActive !== false);
+  },
 });
 
 /**
@@ -103,7 +124,12 @@ export const createOrUpdateUser = mutation({
       // Identity fields plus self-heal only. This path must never write
       // `role`, and must never write `userType` unconditionally - that was
       // the downgrade.
-      await ctx.db.patch(existing._id, buildReturningUserPatch(existing, profile, now));
+      await ctx.db.patch(existing._id, {
+        ...buildReturningUserPatch(existing, profile, now),
+        ...(isInactiveAccount(existing)
+          ? { deletedAt: undefined, isActive: true }
+          : {}),
+      });
       return existing._id;
     }
 
@@ -117,8 +143,10 @@ export const updateProfile = mutation({
     fullName: v.optional(v.string()),
   },
   handler: async (ctx, { userId, fullName }) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
+    const currentUser = await requireUser(ctx);
+    if (currentUser._id !== userId && currentUser.role !== "admin") {
+      throw new Error("Access denied");
+    }
     await ctx.db.patch(userId, { fullName, updatedAt: Date.now() });
     return userId;
   },
@@ -129,29 +157,8 @@ export const updateUserType = mutation({
     userType: v.union(v.literal("free"), v.literal("paid")),
   },
   handler: async (ctx, { userType }) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
-
-    let user = null;
-    const subjectParts = identity.subject.split("|");
-    if (subjectParts.length >= 2) {
-      const userId = subjectParts[1] as import("./_generated/dataModel").Id<"users">;
-      try {
-        user = await ctx.db.get(userId);
-      } catch {
-        // fall through
-      }
-    }
-
-    if (!user && identity.email) {
-      user = await ctx.db
-        .query("users")
-        .withIndex("by_email", (q) => q.eq("email", identity.email ?? ""))
-        .unique();
-    }
-
-    if (!user) throw new Error("User not found");
-
+    assertClientMaySetUserType(userType);
+    const user = await requireUser(ctx);
     await ctx.db.patch(user._id, { userType, updatedAt: Date.now() });
     return user._id;
   },
@@ -161,7 +168,7 @@ export const updateUserType = mutation({
  * Called by the RevenueCat webhook (convex/revenuecat.ts) to sync subscription status.
  * Uses appUserId (RevenueCat user ID = Convex user email or subject) to find and update the user.
  */
-export const updateSubscriptionStatus = mutation({
+export const updateSubscriptionStatus = internalMutation({
   args: {
     userId: v.string(),
     userType: v.union(v.literal("free"), v.literal("paid")),
@@ -197,8 +204,10 @@ export const updateSubscriptionStatus = mutation({
 export const remove = mutation({
   args: { userId: v.id("users") },
   handler: async (ctx, { userId }) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
+    const currentUser = await requireUser(ctx);
+    if (currentUser._id !== userId && currentUser.role !== "admin") {
+      throw new Error("Access denied");
+    }
     await ctx.db.delete(userId);
   },
 });
@@ -206,22 +215,8 @@ export const remove = mutation({
 export const deleteMyAccount = mutation({
   args: {},
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
-
-    const userId = identity.subject;
-    let deletedCount = 0;
-
-    const user = await ctx.db
-      .query("users")
-      .filter((q) => q.eq(q.field("_id"), userId))
-      .first();
-
-    if (user) {
-      await ctx.db.delete(user._id);
-      deletedCount += 1;
-    }
-
+    const user = await requireUser(ctx);
+    const { deletedCount } = await softDeleteUserAccount(ctx, user._id);
     return { success: true, deletedCount };
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Port #131 onto current `integration` APIs. Closes the payment-bypass mutation, makes the RevenueCat webhook fail-closed and write through an internal mutation, stops clients from inserting assistant/system messages, adds ownership checks on user reads/writes, and replaces the broken `deleteMyAccount` hard-delete (it looked up `identity.subject` as a document id) with a soft-delete of the user and owned rows.

**Kept:** #348 open signup / max-tier grant. The original #131 `auth.ts` rewrite assumed founder-only entitlements and is not ported.

**Do not merge this PR without Amit.** Security surface: auth, payments, account deletion.

## Linked task(s)

`docs/brain/TASKS.md` is a private submodule and is empty in this cloud checkout. Did not invent a `T-XXXX` id. Public board: original #131.

## Screenshots / screen recording

N/A — no user-visible surface except account deletion now actually soft-deletes.

## Test plan

- [x] Local `bun test convex/lib/subscriptionGuards.test.ts convex/lib/accountDeletion.test.ts` — 6 pass
- [ ] CI Typecheck / Lint / Test / Scans / Notices / E2E
- [x] Open signup path unchanged (`newUserFields` / `buildReturningUserPatch`)
- [x] Web `PremiumGate` / Navbar already gate mock upgrades on `MOCK_PAYMENTS`; server now matches

## Acceptance criteria

- `updateSubscriptionStatus` is `internalMutation` — clients cannot call it
- RevenueCat webhook returns 503 if `REVENUECAT_WEBHOOK_SECRET` is unset; 401 on bad Authorization
- `updateUserType("paid")` throws unless `MOCK_PAYMENTS === "true"`
- `getById` / `updateProfile` / `remove` / `listActive` require the owner or an admin
- `deleteMyAccount` soft-deletes the user and owned rows (including `calendarEvents` and `taskRepeatCfgs` added after the original PR)
- Soft-deleted users cannot pass `requireUser`; signing in again clears `deletedAt` so `beforeSessionCreation` can issue a session
- Client `messages.create` accepts `role: "user"` only

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI-originated state changes N/A
- [x] Schema unchanged; soft-delete used for DSR (§9)
- [x] Styling N/A
- [x] Accessibility N/A
- [x] No secrets committed or logged
- [x] Voice: session error is "This account is not active" (no shame)

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`) — **required**. Agent will not merge.

## Graph / code vs ticket

Original #131 also rewrote `auth.ts` around founder entitlements and committed `convex/_generated/api.d.ts`. Current auth is open signup. Generated API types are derived from the `internalMutation` export; not hand-edited.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

