### PR TITLE
test(convex): extract habit streak math and cover the AI router

### DIFF
--- a/convex/habits.ts
+++ b/convex/habits.ts
@@ -1,104 +1,105 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
+import { computeHabitStreakUpdate } from "./lib/habitStreak";
 import { requireUser } from "./lib/requireUser";
 
 export const list = query({
-  args: {},
-  handler: async (ctx) => {
-    const user = await requireUser(ctx);
-    const rows = await ctx.db
-      .query("habits")
-      .withIndex("by_userId", (q) => q.eq("userId", user._id))
-      .collect();
-    rows.sort((a, b) => b.updatedAt - a.updatedAt);
-    return rows;
-  },
+	args: {},
+	handler: async (ctx) => {
+		const user = await requireUser(ctx);
+		const rows = await ctx.db
+			.query("habits")
+			.withIndex("by_userId", (q) => q.eq("userId", user._id))
+			.collect();
+		rows.sort((a, b) => b.updatedAt - a.updatedAt);
+		return rows;
+	},
 });
 
 export const create = mutation({
-  args: {
-    name: v.string(),
-    cadence: v.union(v.literal("daily"), v.literal("weekly")),
-  },
-  handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
-    const now = Date.now();
-    return ctx.db.insert("habits", {
-      userId: user._id,
-      name: args.name.trim(),
-      cadence: args.cadence,
-      currentStreak: 0,
-      longestStreak: 0,
-      createdAt: now,
-      updatedAt: now,
-    });
-  },
+	args: {
+		name: v.string(),
+		cadence: v.union(v.literal("daily"), v.literal("weekly")),
+	},
+	handler: async (ctx, args) => {
+		const user = await requireUser(ctx);
+		const now = Date.now();
+		return ctx.db.insert("habits", {
+			userId: user._id,
+			name: args.name.trim(),
+			cadence: args.cadence,
+			currentStreak: 0,
+			longestStreak: 0,
+			createdAt: now,
+			updatedAt: now,
+		});
+	},
 });
 
 export const completeToday = mutation({
-  args: { habitId: v.id("habits") },
-  handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
-    const habit = await ctx.db.get(args.habitId);
-    if (!habit || habit.userId !== user._id) {
-      throw new Error("Habit not found");
-    }
-    const now = Date.now();
-    const dayMs = 24 * 60 * 60 * 1000;
-    let current = habit.currentStreak;
-    if (habit.lastCompletedAt !== undefined) {
-      const daysSince = Math.floor((now - habit.lastCompletedAt) / dayMs);
-      if (daysSince === 0) {
-        return { currentStreak: habit.currentStreak, alreadyDone: true as const };
-      }
-      if (daysSince === 1) {
-        current += 1;
-      } else {
-        current = 1;
-      }
-    } else {
-      current = 1;
-    }
-    const longest = Math.max(habit.longestStreak, current);
-    await ctx.db.patch(args.habitId, {
-      currentStreak: current,
-      longestStreak: longest,
-      lastCompletedAt: now,
-      updatedAt: now,
-    });
-    return { currentStreak: current, longestStreak: longest, alreadyDone: false as const };
-  },
+	args: { habitId: v.id("habits") },
+	handler: async (ctx, args) => {
+		const user = await requireUser(ctx);
+		const habit = await ctx.db.get(args.habitId);
+		if (!habit || habit.userId !== user._id) {
+			throw new Error("Habit not found");
+		}
+		const now = Date.now();
+		const update = computeHabitStreakUpdate(
+			now,
+			habit.lastCompletedAt,
+			habit.currentStreak,
+			habit.longestStreak,
+		);
+		if (update.alreadyDone) {
+			return {
+				currentStreak: update.currentStreak,
+				alreadyDone: true as const,
+			};
+		}
+		await ctx.db.patch(args.habitId, {
+			currentStreak: update.currentStreak,
+			longestStreak: update.longestStreak,
+			lastCompletedAt: now,
+			updatedAt: now,
+		});
+		return {
+			currentStreak: update.currentStreak,
+			longestStreak: update.longestStreak,
+			alreadyDone: false as const,
+		};
+	},
 });
 
 export const update = mutation({
-  args: {
-    habitId: v.id("habits"),
-    name: v.optional(v.string()),
-    cadence: v.optional(v.union(v.literal("daily"), v.literal("weekly"))),
-  },
-  handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
-    const habit = await ctx.db.get(args.habitId);
-    if (!habit || habit.userId !== user._id) {
-      throw new Error("Habit not found");
-    }
-    const patch: Record<string, unknown> = { updatedAt: Date.now() };
-    if (args.name !== undefined) patch.name = args.name.trim();
-    if (args.cadence !== undefined) patch.cadence = args.cadence;
-    await ctx.db.patch(args.habitId, patch as typeof habit);
-    return args.habitId;
-  },
+	args: {
+		habitId: v.id("habits"),
+		name: v.optional(v.string()),
+		cadence: v.optional(v.union(v.literal("daily"), v.literal("weekly"))),
+	},
+	handler: async (ctx, args) => {
+		const user = await requireUser(ctx);
+		const habit = await ctx.db.get(args.habitId);
+		if (!habit || habit.userId !== user._id) {
+			throw new Error("Habit not found");
+		}
+		const patch: Record<string, unknown> = { updatedAt: Date.now() };
+		if (args.name !== undefined) patch.name = args.name.trim();
+		if (args.cadence !== undefined) patch.cadence = args.cadence;
+		await ctx.db.patch(args.habitId, patch as typeof habit);
+		return args.habitId;
+	},
 });
 
 export const remove = mutation({
-  args: { habitId: v.id("habits") },
-  handler: async (ctx, args) => {
-    const user = await requireUser(ctx);
-    const habit = await ctx.db.get(args.habitId);
-    if (!habit || habit.userId !== user._id) {
-      throw new Error("Habit not found");
-    }
-    await ctx.db.delete(args.habitId);
-    return { success: true };
-  },
+	args: { habitId: v.id("habits") },
+	handler: async (ctx, args) => {
+		const user = await requireUser(ctx);
+		const habit = await ctx.db.get(args.habitId);
+		if (!habit || habit.userId !== user._id) {
+			throw new Error("Habit not found");
+		}
+		await ctx.db.delete(args.habitId);
+		return { success: true };
+	},
 });

