### PR TITLE
fix(mobile): smoke-cover existing Tempo routes without the Hebrew shell

### DIFF
--- a/apps/mobile/app/(tempo)/_layout.tsx
+++ b/apps/mobile/app/(tempo)/_layout.tsx
@@ -8,6 +8,12 @@ export default function TempoLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="(tabs)" />
+      <Stack.Screen name="calendar" />
+      <Stack.Screen name="habits" />
+      <Stack.Screen name="journal" />
+      <Stack.Screen name="routines" />
+      <Stack.Screen name="settings" />
+      <Stack.Screen name="templates" />
       <Stack.Screen name="capture" options={{ presentation: "modal" }} />
     </Stack>
   );

--- a/tests/unit/mobile_route_smoke.test.ts
+++ b/tests/unit/mobile_route_smoke.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Route-render smoke for the Tempo mobile surfaces that already exist.
+ *
+ * #208 added a Hebrew product shell (`/home`, `/breathe`, `/move`, …) plus
+ * Playwright + lockfile churn. That shell is a different app. bun:test also
+ * cannot import `react-native` screens (Flow `typeof` in RN's entry). This
+ * port keeps the coverage intent: every shipped (tempo) screen file must
+ * exist and default-export a component so a missing route cannot silently
+ * 404, and the stack must declare those siblings.
+ */
+
+const TEMPO_SCREENS = [
+  ["today", "apps/mobile/app/(tempo)/(tabs)/today.tsx"],
+  ["tasks", "apps/mobile/app/(tempo)/(tabs)/tasks.tsx"],
+  ["notes", "apps/mobile/app/(tempo)/(tabs)/notes.tsx"],
+  ["coach", "apps/mobile/app/(tempo)/(tabs)/coach.tsx"],
+  ["calendar", "apps/mobile/app/(tempo)/calendar.tsx"],
+  ["habits", "apps/mobile/app/(tempo)/habits.tsx"],
+  ["journal", "apps/mobile/app/(tempo)/journal.tsx"],
+  ["routines", "apps/mobile/app/(tempo)/routines.tsx"],
+  ["settings", "apps/mobile/app/(tempo)/settings.tsx"],
+  ["templates", "apps/mobile/app/(tempo)/templates.tsx"],
+  ["capture", "apps/mobile/app/(tempo)/capture.tsx"],
+] as const;
+
+describe("mobile tempo route smoke", () => {
+  test.each([...TEMPO_SCREENS])("%s exists and default-exports a screen", async (_name, filePath) => {
+    const source = await Bun.file(filePath).text();
+    expect(source.length).toBeGreaterThan(0);
+    expect(source).toMatch(/export default function \w+/);
+  });
+
+  test("tempo stack declares the sibling screens that already exist", async () => {
+    const source = await Bun.file("apps/mobile/app/(tempo)/_layout.tsx").text();
+    for (const name of [
+      "(tabs)",
+      "calendar",
+      "habits",
+      "journal",
+      "routines",
+      "settings",
+      "templates",
+      "capture",
+    ]) {
+      expect(source).toContain(`name="${name}"`);
+    }
+    expect(source).not.toContain('name="home"');
+    expect(source).not.toContain('name="breathe"');
+    expect(source).not.toContain('name="move"');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#208's intent is route-render smoke coverage. Its implementation added a Hebrew product shell (`/home`, `/breathe`, `/move`, `/condition`, `/progress`), Playwright, Babel, and `bun.lock` churn on top of `master`. Those routes are a different app than Tempo (today / tasks / notes / coach / routines).

This port keeps the coverage, drops the shell:

- `(tempo)/_layout.tsx` now declares the sibling screens that already exist (`calendar`, `habits`, `journal`, `routines`, `settings`, `templates`, plus the capture modal).
- `tests/unit/mobile_route_smoke.test.ts` asserts each shipped screen file default-exports a component, and that the stack does **not** register the Hebrew routes.

Skipped from #208 (on purpose): `breathe.tsx` / `home.tsx` / `move.tsx` / `condition.tsx` / `progress.tsx`, `apps/mobile/e2e/navigation.spec.ts` (Playwright + Expo web server), `apps/mobile/package.json` and `bun.lock`.

## Linked task(s)

Task: mobile route smoke follow-up to #208 (no readable `T-XXXX` row — `docs/brain/TASKS.md` is a private submodule).

Replaces: #208

## Screenshots / screen recording

N/A — no user-visible surface beyond declaring already-shipped stack screens.

## Test plan

- [x] Local `bun test tests/unit/mobile_route_smoke.test.ts` — 12 pass / 0 fail
- [ ] CI Typecheck / Lint / Test / Scans / E2E / secrets

## Acceptance criteria

- Every shipped Tempo mobile screen is covered by a smoke assertion.
- No Hebrew product routes and no lockfile / Playwright dependency added.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2).
- [x] AI accept/reject — N/A.
- [x] Schema — untouched.
- [x] Styling — existing tokens only; no new UI.
- [x] Accessibility — N/A (no new interactive UI).
- [x] No secrets; no env changes.
- [x] Anti-shame copy — N/A (no new user-facing strings).

## Owner tag (§14)

- [x] `cursor-cloud-3`

## Reviewer

Amit (`human-amit`). Low-risk test + stack declarations; merge once CI is green.

## Notes

- bun:test cannot import `react-native` screen modules (Flow `typeof` in RN's entry), so the smoke reads source instead of rendering. That is weaker than #208's Playwright pass and is called out on purpose.
- Convex is expected in this repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

