### PR TITLE
feat(today): energy-aware task recommendations with accept/reject

### DIFF
--- a/apps/web/components/today/TodayEnergyRecommendations.tsx
+++ b/apps/web/components/today/TodayEnergyRecommendations.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useMutation, useQuery } from "convex/react";
+import { BatteryLow, BatteryMedium, Plus, Sparkles, X, Zap } from "lucide-react";
+import { useState, type ReactNode } from "react";
+import type { Id } from "@/convex/_generated/dataModel";
+import { api } from "@/convex/_generated/api";
+import {
+  type EnergyLevel,
+  recommendTasksForEnergy,
+} from "@/lib/energyRecommendations";
+import { cn } from "@/lib/utils";
+
+/**
+ * T-007c — energy-aware suggestions with an explicit accept / reject step.
+ *
+ * Reads the user's open tasks and recommends up to three that fit the energy
+ * level they pick. Accepting ("Add to Today") calls the existing
+ * `tasks.update` mutation with today's dueAt; "Not now" dismisses locally.
+ * Nothing is ever applied without the user's click (HARD_RULES §1).
+ */
+
+type TodayEnergyRecommendationsProps = {
+  /** End-of-today dueAt to stamp on accepted tasks (bounds.endMs - 1). */
+  dueAt: number;
+  todayStartMs: number;
+  todayEndMs: number;
+};
+
+const ENERGY_OPTIONS: Array<{ level: EnergyLevel; label: string; icon: ReactNode }> = [
+  { level: "low", label: "Low", icon: <BatteryLow className="h-4 w-4" aria-hidden /> },
+  { level: "medium", label: "Medium", icon: <BatteryMedium className="h-4 w-4" aria-hidden /> },
+  { level: "high", label: "High", icon: <Zap className="h-4 w-4" aria-hidden /> },
+];
+
+export function TodayEnergyRecommendations({
+  dueAt,
+  todayStartMs,
+  todayEndMs,
+}: TodayEnergyRecommendationsProps) {
+  const [energy, setEnergy] = useState<EnergyLevel | null>(null);
+  const [dismissedIds, setDismissedIds] = useState<ReadonlySet<string>>(new Set());
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const updateTask = useMutation(api.tasks.update);
+
+  // Only subscribe once the user has opted in by picking an energy level.
+  const tasks = useQuery(api.tasks.list, energy !== null ? {} : "skip");
+
+  const recommendations =
+    energy !== null && tasks !== undefined
+      ? recommendTasksForEnergy(
+          tasks.map((t) => ({
+            id: t._id,
+            title: t.title,
+            status: t.status,
+            priority: t.priority,
+            energy: t.energy,
+            dueAt: t.dueAt,
+            updatedAt: t.updatedAt,
+          })),
+          { energy, todayStartMs, todayEndMs, dismissedIds },
+        )
+      : null;
+
+  const acceptTask = async (taskId: string) => {
+    setPendingId(taskId);
+    try {
+      await updateTask({ taskId: taskId as Id<"tasks">, dueAt });
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const dismissTask = (taskId: string) => {
+    setDismissedIds((prev) => {
+      const next = new Set(prev);
+      next.add(taskId);
+      return next;
+    });
+  };
+
+  return (
+    <section
+      className="rounded-3xl border border-border/80 bg-card/90 p-6 shadow-[0_10px_30px_rgba(26,25,23,0.08)]"
+      aria-labelledby="energy-recommendations-heading"
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <Sparkles className="h-5 w-5" aria-hidden />
+        </div>
+        <div>
+          <h2
+            id="energy-recommendations-heading"
+            className="font-heading text-2xl font-semibold text-foreground"
+          >
+            Match your energy
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            How's your energy right now? We'll suggest tasks that fit — you decide.
+          </p>
+        </div>
+      </div>
+
+      <fieldset className="mt-4 flex flex-wrap gap-2 border-0 p-0">
+        <legend className="sr-only">Pick your current energy level</legend>
+        {ENERGY_OPTIONS.map((option) => {
+          const isActive = energy === option.level;
+          return (
+            <button
+              key={option.level}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => setEnergy(isActive ? null : option.level)}
+              className={cn(
+                "flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+                isActive
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-background/70 text-foreground hover:border-primary hover:text-primary",
+              )}
+            >
+              {option.icon}
+              {option.label}
+            </button>
+          );
+        })}
+      </fieldset>
+
+      {energy === null ? null : recommendations === null ? (
+        <div className="mt-4 space-y-3" aria-hidden>
+          <div className="h-16 animate-pulse rounded-2xl bg-muted" />
+          <div className="h-16 animate-pulse rounded-2xl bg-muted" />
+        </div>
+      ) : recommendations.length === 0 ? (
+        <div className="mt-4 rounded-2xl border border-dashed border-border bg-muted/30 px-5 py-6 text-center">
+          <p className="text-base text-foreground">
+            Nothing outside today's plan fits that energy right now.
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            That's a fine answer — today's list already has you covered.
+          </p>
+        </div>
+      ) : (
+        <ul className="mt-4 space-y-3">
+          {recommendations.map(({ task, reason }) => (
+            <li
+              key={task.id}
+              className="rounded-2xl border border-border/80 bg-background/70 px-4 py-4"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium text-foreground">{task.title}</p>
+                  <p className="mt-0.5 text-sm text-muted-foreground">{reason}</p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    disabled={pendingId === task.id}
+                    onClick={() => {
+                      void acceptTask(task.id);
+                    }}
+                    className="flex items-center gap-1.5 rounded-full bg-primary px-3.5 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-60"
+                    aria-label={`Add ${task.title} to Today`}
+                  >
+                    <Plus className="h-4 w-4" aria-hidden />
+                    Add to Today
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => dismissTask(task.id)}
+                    className="flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-2 text-sm font-medium text-muted-foreground transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                    aria-label={`Not now: ${task.title}`}
+                  >
+                    <X className="h-4 w-4" aria-hidden />
+                    Not now
+                  </button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/today/TodayScreen.tsx
+++ b/apps/web/components/today/TodayScreen.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { api } from "@/convex/_generated/api";
 import { useLocalDayBounds } from "@/lib/useLocalDayBounds";
 import { TodayBrainDumpPanel } from "./TodayBrainDumpPanel";
+import { TodayEnergyRecommendations } from "./TodayEnergyRecommendations";
 import { TodayGreeting } from "./TodayGreeting";
 import { TodayQuickAdd } from "./TodayQuickAdd";
 import { TodayTaskList } from "./TodayTaskList";
@@ -76,6 +77,11 @@ export function TodayScreen() {
           <TodayQuickAdd dueAt={bounds.endMs - 1} />
           <TodayTaskList tasks={todayTasks} />
         </div>
+        <TodayEnergyRecommendations
+          dueAt={bounds.endMs - 1}
+          todayStartMs={bounds.startMs}
+          todayEndMs={bounds.endMs}
+        />
       </div>
     </div>
   );

--- a/apps/web/lib/energyRecommendations.test.ts
+++ b/apps/web/lib/energyRecommendations.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type RecommendableTask,
+  recommendTasksForEnergy,
+} from "./energyRecommendations";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const todayStartMs = 10 * DAY_MS;
+const todayEndMs = 11 * DAY_MS;
+
+let nextId = 0;
+
+function task(overrides: Partial<RecommendableTask> = {}): RecommendableTask {
+  nextId += 1;
+  return {
+    id: `t${nextId}`,
+    title: `Task ${nextId}`,
+    status: "todo",
+    priority: "medium",
+    updatedAt: todayStartMs - DAY_MS,
+    ...overrides,
+  };
+}
+
+function recommend(
+  tasks: RecommendableTask[],
+  overrides: Partial<Parameters<typeof recommendTasksForEnergy>[1]> = {},
+) {
+  return recommendTasksForEnergy(tasks, {
+    energy: "medium",
+    todayStartMs,
+    todayEndMs,
+    ...overrides,
+  });
+}
+
+describe("recommendTasksForEnergy", () => {
+  test("returns nothing for an empty task list", () => {
+    expect(recommend([])).toEqual([]);
+  });
+
+  test("only todo and in_progress tasks are candidates", () => {
+    const open = task({ energy: "medium" });
+    const inProgress = task({ energy: "medium", status: "in_progress" });
+    const picks = recommend([
+      open,
+      inProgress,
+      task({ energy: "medium", status: "done" }),
+      task({ energy: "medium", status: "cancelled" }),
+    ]);
+    expect(picks.map((p) => p.task.id).toSorted()).toEqual([open.id, inProgress.id].toSorted());
+  });
+
+  test("tasks already due today are excluded; other dueAt values are not", () => {
+    const dueToday = task({ energy: "medium", dueAt: todayStartMs });
+    const dueTodayEdge = task({ energy: "medium", dueAt: todayEndMs - 1 });
+    const dueTomorrow = task({ energy: "medium", dueAt: todayEndMs });
+    const overdue = task({ energy: "medium", dueAt: todayStartMs - 1 });
+    const picks = recommend([dueToday, dueTodayEdge, dueTomorrow, overdue]);
+    const ids = picks.map((p) => p.task.id);
+    expect(ids).not.toContain(dueToday.id);
+    expect(ids).not.toContain(dueTodayEdge.id);
+    expect(ids).toContain(dueTomorrow.id);
+    expect(ids).toContain(overdue.id);
+  });
+
+  test("exact energy matches come first and are flagged exactMatch", () => {
+    const low = task({ energy: "low" });
+    const medium = task({ energy: "medium" });
+    const picks = recommend([low, medium], { energy: "low" });
+    expect(picks[0]?.task.id).toBe(low.id);
+    expect(picks[0]?.exactMatch).toBe(true);
+    expect(picks[1]?.task.id).toBe(medium.id);
+    expect(picks[1]?.exactMatch).toBe(false);
+  });
+
+  test("a task without an energy level counts as medium", () => {
+    const unlabelled = task({ energy: undefined });
+    const picks = recommend([unlabelled], { energy: "medium" });
+    expect(picks[0]?.task.id).toBe(unlabelled.id);
+    expect(picks[0]?.exactMatch).toBe(true);
+  });
+
+  test("low-energy request never surfaces high-energy work", () => {
+    const high = task({ energy: "high" });
+    const picks = recommend([high], { energy: "low" });
+    expect(picks).toEqual([]);
+  });
+
+  test("high-energy request never surfaces low-energy work", () => {
+    const low = task({ energy: "low" });
+    const picks = recommend([low], { energy: "high" });
+    expect(picks).toEqual([]);
+  });
+
+  test("ranking: higher priority first, then longest-waiting task", () => {
+    const oldLowPriority = task({ energy: "medium", priority: "low", updatedAt: 1 });
+    const newHighPriority = task({ energy: "medium", priority: "high", updatedAt: 9 * DAY_MS });
+    const oldHighPriority = task({ energy: "medium", priority: "high", updatedAt: 1 });
+    const picks = recommend([oldLowPriority, newHighPriority, oldHighPriority]);
+    expect(picks.map((p) => p.task.id)).toEqual([
+      oldHighPriority.id,
+      newHighPriority.id,
+      oldLowPriority.id,
+    ]);
+  });
+
+  test("limit caps results (default 3)", () => {
+    const tasks = [task(), task(), task(), task(), task()].map((t) => ({
+      ...t,
+      energy: "medium" as const,
+    }));
+    expect(recommend(tasks)).toHaveLength(3);
+    expect(recommend(tasks, { limit: 2 })).toHaveLength(2);
+    expect(recommend(tasks, { limit: 0 })).toEqual([]);
+  });
+
+  test("dismissed tasks are never re-suggested", () => {
+    const a = task({ energy: "medium" });
+    const b = task({ energy: "medium" });
+    const picks = recommend([a, b], { dismissedIds: new Set([a.id]) });
+    expect(picks.map((p) => p.task.id)).toEqual([b.id]);
+  });
+
+  test("fallback fills remaining slots after exact matches, in preference order", () => {
+    const exact = task({ energy: "medium" });
+    const low = task({ energy: "low" });
+    const high = task({ energy: "high" });
+    const picks = recommend([high, low, exact], { energy: "medium" });
+    expect(picks.map((p) => p.task.id)).toEqual([exact.id, low.id, high.id]);
+    expect(picks.map((p) => p.exactMatch)).toEqual([true, false, false]);
+  });
+
+  test("every reason string is shame-free", () => {
+    const picks = recommend(
+      [task({ energy: "medium" }), task({ energy: "low" }), task({ energy: "high" })],
+      { energy: "medium" },
+    );
+    for (const pick of picks) {
+      expect(pick.reason).not.toMatch(/\b(behind|failing|failure|lazy|overdue|late)\b/i);
+    }
+  });
+
+  test("does not mutate the input array", () => {
+    const tasks = [
+      task({ energy: "medium", priority: "low" }),
+      task({ energy: "medium", priority: "high" }),
+    ];
+    const order = tasks.map((t) => t.id);
+    recommend(tasks);
+    expect(tasks.map((t) => t.id)).toEqual(order);
+  });
+});

--- a/apps/web/lib/energyRecommendations.ts
+++ b/apps/web/lib/energyRecommendations.ts
@@ -1,0 +1,138 @@
+/**
+ * T-007c — energy-aware task recommendations (pure logic, unit-tested).
+ *
+ * Given the user's current energy level and their open tasks, pick a small,
+ * non-overwhelming set of tasks that fit how they feel right now. This module
+ * only READS and RECOMMENDS — accepting a recommendation is an explicit user
+ * action handled by the UI via the existing `tasks.update` mutation
+ * (HARD_RULES §1: nothing is ever applied silently).
+ */
+
+export type EnergyLevel = "low" | "medium" | "high";
+
+export type RecommendableTask = {
+  id: string;
+  title: string;
+  status: "todo" | "in_progress" | "done" | "cancelled";
+  priority: "low" | "medium" | "high";
+  energy?: EnergyLevel;
+  dueAt?: number;
+  updatedAt: number;
+};
+
+export type EnergyRecommendation = {
+  task: RecommendableTask;
+  /** True when the task's energy is exactly the requested level (vs. a nearby fallback). */
+  exactMatch: boolean;
+  /** Shame-free, one-line explanation for why this task is suggested. */
+  reason: string;
+};
+
+const PRIORITY_RANK: Record<RecommendableTask["priority"], number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+/** Neighbouring energy levels to fall back to, in preference order. */
+const ENERGY_FALLBACK: Record<EnergyLevel, EnergyLevel[]> = {
+  low: ["medium"],
+  medium: ["low", "high"],
+  high: ["medium"],
+};
+
+const EXACT_REASON: Record<EnergyLevel, string> = {
+  low: "A gentle fit for low energy — small effort, real progress.",
+  medium: "A steady fit for how you're feeling right now.",
+  high: "You've got momentum — this one is sized for it.",
+};
+
+const FALLBACK_REASON: Record<EnergyLevel, string> = {
+  low: "Close to your current energy — only if it feels right.",
+  medium: "Slightly off your current energy, but very doable.",
+  high: "Not quite max-energy work, but momentum makes it easy.",
+};
+
+function taskEnergy(task: RecommendableTask): EnergyLevel {
+  return task.energy ?? "medium";
+}
+
+/**
+ * Ranking inside an energy bucket: higher priority first, then the task that
+ * has waited longest (oldest updatedAt) — quietly resurfacing stale work
+ * without ever calling it "overdue".
+ */
+function rankCandidates(a: RecommendableTask, b: RecommendableTask): number {
+  const byPriority = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
+  if (byPriority !== 0) {
+    return byPriority;
+  }
+  return a.updatedAt - b.updatedAt;
+}
+
+export function recommendTasksForEnergy(
+  tasks: RecommendableTask[],
+  options: {
+    energy: EnergyLevel;
+    /** Local-day window — tasks already due today are excluded (they're on the plan). */
+    todayStartMs: number;
+    todayEndMs: number;
+    /** Maximum number of recommendations (default 3). */
+    limit?: number;
+    /** Task ids the user dismissed this session ("Not now"); never re-suggested. */
+    dismissedIds?: ReadonlySet<string>;
+  },
+): EnergyRecommendation[] {
+  const limit = options.limit ?? 3;
+  if (limit <= 0) {
+    return [];
+  }
+  const dismissed = options.dismissedIds ?? new Set<string>();
+
+  const candidates = tasks.filter((task) => {
+    if (task.status !== "todo" && task.status !== "in_progress") {
+      return false;
+    }
+    if (dismissed.has(task.id)) {
+      return false;
+    }
+    // Already due today → it is on today's plan; don't recommend it again.
+    if (
+      task.dueAt !== undefined &&
+      task.dueAt >= options.todayStartMs &&
+      task.dueAt < options.todayEndMs
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  const exact = candidates
+    .filter((task) => taskEnergy(task) === options.energy)
+    .toSorted(rankCandidates);
+
+  const picks: EnergyRecommendation[] = exact.slice(0, limit).map((task) => ({
+    task,
+    exactMatch: true,
+    reason: EXACT_REASON[options.energy],
+  }));
+
+  if (picks.length < limit) {
+    for (const fallbackLevel of ENERGY_FALLBACK[options.energy]) {
+      if (picks.length >= limit) {
+        break;
+      }
+      const fallback = candidates
+        .filter((task) => taskEnergy(task) === fallbackLevel)
+        .toSorted(rankCandidates);
+      for (const task of fallback) {
+        if (picks.length >= limit) {
+          break;
+        }
+        picks.push({ task, exactMatch: false, reason: FALLBACK_REASON[options.energy] });
+      }
+    }
+  }
+
+  return picks;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports #323 onto current `integration` (`be70516`). Today gets an energy picker (low / medium / high) that suggests up to three open tasks that are **not** already on today's plan. **Add to Today** stamps `dueAt` via the existing `tasks.update` mutation. **Not now** dismisses locally for the session. Nothing applies without a click (HARD_RULES §1).

## Linked task(s)

Task: T-007c energy recommendations (id from the original #323 title; `docs/brain/TASKS.md` is a private submodule).

Replaces: #323

## Screenshots / screen recording

N/A in this cloud environment — no signed-in Convex session to exercise Today. CI + 13 unit tests cover ranking, window exclusion, dismiss, and shame-free copy.

## Test plan

- [x] Local `bun test apps/web/lib/energyRecommendations.test.ts` — 13 pass / 0 fail
- [ ] CI Typecheck / Lint / Test / Scans / E2E / secrets
- [ ] Manual: pick energy, accept one task, confirm it appears on Today's list; dismiss another and confirm it stays gone for the session

## Acceptance criteria

- Recommendations are computed from existing `tasks.list` + `energy` / `priority` / `dueAt` fields (no schema change).
- Accept uses `tasks.update({ dueAt })`; reject is local dismiss only.
- Empty state is kind (“That's a fine answer — today's list already has you covered.”).
- Low energy never surfaces high-energy work; high never surfaces low.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2).
- [x] AI-originated state changes — N/A (user-picked energy; explicit accept/reject).
- [x] Schema untouched (§5).
- [x] Styling uses existing tokens (`border-border`, `bg-card`, `text-muted-foreground`, `font-heading`).
- [x] Accessibility: fieldset/legend, `aria-pressed`, `aria-label` on actions, focus-visible rings.
- [x] No secrets; no env changes.
- [x] Anti-shame copy; empty state is kind.

## Owner tag (§14)

- [x] `cursor-cloud-2`

## Reviewer

Amit (`human-amit`). Low-risk QUEUE feat (no auth / payments / deletion). Merge once CI is green.

## Notes

- `tasks.list` / `tasks.update` APIs on current `integration` already expose `energy` and `dueAt`.
- `React.ReactNode` in the original was switched to `import type { ReactNode }` for the React 19 JSX runtime.
- Convex is expected in this repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