--- a/convex/lib/ai_router.test.ts
+++ b/convex/lib/ai_router.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	AiAuthError,
+	AiContextTooLargeError,
+	AiRateLimitedError,
+	AiUpstreamError,
+} from "./ai_errors";
+import { callLLM, TIER_MODEL } from "./ai_router";
+
+const originalFetch = globalThis.fetch;
+const originalApiKey = process.env.MISTRAL_API_KEY;
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+		...init,
+	});
+}
+
+function errorResponse(
+	status: number,
+	body: string,
+	headers?: HeadersInit,
+): Response {
+	return new Response(body, { status, headers });
+}
+
+function successBody(content = "ok") {
+	return {
+		choices: [{ message: { content } }],
+		usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+	};
+}
+
+beforeEach(() => {
+	process.env.MISTRAL_API_KEY = "test-key";
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	if (originalApiKey === undefined) {
+		delete process.env.MISTRAL_API_KEY;
+	} else {
+		process.env.MISTRAL_API_KEY = originalApiKey;
+	}
+});
+
+describe("callLLM", () => {
+	test("throws AiAuthError when MISTRAL_API_KEY is missing", async () => {
+		delete process.env.MISTRAL_API_KEY;
+		await expect(
+			callLLM({ tier: "fast", messages: [{ role: "user", content: "hi" }] }),
+		).rejects.toBeInstanceOf(AiAuthError);
+	});
+
+	test("returns parsed content on success", async () => {
+		globalThis.fetch = mock(() =>
+			Promise.resolve(jsonResponse(successBody('{"plan":true}'))),
+		);
+
+		const result = await callLLM({
+			tier: "fast",
+			messages: [{ role: "user", content: "hi" }],
+			responseFormat: "json_object",
+		});
+
+		expect(result.content).toBe('{"plan":true}');
+		expect(result.tier).toBe("fast");
+		expect(result.model).toBe(TIER_MODEL.fast);
+		expect(result.escalated).toBe(false);
+		expect(result.usage.totalTokens).toBe(15);
+	});
+
+	test("throws AiAuthError on HTTP 401 without retrying", async () => {
+		const fetchMock = mock(() =>
+			Promise.resolve(errorResponse(401, "bad key")),
+		);
+		globalThis.fetch = fetchMock;
+
+		await expect(
+			callLLM({ tier: "fast", messages: [{ role: "user", content: "hi" }] }),
+		).rejects.toBeInstanceOf(AiAuthError);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("retries once on HTTP 429 then succeeds", async () => {
+		const fetchMock = mock(() =>
+			Promise.resolve(errorResponse(429, "slow down", { "Retry-After": "1" })),
+		)
+			.mockImplementationOnce(() =>
+				Promise.resolve(
+					errorResponse(429, "slow down", { "Retry-After": "1" }),
+				),
+			)
+			.mockImplementationOnce(() =>
+				Promise.resolve(jsonResponse(successBody("done"))),
+			);
+
+		globalThis.fetch = fetchMock;
+
+		const result = await callLLM({
+			tier: "balanced",
+			messages: [{ role: "user", content: "hi" }],
+		});
+
+		expect(result.content).toBe("done");
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test("throws AiRateLimitedError after two 429 responses", async () => {
+		const fetchMock = mock(() =>
+			Promise.resolve(errorResponse(429, "slow down")),
+		);
+		globalThis.fetch = fetchMock;
+
+		await expect(
+			callLLM({ tier: "fast", messages: [{ role: "user", content: "hi" }] }),
+		).rejects.toBeInstanceOf(AiRateLimitedError);
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test("escalates to balanced tier when fast tier hits context limit", async () => {
+		const fetchMock = mock(
+			(_url: string | URL | Request, init?: RequestInit) => {
+				const body = JSON.parse(String(init?.body)) as { model: string };
+				if (body.model === TIER_MODEL.fast) {
+					return Promise.resolve(
+						errorResponse(
+							400,
+							JSON.stringify({ error: "context_length_exceeded" }),
+						),
+					);
+				}
+				return Promise.resolve(jsonResponse(successBody("escalated")));
+			},
+		);
+		globalThis.fetch = fetchMock;
+
+		const result = await callLLM({
+			tier: "fast",
+			messages: [{ role: "user", content: "big" }],
+		});
+
+		expect(result.content).toBe("escalated");
+		expect(result.tier).toBe("balanced");
+		expect(result.escalated).toBe(true);
+	});
+
+	test("throws AiContextTooLargeError when deep tier still exceeds context", async () => {
+		globalThis.fetch = mock(() =>
+			Promise.resolve(
+				errorResponse(400, "maximum context length exceeded for this model"),
+			),
+		);
+
+		await expect(
+			callLLM({ tier: "deep", messages: [{ role: "user", content: "huge" }] }),
+		).rejects.toBeInstanceOf(AiContextTooLargeError);
+	});
+
+	test("retries once on HTTP 503 then surfaces AiUpstreamError", async () => {
+		const fetchMock = mock(() =>
+			Promise.resolve(errorResponse(503, "unavailable")),
+		);
+		globalThis.fetch = fetchMock;
+
+		await expect(
+			callLLM({ tier: "fast", messages: [{ role: "user", content: "hi" }] }),
+		).rejects.toBeInstanceOf(AiUpstreamError);
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+});

--- a/convex/lib/habitStreak.test.ts
+++ b/convex/lib/habitStreak.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { computeHabitStreakUpdate } from "./habitStreak";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("computeHabitStreakUpdate", () => {
+	test("first completion starts streak at 1", () => {
+		const now = 1_700_000_000_000;
+		const result = computeHabitStreakUpdate(now, undefined, 0, 0);
+		expect(result.alreadyDone).toBe(false);
+		if (!result.alreadyDone) {
+			expect(result.currentStreak).toBe(1);
+			expect(result.longestStreak).toBe(1);
+		}
+	});
+
+	test("same UTC day returns alreadyDone without incrementing", () => {
+		const last = 1_700_000_000_000;
+		const now = last + 6 * 60 * 60 * 1000;
+		const result = computeHabitStreakUpdate(now, last, 3, 5);
+		expect(result.alreadyDone).toBe(true);
+		if (result.alreadyDone) {
+			expect(result.currentStreak).toBe(3);
+		}
+	});
+
+	test("exactly one day later increments streak", () => {
+		const last = 1_700_000_000_000;
+		const now = last + DAY_MS;
+		const result = computeHabitStreakUpdate(now, last, 4, 4);
+		expect(result.alreadyDone).toBe(false);
+		if (!result.alreadyDone) {
+			expect(result.currentStreak).toBe(5);
+			expect(result.longestStreak).toBe(5);
+		}
+	});
+
+	test("two or more days gap resets streak to 1", () => {
+		const last = 1_700_000_000_000;
+		const now = last + 2 * DAY_MS;
+		const result = computeHabitStreakUpdate(now, last, 10, 10);
+		expect(result.alreadyDone).toBe(false);
+		if (!result.alreadyDone) {
+			expect(result.currentStreak).toBe(1);
+			expect(result.longestStreak).toBe(10);
+		}
+	});
+
+	test("longest streak only increases when current exceeds prior best", () => {
+		const last = 1_700_000_000_000;
+		const now = last + DAY_MS;
+		const result = computeHabitStreakUpdate(now, last, 2, 7);
+		expect(result.alreadyDone).toBe(false);
+		if (!result.alreadyDone) {
+			expect(result.currentStreak).toBe(3);
+			expect(result.longestStreak).toBe(7);
+		}
+	});
+});

--- a/convex/lib/habitStreak.ts
+++ b/convex/lib/habitStreak.ts
@@ -1,0 +1,36 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type HabitStreakUpdate =
+	| { alreadyDone: true; currentStreak: number }
+	| { alreadyDone: false; currentStreak: number; longestStreak: number };
+
+/**
+ * Pure streak math for `habits.completeToday`. Exported for unit tests.
+ * Uses UTC day boundaries (floor of elapsed ms / DAY_MS).
+ */
+export function computeHabitStreakUpdate(
+	now: number,
+	lastCompletedAt: number | undefined,
+	currentStreak: number,
+	longestStreak: number,
+): HabitStreakUpdate {
+	let current = currentStreak;
+	if (lastCompletedAt !== undefined) {
+		const daysSince = Math.floor((now - lastCompletedAt) / DAY_MS);
+		if (daysSince === 0) {
+			return { currentStreak: currentStreak, alreadyDone: true };
+		}
+		if (daysSince === 1) {
+			current += 1;
+		} else {
+			current = 1;
+		}
+	} else {
+		current = 1;
+	}
+	return {
+		currentStreak: current,
+		longestStreak: Math.max(longestStreak, current),
+		alreadyDone: false,
+	};
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#114's unique leftover after #353 was habit-streak extraction plus `callLLM` regression tests. RevenueCat mapping and Today due-range from that PR already landed as `revenuecat_events` / `task_filters`. This ports only the leftover: a pure `computeHabitStreakUpdate` helper wired into `habits.completeToday`, and mocked `callLLM` tests against the current Mistral router.

## Linked task(s)

Task leftover: PR #114. Private `docs/brain/TASKS.md` is not readable in this cloud clone; no invented T-XXXX ID.

## Screenshots / screen recording

N/A — no user-visible surface.

## Test plan

- [x] `bun test convex/lib/habitStreak.test.ts convex/lib/ai_router.test.ts` — 13 pass
- [x] Streak: first day, same day, +1 day, gap reset, longest preserved
- [x] Router: missing key, success, 401 no-retry, 429 retry, context escalate, 503 retry-then-surface
- [x] Did not port `convex/revenuecat.ts` or duplicate RevenueCat/taskDueRange helpers
- [ ] CI typecheck / lint / tests

## Acceptance criteria

- Habit streak math is unit-tested without Convex.
- `completeToday` uses the helper; same-day / next-day / gap behavior unchanged.
- `callLLM` retry and escalate paths have tests against current `ai_router.ts`.
- No RevenueCat / payment files in this PR.
- Original #114 is not closed until this leftover lands.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI accept-reject N/A (router coverage only; no new mutation path)
- [x] Schema N/A
- [x] Styling N/A
- [x] Accessibility N/A
- [x] No secrets committed (`MISTRAL_API_KEY=test-key` is a mock)
- [x] Voice rules N/A

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`). Low-risk extract + tests; authorized to merge once CI is green.

## Graph / scope notes

Skipped #114 `revenueCatEvents` / `taskDueRange` / `revenuecat.ts` / `tasks.ts`. Did not invent T-XXXX IDs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

