### PR TITLE
feat(utils): add config-driven breath pattern cycles

### DIFF
--- a/packages/utils/src/breathwork.ts
+++ b/packages/utils/src/breathwork.ts
@@ -1,0 +1,78 @@
+export type BreathPhase = "inhale" | "hold" | "exhale" | "rest";
+
+export type BreathPatternStep = {
+  phase: BreathPhase;
+  durationMs: number;
+};
+
+export type BreathPatternConfig = {
+  id: string;
+  label: string;
+  steps: BreathPatternStep[];
+};
+
+export type BreathCycleStep = {
+  phase: BreathPhase;
+  startsAtMs: number;
+  endsAtMs: number;
+};
+
+export type BreathCycle = {
+  patternId: string;
+  label: string;
+  totalDurationMs: number;
+  steps: BreathCycleStep[];
+};
+
+function assertValidDuration(durationMs: number): void {
+  if (!Number.isFinite(durationMs) || durationMs <= 0) {
+    throw new Error("Breath pattern step duration must be a positive finite number");
+  }
+}
+
+export function buildBreathCycle(pattern: BreathPatternConfig): BreathCycle {
+  if (pattern.steps.length === 0) {
+    throw new Error("Breath pattern must include at least one step");
+  }
+
+  let cursorMs = 0;
+  const steps = pattern.steps.map((step) => {
+    assertValidDuration(step.durationMs);
+
+    const startsAtMs = cursorMs;
+    const endsAtMs = startsAtMs + step.durationMs;
+    cursorMs = endsAtMs;
+
+    return {
+      phase: step.phase,
+      startsAtMs,
+      endsAtMs,
+    };
+  });
+
+  return {
+    patternId: pattern.id,
+    label: pattern.label,
+    totalDurationMs: cursorMs,
+    steps,
+  };
+}
+
+export function getBreathPhaseAt(pattern: BreathPatternConfig, elapsedMs: number): BreathPhase {
+  const cycle = buildBreathCycle(pattern);
+  const cycleOffsetMs =
+    ((elapsedMs % cycle.totalDurationMs) + cycle.totalDurationMs) % cycle.totalDurationMs;
+
+  for (const step of cycle.steps) {
+    if (cycleOffsetMs >= step.startsAtMs && cycleOffsetMs < step.endsAtMs) {
+      return step.phase;
+    }
+  }
+
+  const firstStep = cycle.steps[0];
+  if (!firstStep) {
+    throw new Error("Breath pattern must include at least one step");
+  }
+
+  return firstStep.phase;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,15 @@
 // @tempo/utils — shared utility exports
 
+export {
+  type BreathCycle,
+  type BreathCycleStep,
+  type BreathPatternConfig,
+  type BreathPatternStep,
+  type BreathPhase,
+  buildBreathCycle,
+  getBreathPhaseAt,
+} from "./breathwork";
+
 /**
  * Format a Unix timestamp (ms) to a locale date string
  */

--- a/tests/unit/breathwork_patterns.test.ts
+++ b/tests/unit/breathwork_patterns.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type BreathPatternConfig,
+	buildBreathCycle,
+	getBreathPhaseAt,
+} from "../../packages/utils/src/breathwork";
+
+const coherence: BreathPatternConfig = {
+	id: "coherence",
+	label: "Coherence breathing",
+	steps: [
+		{ phase: "inhale", durationMs: 5_000 },
+		{ phase: "exhale", durationMs: 5_000 },
+	],
+};
+
+describe("buildBreathCycle", () => {
+	test("plays a newly added coherence pattern from config only", () => {
+		const cycle = buildBreathCycle(coherence);
+
+		expect(cycle.totalDurationMs).toBe(10_000);
+		expect(cycle.steps).toEqual([
+			{ phase: "inhale", startsAtMs: 0, endsAtMs: 5_000 },
+			{ phase: "exhale", startsAtMs: 5_000, endsAtMs: 10_000 },
+		]);
+	});
+
+	test("rejects an empty pattern", () => {
+		expect(() =>
+			buildBreathCycle({
+				id: "empty",
+				label: "Empty",
+				steps: [],
+			}),
+		).toThrow("Breath pattern must include at least one step");
+	});
+
+	test("rejects a non-positive step duration", () => {
+		expect(() =>
+			buildBreathCycle({
+				id: "bad",
+				label: "Bad",
+				steps: [{ phase: "inhale", durationMs: 0 }],
+			}),
+		).toThrow("Breath pattern step duration must be a positive finite number");
+	});
+});
+
+describe("getBreathPhaseAt", () => {
+	test("wraps elapsed time through the configured cycle", () => {
+		expect(getBreathPhaseAt(coherence, 0)).toBe("inhale");
+		expect(getBreathPhaseAt(coherence, 4_999)).toBe("inhale");
+		expect(getBreathPhaseAt(coherence, 5_000)).toBe("exhale");
+		expect(getBreathPhaseAt(coherence, 9_999)).toBe("exhale");
+		expect(getBreathPhaseAt(coherence, 10_000)).toBe("inhale");
+		expect(getBreathPhaseAt(coherence, -1)).toBe("exhale");
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#191's unique leftover was a `packages/utils` breath-pattern helper. #354 landed a discrete cue timer on mobile (`advancePhase` + audio/haptic). This ports the complementary config-driven cycle: `buildBreathCycle` and `getBreathPhaseAt` so a new pattern is data, not another controller.

## Linked task(s)

Task leftover: PR #191. Private `docs/brain/TASKS.md` is not readable in this cloud clone; no invented T-XXXX ID.

## Screenshots / screen recording

N/A — no user-visible surface. Mobile still uses the #354 timer.

## Test plan

- [x] `bun test tests/unit/breathwork_patterns.test.ts` — 4 pass
- [x] Coherence pattern from config only (original #191 assertion)
- [x] Empty pattern and non-positive duration throw
- [x] Elapsed wrap including negative offset
- [x] Test file is under `tests/unit` so root `bun test` runs it (original #191 put the test inside `packages/utils`, which CI does not collect)
- [ ] CI typecheck / lint / tests

## Acceptance criteria

- `@tempo/utils` exports `buildBreathCycle` and `getBreathPhaseAt`.
- A new pattern (coherence 5/5) works from config without editing the mobile controller.
- #354 mobile timer is unchanged.
- Original #191 is not closed until this leftover lands.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI accept-reject N/A
- [x] Schema N/A
- [x] Styling N/A
- [x] Accessibility N/A
- [x] No secrets committed
- [x] Voice rules N/A (no user-facing copy)

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`). Low-risk utils + unit tests; authorized to merge once CI is green.

## Graph / scope notes

Did not port #189/#183 (they would overwrite the landed #354 timer + e2e/lockfile). Did not invent T-XXXX IDs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

