### PR TITLE
test(auth): share subject-then-email user resolution — DO NOT MERGE

### DIFF
--- a/convex/lib/requireUser.test.ts
+++ b/convex/lib/requireUser.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import type { QueryCtx } from "../_generated/server";
+import { fetchCurrentUser } from "../users";
+import { requireUser } from "./requireUser";
+
+type FakeIdentity = {
+	subject: string;
+	email?: string;
+};
+
+type FakeUser = {
+	_id: string;
+	email: string;
+	deletedAt?: number;
+	isActive?: boolean;
+};
+
+function makeCtx({
+	identity,
+	users,
+}: {
+	identity: FakeIdentity | null;
+	users: FakeUser[];
+}) {
+	const byId = new Map(users.map((user) => [user._id, user]));
+	const byEmail = new Map(users.map((user) => [user.email, user]));
+
+	return {
+		auth: {
+			getUserIdentity: async () => identity,
+		},
+		db: {
+			normalizeId: (_table: "users", id: string) => (byId.has(id) ? id : null),
+			get: async (id: string) => byId.get(id) ?? null,
+			query: (_table: "users") => ({
+				withIndex: (
+					_indexName: "by_email",
+					buildQuery: (q: {
+						eq: (_field: "email", value: string) => string;
+					}) => string,
+				) => {
+					const email = buildQuery({
+						eq: (_field, value) => value,
+					});
+					return {
+						unique: async () => byEmail.get(email) ?? null,
+					};
+				},
+			}),
+		},
+	} as unknown as QueryCtx;
+}
+
+describe("auth user resolution", () => {
+	test("requireUser resolves a user from any normalized auth subject part without email", async () => {
+		const user = { _id: "users:found", email: "alex@example.com" };
+		const ctx = makeCtx({
+			identity: { subject: "auth-account|invalid-user-id|users:found" },
+			users: [user],
+		});
+
+		await expect(requireUser(ctx)).resolves.toMatchObject(user);
+	});
+
+	test("requireUser falls back to email when subject parts do not resolve", async () => {
+		const user = { _id: "users:email", email: "alex@example.com" };
+		const ctx = makeCtx({
+			identity: {
+				subject: "auth-account|missing-user",
+				email: "alex@example.com",
+			},
+			users: [user],
+		});
+
+		await expect(requireUser(ctx)).resolves.toMatchObject(user);
+	});
+
+	test("requireUser throws when no authenticated identity is available", async () => {
+		const ctx = makeCtx({ identity: null, users: [] });
+
+		await expect(requireUser(ctx)).rejects.toThrow("Not authenticated");
+	});
+
+	test("requireUser throws not authenticated when identity has no email and no matching subject user", async () => {
+		const ctx = makeCtx({
+			identity: { subject: "auth-account|missing-user" },
+			users: [],
+		});
+
+		await expect(requireUser(ctx)).rejects.toThrow("Not authenticated");
+	});
+
+	test("requireUser throws User not found when email does not match an app user", async () => {
+		const ctx = makeCtx({
+			identity: {
+				subject: "auth-account|missing-user",
+				email: "missing@example.com",
+			},
+			users: [],
+		});
+
+		await expect(requireUser(ctx)).rejects.toThrow("User not found");
+	});
+
+	test("requireUser rejects a soft-deleted account", async () => {
+		const user = {
+			_id: "users:gone",
+			email: "gone@example.com",
+			deletedAt: 1,
+			isActive: false,
+		};
+		const ctx = makeCtx({
+			identity: { subject: "auth-account|users:gone" },
+			users: [user],
+		});
+
+		await expect(requireUser(ctx)).rejects.toThrow(
+			"This account is not active",
+		);
+	});
+
+	test("fetchCurrentUser uses the same subject resolver as mutations and does not require email", async () => {
+		const user = { _id: "users:found", email: "alex@example.com" };
+		const ctx = makeCtx({
+			identity: { subject: "auth-account|invalid-user-id|users:found" },
+			users: [user],
+		});
+
+		await expect(fetchCurrentUser(ctx)).resolves.toMatchObject(user);
+	});
+
+	test("fetchCurrentUser returns null instead of throwing when identity is missing", async () => {
+		const ctx = makeCtx({ identity: null, users: [] });
+
+		await expect(fetchCurrentUser(ctx)).resolves.toBeNull();
+	});
+
+	test("fetchCurrentUser returns null when subject and email do not match an app user", async () => {
+		const ctx = makeCtx({
+			identity: {
+				subject: "auth-account|missing-user",
+				email: "missing@example.com",
+			},
+			users: [],
+		});
+
+		await expect(fetchCurrentUser(ctx)).resolves.toBeNull();
+	});
+
+	test("fetchCurrentUser returns null for a soft-deleted account", async () => {
+		const user = {
+			_id: "users:gone",
+			email: "gone@example.com",
+			deletedAt: 1,
+			isActive: false,
+		};
+		const ctx = makeCtx({
+			identity: { subject: "auth-account|users:gone" },
+			users: [user],
+		});
+
+		await expect(fetchCurrentUser(ctx)).resolves.toBeNull();
+	});
+});

