### PR TITLE
docs(prompts): align AI call audit with Mistral router

### DIFF
--- a/docs/CURSOR_PROMPTS.md
+++ b/docs/CURSOR_PROMPTS.md
@@ -381,10 +381,11 @@ If found, comment on the PR with the rule violated and the line numbers.
 ### 13.4 AI call audit
 
 ```
-Scan all files touching OpenRouter:
-- Every fetch call to OpenRouter must log to ai_usage.
-- Every fetch call must include the X-Tempo-No-Train header.
-- No provider SDK imports allowed.
+Scan all files touching the Mistral router (`convex/lib/ai_router.ts` and callers):
+- Every LLM call must go through `convex/lib/ai_router.ts` (or approved wrapper).
+- No vendor AI SDK imports (`openai`, `@anthropic-ai/*`, `@google/generative-ai`, `@mistralai/*`).
+- Router uses native fetch against https://api.mistral.ai/v1/chat/completions.
+- AI-originating mutations must flow through the proposals / accept-reject path.
 
 Block merge if violations found.
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#109's unique leftover was a Mistral rewrite of the Cursor prompt AI-call audit. #352 landed the rest of the docs alignment; trunk `docs/CURSOR_PROMPTS.md` still named OpenRouter and `X-Tempo-No-Train`. This ports only that leftover so the audit prompt matches HARD_RULES §6.

## Linked task(s)

Task leftover: PR #109 (original docs alignment against `master`). Private `docs/brain/TASKS.md` is not readable in this cloud clone; no invented T-XXXX ID.

## Screenshots / screen recording

N/A — no user-visible surface.

## Test plan

- [x] Diff is the #109 leftover only (5 insertions / 4 deletions in `docs/CURSOR_PROMPTS.md`)
- [ ] CI typecheck / lint / tests (docs-only; existing suite)
- [x] Confirmed trunk still said OpenRouter before this change
- [x] Other #109 files already covered by #352 — not re-ported

## Acceptance criteria

- Cursor prompt §13.4 names `convex/lib/ai_router.ts` and Mistral `fetch`, not OpenRouter.
- No vendor AI SDK imports allowed, including `@mistralai/*`.
- AI-originating mutations must use the proposals / accept-reject path.
- Original #109 is not closed until this leftover lands.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6) — prompt now requires this
- [x] Schema changes N/A
- [x] Styling N/A
- [x] Accessibility N/A
- [x] No secrets committed
- [x] Voice rules N/A

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`). Docs-only, low-risk; authorized to merge once CI is green.

## Graph / scope notes

`docs/brain/` is a private empty submodule in this clone. Did not invent T-XXXX IDs. Did not close #109 on the label — leftover was still live.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

