### PR TITLE
fix(mobile): allow Expo web export when Convex URL is unset

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -3,13 +3,14 @@ import { ConvexReactClient } from 'convex/react';
 import { Slot } from 'expo-router';
 import * as SecureStore from 'expo-secure-store';
 import { StatusBar } from 'expo-status-bar';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
+import { Text, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import '../global.css';
 
 import { RevenueCatProvider } from '@/contexts/RevenueCatContext';
 import { bootstrapRTL } from '@/lib/rtlBootstrap';
-import { getConvexUrl } from '@/utils/convexConfig';
+import { getConvexUrl, readPublicConvexUrl } from '@/utils/convexConfig';
 
 // אסטרטגיית RTL (ראה docs/rtl-knowhow.md):
 // 1. תוסף expo-localization (app.json) - מגדיר RTL ברמת ה-Native (עובד ב-Dev Builds ו-Production)
@@ -17,10 +18,6 @@ import { getConvexUrl } from '@/utils/convexConfig';
 // 3. סידור ידני של טאבים - מטפל ב-Tab Bar בכל הסביבות
 //
 // הגישה ההיברידית מבטיחה תמיכה עקבית בעברית/RTL בכל הסביבות.
-
-// שימוש בפונקציית הקונפיגורציה לבחירת כתובת Convex לפי הסביבה
-const convexUrl = getConvexUrl();
-const convex = new ConvexReactClient(convexUrl);
 
 // אחסון מאובטח של הטוקן (Token) באמצעות expo-secure-store
 // זה קריטי לשמירה על אבטחת המידע של המשתמש
@@ -49,12 +46,36 @@ const secureStorage = {
 };
 
 export default function RootLayout() {
+  const convexUrl = readPublicConvexUrl();
+  const convex = useMemo(() => {
+    if (!convexUrl) {
+      return null;
+    }
+    return new ConvexReactClient(getConvexUrl());
+  }, [convexUrl]);
+
   // Bootstrap RTL for Expo Go on first mount
   useEffect(() => {
     bootstrapRTL().catch(() => {
       // Silently handle errors - bootstrap will reload app if needed
     });
   }, []);
+
+  if (!convex) {
+    return (
+      <SafeAreaProvider>
+        <StatusBar style="light" translucent={false} backgroundColor="#0a0a0a" />
+        <View className="flex-1 items-center justify-center bg-background px-6">
+          <Text className="text-center font-serif text-2xl text-foreground">
+            This build is missing its app URL.
+          </Text>
+          <Text className="mt-3 text-center text-base text-muted-foreground">
+            Add EXPO_PUBLIC_CONVEX_URL to the environment, then start again.
+          </Text>
+        </View>
+      </SafeAreaProvider>
+    );
+  }
 
   return (
     <SafeAreaProvider>

--- a/apps/mobile/utils/convexConfig.ts
+++ b/apps/mobile/utils/convexConfig.ts
@@ -3,6 +3,26 @@
 // ============================================================================
 // ניהול כתובת Convex
 
+export type PublicEnv = {
+  EXPO_PUBLIC_CONVEX_URL?: string;
+};
+
+/**
+ * Read the public Convex URL without throwing.
+ * Expo web export and CI builds often have no `.env`; callers should render
+ * a missing-config state instead of crashing at module load.
+ */
+export function readPublicConvexUrl(
+  env: PublicEnv = process.env,
+): string | null {
+  const convexUrl = env.EXPO_PUBLIC_CONVEX_URL;
+  if (typeof convexUrl !== 'string') {
+    return null;
+  }
+  const trimmed = convexUrl.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 /**
  * קבלת כתובת Convex
  * הכתובת נלקחת ממשתנה הסביבה EXPO_PUBLIC_CONVEX_URL
@@ -11,8 +31,8 @@
  * - פיתוח מקומי: `bunx convex dev` (משתמש ב-dev deployment)
  * - ייצור: `bunx convex deploy` (משתמש ב-prod deployment)
  */
-export function getConvexUrl(): string {
-  const convexUrl = process.env.EXPO_PUBLIC_CONVEX_URL;
+export function getConvexUrl(env: PublicEnv = process.env): string {
+  const convexUrl = readPublicConvexUrl(env);
 
   if (!convexUrl) {
     throw new Error('חסרה כתובת Convex. הגדר EXPO_PUBLIC_CONVEX_URL ב-.env');

--- a/apps/mobile/utils/convexConfig.ts
+++ b/apps/mobile/utils/convexConfig.ts
@@ -4,7 +4,7 @@
 // ניהול כתובת Convex
 
 export type PublicEnv = {
-  EXPO_PUBLIC_CONVEX_URL?: string;
+  readonly [key: string]: string | undefined;
 };
 
 /**

--- a/tests/unit/expo_public_convex_url.test.ts
+++ b/tests/unit/expo_public_convex_url.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { getConvexUrl, readPublicConvexUrl } from "../../apps/mobile/utils/convexConfig";
+
+describe("readPublicConvexUrl", () => {
+  test("returns null when the env var is missing", () => {
+    expect(readPublicConvexUrl({})).toBeNull();
+  });
+
+  test("returns null for blank values so Expo web export can keep going", () => {
+    expect(readPublicConvexUrl({ EXPO_PUBLIC_CONVEX_URL: "" })).toBeNull();
+    expect(readPublicConvexUrl({ EXPO_PUBLIC_CONVEX_URL: "   " })).toBeNull();
+  });
+
+  test("returns a trimmed URL when one is set", () => {
+    expect(
+      readPublicConvexUrl({
+        EXPO_PUBLIC_CONVEX_URL: " https://example.convex.cloud ",
+      }),
+    ).toBe("https://example.convex.cloud");
+  });
+});
+
+describe("getConvexUrl", () => {
+  test("still throws when callers need a required URL", () => {
+    expect(() => getConvexUrl({})).toThrow(/EXPO_PUBLIC_CONVEX_URL/);
+  });
+
+  test("returns the URL when present", () => {
+    expect(
+      getConvexUrl({ EXPO_PUBLIC_CONVEX_URL: "https://example.convex.cloud" }),
+    ).toBe("https://example.convex.cloud");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Expo web export (and any CI build without a local `.env`) crashed at module load because `getConvexUrl()` threw before React could render. This ports the #207 intent onto current `integration`: read `EXPO_PUBLIC_CONVEX_URL` first, and if it is missing show a calm missing-config screen instead of crashing. No lockfile or Babel dependency changes.

Follow-up commit `26b7211` widens `PublicEnv` to an index signature so `process.env` typechecks under the mobile `tsc` config (TS2559).

## Linked task(s)

Task: Phase 3 FIX tail — original #207 (`fix(mobile): allow Expo web export without local env`). `docs/brain/TASKS.md` is a private submodule (empty in this clone); no invented `T-XXXX`.

## Screenshots / screen recording

N/A — developer empty-state copy only; no product flow change when the URL is set.

## Test plan

- [x] `bun test tests/unit/expo_public_convex_url.test.ts` — 5 pass
- [x] Local `apps/mobile` `bun run typecheck` passes after `26b7211`
- [ ] CI Typecheck / Lint / Test (re-running)
- [x] Relevant unit tests added
- [ ] Manual QA: confirm a configured build still mounts Convex as before
- [x] Reproduces the acceptance criteria below

## Acceptance criteria

- Importing the mobile root layout does not throw when `EXPO_PUBLIC_CONVEX_URL` is unset.
- A missing URL shows a kind empty state naming the env var; it does not crash `expo export`.
- A set URL still constructs `ConvexReactClient` and wraps the existing auth/RevenueCat tree.
- No `package.json` / `bun.lock` churn.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI-originated state changes — N/A
- [x] Schema changes — N/A
- [x] Styling uses existing NativeWind tokens (`bg-background`, `text-foreground`, `text-muted-foreground`)
- [x] Accessibility: empty state is readable text; no new interactive control
- [x] No secrets committed; `EXPO_PUBLIC_CONVEX_URL` already exists
- [x] Voice: calm, concrete, no shame

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`). Low-risk FIX; merge once CI is green.

**Original #207:** left open until this lands (it also bundled lockfile/Babel deps we did not take).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