--- a/convex/lib/requireUser.ts
+++ b/convex/lib/requireUser.ts
@@ -2,57 +2,68 @@ import type { Doc } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
 import { isInactiveAccount } from "./accountDeletion";
 
+type AuthIdentity = {
+	subject: string;
+	email?: string | null;
+};
+
 /**
  * Resolve the authenticated app user (users table row) from Convex Auth identity.
  */
 async function resolveUserFromSubject(
-  ctx: QueryCtx | MutationCtx,
-  subject: string,
+	ctx: QueryCtx | MutationCtx,
+	subject: string,
 ): Promise<Doc<"users"> | null> {
-  for (const part of subject.split("|")) {
-    const normalizedId = ctx.db.normalizeId("users", part);
-    if (!normalizedId) {
-      continue;
-    }
-    const user = await ctx.db.get(normalizedId);
-    if (user) {
-      return user;
-    }
-  }
-  return null;
+	for (const part of subject.split("|")) {
+		const normalizedId = ctx.db.normalizeId("users", part);
+		if (!normalizedId) {
+			continue;
+		}
+		const user = await ctx.db.get(normalizedId);
+		if (user) {
+			return user;
+		}
+	}
+	return null;
+}
+
+/** Shared subject-then-email lookup. Does not apply inactive-account policy. */
+export async function resolveUserFromIdentity(
+	ctx: QueryCtx | MutationCtx,
+	identity: AuthIdentity,
+): Promise<Doc<"users"> | null> {
+	const subjectUser = await resolveUserFromSubject(ctx, identity.subject);
+	if (subjectUser) {
+		return subjectUser;
+	}
+
+	const email = identity.email;
+	if (!email) {
+		return null;
+	}
+
+	return ctx.db
+		.query("users")
+		.withIndex("by_email", (q) => q.eq("email", email))
+		.unique();
 }
 
 export async function requireUser(ctx: QueryCtx | MutationCtx) {
-  const identity = await ctx.auth.getUserIdentity();
-  if (!identity) {
-    throw new Error("Not authenticated");
-  }
+	const identity = await ctx.auth.getUserIdentity();
+	if (!identity) {
+		throw new Error("Not authenticated");
+	}
 
-  const subjectUser = await resolveUserFromSubject(ctx, identity.subject);
-  if (subjectUser) {
-    if (isInactiveAccount(subjectUser)) {
-      throw new Error("This account is not active");
-    }
-    return subjectUser;
-  }
+	const user = await resolveUserFromIdentity(ctx, identity);
+	if (!user && !identity.email) {
+		throw new Error("Not authenticated");
+	}
+	if (!user) {
+		throw new Error("User not found");
+	}
+	if (isInactiveAccount(user)) {
+		throw new Error("This account is not active");
+	}
 
-  const email = identity.email;
-  if (!email) {
-    throw new Error("Not authenticated");
-  }
-
-  const user = await ctx.db
-    .query("users")
-    .withIndex("by_email", (q) => q.eq("email", email))
-    .unique();
-
-  if (!user) {
-    throw new Error("User not found");
-  }
-
-  if (isInactiveAccount(user)) {
-    throw new Error("This account is not active");
-  }
-
-  return user;
+	return user;
 }

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -2,91 +2,74 @@ import { v } from "convex/values";
 import type { Doc } from "./_generated/dataModel";
 import type { QueryCtx } from "./_generated/server";
 import { internalMutation, mutation, query } from "./_generated/server";
-import { isInactiveAccount, softDeleteUserAccount } from "./lib/accountDeletion";
+import {
+	isInactiveAccount,
+	softDeleteUserAccount,
+} from "./lib/accountDeletion";
 import { buildReturningUserPatch, newUserFields } from "./lib/entitlements";
-import { requireUser } from "./lib/requireUser";
+import { requireUser, resolveUserFromIdentity } from "./lib/requireUser";
 import { assertClientMaySetUserType } from "./lib/subscriptionGuards";
 
 /** Shared resolver for the authenticated app user document. */
-export async function fetchCurrentUser(ctx: QueryCtx): Promise<Doc<"users"> | null> {
-  const identity = await ctx.auth.getUserIdentity();
-  if (!identity) {
-    return null;
-  }
+export async function fetchCurrentUser(
+	ctx: QueryCtx,
+): Promise<Doc<"users"> | null> {
+	const identity = await ctx.auth.getUserIdentity();
+	if (!identity) {
+		return null;
+	}
 
-  // In Convex Auth the subject is: authAccountId|userId
-  const subjectParts = identity.subject.split("|");
-  if (subjectParts.length >= 2) {
-    const userId = subjectParts[1] as import("./_generated/dataModel").Id<"users">;
-    try {
-      const user = await ctx.db.get(userId);
-      if (user) {
-        if (isInactiveAccount(user)) return null;
-        return user;
-      }
-    } catch {
-      // invalid ID, fall through to email lookup
-    }
-  }
-
-  if (identity.email) {
-    const user = await ctx.db
-      .query("users")
-      .withIndex("by_email", (q) => q.eq("email", identity.email ?? ""))
-      .unique();
-    if (user) {
-      if (isInactiveAccount(user)) return null;
-      return user;
-    }
-  }
-
-  return null;
+	const user = await resolveUserFromIdentity(ctx, identity);
+	if (!user || isInactiveAccount(user)) {
+		return null;
+	}
+	return user;
 }
 
 export const getCurrentUser = query({
-  args: {},
-  handler: async (ctx) => fetchCurrentUser(ctx),
+	args: {},
+	handler: async (ctx) => fetchCurrentUser(ctx),
 });
 
 /** Profile for dashboard greeting and header; extends user with `greetingName`. */
 export const getProfile = query({
-  args: {},
-  handler: async (ctx) => {
-    const user = await fetchCurrentUser(ctx);
-    if (!user) return null;
-    const greetingName =
-      user.fullName?.trim() || user.email?.split("@")[0] || "there";
-    return {
-      ...user,
-      greetingName,
-    };
-  },
+	args: {},
+	handler: async (ctx) => {
+		const user = await fetchCurrentUser(ctx);
+		if (!user) return null;
+		const greetingName =
+			user.fullName?.trim() || user.email?.split("@")[0] || "there";
+		return {
+			...user,
+			greetingName,
+		};
+	},
 });
 
 export const getById = query({
-  args: { userId: v.id("users") },
-  handler: async (ctx, { userId }) => {
-    const currentUser = await requireUser(ctx);
-    if (currentUser._id !== userId && currentUser.role !== "admin") {
-      throw new Error("Access denied");
-    }
-    return ctx.db.get(userId);
-  },
+	args: { userId: v.id("users") },
+	handler: async (ctx, { userId }) => {
+		const currentUser = await requireUser(ctx);
+		if (currentUser._id !== userId && currentUser.role !== "admin") {
+			throw new Error("Access denied");
+		}
+		return ctx.db.get(userId);
+	},
 });
 
 export const listActive = query({
-  args: {},
-  handler: async (ctx) => {
-    const currentUser = await requireUser(ctx);
-    if (currentUser.role !== "admin") {
-      throw new Error("Access denied");
-    }
-    const rows = await ctx.db
-      .query("users")
-      .withIndex("by_deletedAt", (q) => q.eq("deletedAt", undefined))
-      .collect();
-    return rows.filter((user) => user.isActive !== false);
-  },
+	args: {},
+	handler: async (ctx) => {
+		const currentUser = await requireUser(ctx);
+		if (currentUser.role !== "admin") {
+			throw new Error("Access denied");
+		}
+		const rows = await ctx.db
+			.query("users")
+			.withIndex("by_deletedAt", (q) => q.eq("deletedAt", undefined))
+			.collect();
+		return rows.filter((user) => user.isActive !== false);
+	},
 });
 
 /**
@@ -101,67 +84,67 @@ export const listActive = query({
  * again.
  */
 export const createOrUpdateUser = mutation({
-  args: {},
-  handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
+	args: {},
+	handler: async (ctx) => {
+		const identity = await ctx.auth.getUserIdentity();
+		if (!identity) throw new Error("Not authenticated");
 
-    const email = identity.email ?? "";
-    const now = Date.now();
+		const email = identity.email ?? "";
+		const now = Date.now();
 
-    const profile = {
-      email,
-      emailVerified: identity.emailVerified ?? false,
-      fullName: identity.name || identity.nickname || "User",
-    };
+		const profile = {
+			email,
+			emailVerified: identity.emailVerified ?? false,
+			fullName: identity.name || identity.nickname || "User",
+		};
 
-    const existing = await ctx.db
-      .query("users")
-      .withIndex("by_email", (q) => q.eq("email", email))
-      .unique();
+		const existing = await ctx.db
+			.query("users")
+			.withIndex("by_email", (q) => q.eq("email", email))
+			.unique();
 
-    if (existing) {
-      // Identity fields plus self-heal only. This path must never write
-      // `role`, and must never write `userType` unconditionally - that was
-      // the downgrade.
-      await ctx.db.patch(existing._id, {
-        ...buildReturningUserPatch(existing, profile, now),
-        ...(isInactiveAccount(existing)
-          ? { deletedAt: undefined, isActive: true }
-          : {}),
-      });
-      return existing._id;
-    }
+		if (existing) {
+			// Identity fields plus self-heal only. This path must never write
+			// `role`, and must never write `userType` unconditionally - that was
+			// the downgrade.
+			await ctx.db.patch(existing._id, {
+				...buildReturningUserPatch(existing, profile, now),
+				...(isInactiveAccount(existing)
+					? { deletedAt: undefined, isActive: true }
+					: {}),
+			});
+			return existing._id;
+		}
 
-    return ctx.db.insert("users", newUserFields(profile, now));
-  },
+		return ctx.db.insert("users", newUserFields(profile, now));
+	},
 });
 
 export const updateProfile = mutation({
-  args: {
-    userId: v.id("users"),
-    fullName: v.optional(v.string()),
-  },
-  handler: async (ctx, { userId, fullName }) => {
-    const currentUser = await requireUser(ctx);
-    if (currentUser._id !== userId && currentUser.role !== "admin") {
-      throw new Error("Access denied");
-    }
-    await ctx.db.patch(userId, { fullName, updatedAt: Date.now() });
-    return userId;
-  },
+	args: {
+		userId: v.id("users"),
+		fullName: v.optional(v.string()),
+	},
+	handler: async (ctx, { userId, fullName }) => {
+		const currentUser = await requireUser(ctx);
+		if (currentUser._id !== userId && currentUser.role !== "admin") {
+			throw new Error("Access denied");
+		}
+		await ctx.db.patch(userId, { fullName, updatedAt: Date.now() });
+		return userId;
+	},
 });
 
 export const updateUserType = mutation({
-  args: {
-    userType: v.union(v.literal("free"), v.literal("paid")),
-  },
-  handler: async (ctx, { userType }) => {
-    assertClientMaySetUserType(userType);
-    const user = await requireUser(ctx);
-    await ctx.db.patch(user._id, { userType, updatedAt: Date.now() });
-    return user._id;
-  },
+	args: {
+		userType: v.union(v.literal("free"), v.literal("paid")),
+	},
+	handler: async (ctx, { userType }) => {
+		assertClientMaySetUserType(userType);
+		const user = await requireUser(ctx);
+		await ctx.db.patch(user._id, { userType, updatedAt: Date.now() });
+		return user._id;
+	},
 });
 
 /**
@@ -169,54 +152,64 @@ export const updateUserType = mutation({
  * Uses appUserId (RevenueCat user ID = Convex user email or subject) to find and update the user.
  */
 export const updateSubscriptionStatus = internalMutation({
-  args: {
-    userId: v.string(),
-    userType: v.union(v.literal("free"), v.literal("paid")),
-    activeEntitlements: v.array(v.string()),
-    revenueCatEvent: v.string(),
-  },
-  handler: async (ctx, { userId, userType, activeEntitlements: _entitlements, revenueCatEvent: _event }) => {
-    // Try to find user by email (RevenueCat appUserId is typically the user's email)
-    let user = await ctx.db
-      .query("users")
-      .withIndex("by_email", (q) => q.eq("email", userId))
-      .unique();
+	args: {
+		userId: v.string(),
+		userType: v.union(v.literal("free"), v.literal("paid")),
+		activeEntitlements: v.array(v.string()),
+		revenueCatEvent: v.string(),
+	},
+	handler: async (
+		ctx,
+		{
+			userId,
+			userType,
+			activeEntitlements: _entitlements,
+			revenueCatEvent: _event,
+		},
+	) => {
+		// Try to find user by email (RevenueCat appUserId is typically the user's email)
+		let user = await ctx.db
+			.query("users")
+			.withIndex("by_email", (q) => q.eq("email", userId))
+			.unique();
 
-    // Fallback: try to find by ID if userId looks like a Convex ID
-    if (!user) {
-      try {
-        user = await ctx.db.get(userId as import("./_generated/dataModel").Id<"users">);
-      } catch {
-        // Not a valid Convex ID — user not found
-      }
-    }
+		// Fallback: try to find by ID if userId looks like a Convex ID
+		if (!user) {
+			try {
+				user = await ctx.db.get(
+					userId as import("./_generated/dataModel").Id<"users">,
+				);
+			} catch {
+				// Not a valid Convex ID — user not found
+			}
+		}
 
-    if (!user) {
-      console.warn(`[RevenueCat] User not found for appUserId: ${userId}`);
-      return { updated: false };
-    }
+		if (!user) {
+			console.warn(`[RevenueCat] User not found for appUserId: ${userId}`);
+			return { updated: false };
+		}
 
-    await ctx.db.patch(user._id, { userType, updatedAt: Date.now() });
-    return { updated: true, userId: user._id };
-  },
+		await ctx.db.patch(user._id, { userType, updatedAt: Date.now() });
+		return { updated: true, userId: user._id };
+	},
 });
 
 export const remove = mutation({
-  args: { userId: v.id("users") },
-  handler: async (ctx, { userId }) => {
-    const currentUser = await requireUser(ctx);
-    if (currentUser._id !== userId && currentUser.role !== "admin") {
-      throw new Error("Access denied");
-    }
-    await ctx.db.delete(userId);
-  },
+	args: { userId: v.id("users") },
+	handler: async (ctx, { userId }) => {
+		const currentUser = await requireUser(ctx);
+		if (currentUser._id !== userId && currentUser.role !== "admin") {
+			throw new Error("Access denied");
+		}
+		await ctx.db.delete(userId);
+	},
 });
 
 export const deleteMyAccount = mutation({
-  args: {},
-  handler: async (ctx) => {
-    const user = await requireUser(ctx);
-    const { deletedCount } = await softDeleteUserAccount(ctx, user._id);
-    return { success: true, deletedCount };
-  },
+	args: {},
+	handler: async (ctx) => {
+		const user = await requireUser(ctx);
+		const { deletedCount } = await softDeleteUserAccount(ctx, user._id);
+		return { success: true, deletedCount };
+	},
 });

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -2,74 +2,69 @@ import { v } from "convex/values";
 import type { Doc } from "./_generated/dataModel";
 import type { QueryCtx } from "./_generated/server";
 import { internalMutation, mutation, query } from "./_generated/server";
-import {
-	isInactiveAccount,
-	softDeleteUserAccount,
-} from "./lib/accountDeletion";
+import { isInactiveAccount, softDeleteUserAccount } from "./lib/accountDeletion";
 import { buildReturningUserPatch, newUserFields } from "./lib/entitlements";
 import { requireUser, resolveUserFromIdentity } from "./lib/requireUser";
 import { assertClientMaySetUserType } from "./lib/subscriptionGuards";
 
 /** Shared resolver for the authenticated app user document. */
-export async function fetchCurrentUser(
-	ctx: QueryCtx,
-): Promise<Doc<"users"> | null> {
-	const identity = await ctx.auth.getUserIdentity();
-	if (!identity) {
-		return null;
-	}
+export async function fetchCurrentUser(ctx: QueryCtx): Promise<Doc<"users"> | null> {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) {
+    return null;
+  }
 
-	const user = await resolveUserFromIdentity(ctx, identity);
-	if (!user || isInactiveAccount(user)) {
-		return null;
-	}
-	return user;
+  const user = await resolveUserFromIdentity(ctx, identity);
+  if (!user || isInactiveAccount(user)) {
+    return null;
+  }
+  return user;
 }
 
 export const getCurrentUser = query({
-	args: {},
-	handler: async (ctx) => fetchCurrentUser(ctx),
+  args: {},
+  handler: async (ctx) => fetchCurrentUser(ctx),
 });
 
 /** Profile for dashboard greeting and header; extends user with `greetingName`. */
 export const getProfile = query({
-	args: {},
-	handler: async (ctx) => {
-		const user = await fetchCurrentUser(ctx);
-		if (!user) return null;
-		const greetingName =
-			user.fullName?.trim() || user.email?.split("@")[0] || "there";
-		return {
-			...user,
-			greetingName,
-		};
-	},
+  args: {},
+  handler: async (ctx) => {
+    const user = await fetchCurrentUser(ctx);
+    if (!user) return null;
+    const greetingName =
+      user.fullName?.trim() || user.email?.split("@")[0] || "there";
+    return {
+      ...user,
+      greetingName,
+    };
+  },
 });
 
 export const getById = query({
-	args: { userId: v.id("users") },
-	handler: async (ctx, { userId }) => {
-		const currentUser = await requireUser(ctx);
-		if (currentUser._id !== userId && currentUser.role !== "admin") {
-			throw new Error("Access denied");
-		}
-		return ctx.db.get(userId);
-	},
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }) => {
+    const currentUser = await requireUser(ctx);
+    if (currentUser._id !== userId && currentUser.role !== "admin") {
+      throw new Error("Access denied");
+    }
+    return ctx.db.get(userId);
+  },
 });
 
 export const listActive = query({
-	args: {},
-	handler: async (ctx) => {
-		const currentUser = await requireUser(ctx);
-		if (currentUser.role !== "admin") {
-			throw new Error("Access denied");
-		}
-		const rows = await ctx.db
-			.query("users")
-			.withIndex("by_deletedAt", (q) => q.eq("deletedAt", undefined))
-			.collect();
-		return rows.filter((user) => user.isActive !== false);
-	},
+  args: {},
+  handler: async (ctx) => {
+    const currentUser = await requireUser(ctx);
+    if (currentUser.role !== "admin") {
+      throw new Error("Access denied");
+    }
+    const rows = await ctx.db
+      .query("users")
+      .withIndex("by_deletedAt", (q) => q.eq("deletedAt", undefined))
+      .collect();
+    return rows.filter((user) => user.isActive !== false);
+  },
 });
 
 /**
@@ -84,67 +79,67 @@ export const listActive = query({
  * again.
  */
 export const createOrUpdateUser = mutation({
-	args: {},
-	handler: async (ctx) => {
-		const identity = await ctx.auth.getUserIdentity();
-		if (!identity) throw new Error("Not authenticated");
+  args: {},
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
 
-		const email = identity.email ?? "";
-		const now = Date.now();
+    const email = identity.email ?? "";
+    const now = Date.now();
 
-		const profile = {
-			email,
-			emailVerified: identity.emailVerified ?? false,
-			fullName: identity.name || identity.nickname || "User",
-		};
+    const profile = {
+      email,
+      emailVerified: identity.emailVerified ?? false,
+      fullName: identity.name || identity.nickname || "User",
+    };
 
-		const existing = await ctx.db
-			.query("users")
-			.withIndex("by_email", (q) => q.eq("email", email))
-			.unique();
+    const existing = await ctx.db
+      .query("users")
+      .withIndex("by_email", (q) => q.eq("email", email))
+      .unique();
 
-		if (existing) {
-			// Identity fields plus self-heal only. This path must never write
-			// `role`, and must never write `userType` unconditionally - that was
-			// the downgrade.
-			await ctx.db.patch(existing._id, {
-				...buildReturningUserPatch(existing, profile, now),
-				...(isInactiveAccount(existing)
-					? { deletedAt: undefined, isActive: true }
-					: {}),
-			});
-			return existing._id;
-		}
+    if (existing) {
+      // Identity fields plus self-heal only. This path must never write
+      // `role`, and must never write `userType` unconditionally - that was
+      // the downgrade.
+      await ctx.db.patch(existing._id, {
+        ...buildReturningUserPatch(existing, profile, now),
+        ...(isInactiveAccount(existing)
+          ? { deletedAt: undefined, isActive: true }
+          : {}),
+      });
+      return existing._id;
+    }
 
-		return ctx.db.insert("users", newUserFields(profile, now));
-	},
+    return ctx.db.insert("users", newUserFields(profile, now));
+  },
 });
 
 export const updateProfile = mutation({
-	args: {
-		userId: v.id("users"),
-		fullName: v.optional(v.string()),
-	},
-	handler: async (ctx, { userId, fullName }) => {
-		const currentUser = await requireUser(ctx);
-		if (currentUser._id !== userId && currentUser.role !== "admin") {
-			throw new Error("Access denied");
-		}
-		await ctx.db.patch(userId, { fullName, updatedAt: Date.now() });
-		return userId;
-	},
+  args: {
+    userId: v.id("users"),
+    fullName: v.optional(v.string()),
+  },
+  handler: async (ctx, { userId, fullName }) => {
+    const currentUser = await requireUser(ctx);
+    if (currentUser._id !== userId && currentUser.role !== "admin") {
+      throw new Error("Access denied");
+    }
+    await ctx.db.patch(userId, { fullName, updatedAt: Date.now() });
+    return userId;
+  },
 });
 
 export const updateUserType = mutation({
-	args: {
-		userType: v.union(v.literal("free"), v.literal("paid")),
-	},
-	handler: async (ctx, { userType }) => {
-		assertClientMaySetUserType(userType);
-		const user = await requireUser(ctx);
-		await ctx.db.patch(user._id, { userType, updatedAt: Date.now() });
-		return user._id;
-	},
+  args: {
+    userType: v.union(v.literal("free"), v.literal("paid")),
+  },
+  handler: async (ctx, { userType }) => {
+    assertClientMaySetUserType(userType);
+    const user = await requireUser(ctx);
+    await ctx.db.patch(user._id, { userType, updatedAt: Date.now() });
+    return user._id;
+  },
 });
 
 /**
@@ -152,64 +147,54 @@ export const updateUserType = mutation({
  * Uses appUserId (RevenueCat user ID = Convex user email or subject) to find and update the user.
  */
 export const updateSubscriptionStatus = internalMutation({
-	args: {
-		userId: v.string(),
-		userType: v.union(v.literal("free"), v.literal("paid")),
-		activeEntitlements: v.array(v.string()),
-		revenueCatEvent: v.string(),
-	},
-	handler: async (
-		ctx,
-		{
-			userId,
-			userType,
-			activeEntitlements: _entitlements,
-			revenueCatEvent: _event,
-		},
-	) => {
-		// Try to find user by email (RevenueCat appUserId is typically the user's email)
-		let user = await ctx.db
-			.query("users")
-			.withIndex("by_email", (q) => q.eq("email", userId))
-			.unique();
+  args: {
+    userId: v.string(),
+    userType: v.union(v.literal("free"), v.literal("paid")),
+    activeEntitlements: v.array(v.string()),
+    revenueCatEvent: v.string(),
+  },
+  handler: async (ctx, { userId, userType, activeEntitlements: _entitlements, revenueCatEvent: _event }) => {
+    // Try to find user by email (RevenueCat appUserId is typically the user's email)
+    let user = await ctx.db
+      .query("users")
+      .withIndex("by_email", (q) => q.eq("email", userId))
+      .unique();
 
-		// Fallback: try to find by ID if userId looks like a Convex ID
-		if (!user) {
-			try {
-				user = await ctx.db.get(
-					userId as import("./_generated/dataModel").Id<"users">,
-				);
-			} catch {
-				// Not a valid Convex ID — user not found
-			}
-		}
+    // Fallback: try to find by ID if userId looks like a Convex ID
+    if (!user) {
+      try {
+        user = await ctx.db.get(userId as import("./_generated/dataModel").Id<"users">);
+      } catch {
+        // Not a valid Convex ID — user not found
+      }
+    }
 
-		if (!user) {
-			console.warn(`[RevenueCat] User not found for appUserId: ${userId}`);
-			return { updated: false };
-		}
+    if (!user) {
+      console.warn(`[RevenueCat] User not found for appUserId: ${userId}`);
+      return { updated: false };
+    }
 
-		await ctx.db.patch(user._id, { userType, updatedAt: Date.now() });
-		return { updated: true, userId: user._id };
-	},
+    await ctx.db.patch(user._id, { userType, updatedAt: Date.now() });
+    return { updated: true, userId: user._id };
+  },
 });
 
 export const remove = mutation({
-	args: { userId: v.id("users") },
-	handler: async (ctx, { userId }) => {
-		const currentUser = await requireUser(ctx);
-		if (currentUser._id !== userId && currentUser.role !== "admin") {
-			throw new Error("Access denied");
-		}
-		await ctx.db.delete(userId);
-	},
+  args: { userId: v.id("users") },
+  handler: async (ctx, { userId }) => {
+    const currentUser = await requireUser(ctx);
+    if (currentUser._id !== userId && currentUser.role !== "admin") {
+      throw new Error("Access denied");
+    }
+    await ctx.db.delete(userId);
+  },
 });
 
 export const deleteMyAccount = mutation({
-	args: {},
-	handler: async (ctx) => {
-		const user = await requireUser(ctx);
-		const { deletedCount } = await softDeleteUserAccount(ctx, user._id);
-		return { success: true, deletedCount };
-	},
+  args: {},
+  handler: async (ctx) => {
+    const user = await requireUser(ctx);
+    const { deletedCount } = await softDeleteUserAccount(ctx, user._id);
+    return { success: true, deletedCount };
+  },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

AUTH leftover from #48. `requireUser` already walked every normalized subject part (plus inactive-account checks from #356). `fetchCurrentUser` still used `subjectParts[1]` only. Both now call `resolveUserFromIdentity`. Inactive policy is unchanged: `requireUser` throws, `fetchCurrentUser` returns null.

**Do not merge.** This touches auth / account-deletion. Left draft so auto-arm cannot land it. Bring to green, then Amit reviews.

## Linked task(s)

Task leftover: PR #48. Private `docs/brain/TASKS.md` is not readable in this cloud clone; no invented T-XXXX ID.

## Screenshots / screen recording

N/A — no user-visible surface.

## Test plan

- [x] `bun test convex/lib/requireUser.test.ts` — 10 pass
- [x] Subject any-part resolve without email
- [x] Email fallback
- [x] Missing identity / missing user errors
- [x] Soft-deleted account: throw vs null
- [ ] CI typecheck / lint / tests

## Acceptance criteria

- `fetchCurrentUser` and `requireUser` share one subject-then-email resolver.
- Soft-deleted accounts stay blocked (`This account is not active` / null).
- CI green.
- **Not merged by a code agent.**

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI accept-reject N/A
- [x] Schema N/A
- [x] Styling N/A
- [x] Accessibility N/A
- [x] No secrets committed
- [x] Voice rules N/A

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`) — **required**. Auth / account-deletion. Agent will not merge.

## Graph / scope notes

Did not close #48. Did not invent T-XXXX IDs. Phase 2 still gated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

