### PR TITLE
refactor(brain-dump): extract input validation and plan parse helpers

### DIFF
--- a/convex/brain_dump.ts
+++ b/convex/brain_dump.ts
@@ -2,8 +2,14 @@ import { v } from "convex/values";
 import { action } from "./_generated/server";
 import { AiAuthError, AiContextTooLargeError, AiRateLimitedError, AiUpstreamError } from "./lib/ai_errors";
 import { callLLM } from "./lib/ai_router";
+import { validateBrainDumpInput } from "./lib/brainDumpInput";
+import {
+  type BrainDumpPlan,
+  parsePlanFromModelContent,
+} from "./lib/brainDumpParse";
 
-const MAX_RAW_CHARS = 12_000;
+export type { BrainDumpPlan, BrainDumpPriority } from "./lib/brainDumpParse";
+export { parsePlanFromModelContent } from "./lib/brainDumpParse";
 
 const SYSTEM_PROMPT = `You are a calm planning assistant for an ADHD-friendly app. The user pastes a messy brain dump (tasks, worries, reminders mixed together).
 
@@ -27,93 +33,6 @@ Rules:
 - Titles must be practical next moves, not vague ("Reply to Sam" not "Communication").
 - Use plain language.`;
 
-type BrainDumpUrgency = "now" | "soon" | "later";
-
-export type BrainDumpPriority = {
-  title: string;
-  reason: string;
-  urgency: BrainDumpUrgency;
-};
-
-export type BrainDumpPlan = {
-  summary: string;
-  priorities: BrainDumpPriority[];
-};
-
-function isUrgency(x: unknown): x is BrainDumpUrgency {
-  return x === "now" || x === "soon" || x === "later";
-}
-
-function sanitizeText(text: string): string {
-  // Strip C0/C1 control characters that could leak through from a malformed model
-  // response, then collapse internal whitespace. We do not change the visible
-  // characters, just remove ones that should never appear in a task title.
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping C0/C1 control chars is the intent
-  return text.replace(/[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/g, "").trim();
-}
-
-/**
- * Exported for unit tests. Pure function that converts a model content string
- * into a validated {@link BrainDumpPlan}. Throws a friendly Error on invalid
- * shape. Strips C0/C1 control chars from string fields.
- */
-export function parsePlanFromModelContent(content: string): BrainDumpPlan {
-  const trimmed = content.trim();
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed);
-  } catch {
-    const fence = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
-    if (fence?.[1]) {
-      try {
-        parsed = JSON.parse(fence[1].trim());
-      } catch {
-        throw new Error("Could not read the plan format. Try again?");
-      }
-    } else {
-      throw new Error("Could not read the plan format. Try again?");
-    }
-  }
-
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("Plan response was incomplete. Try again?");
-  }
-
-  const obj = parsed as Record<string, unknown>;
-  const summary =
-    typeof obj.summary === "string" ? sanitizeText(obj.summary) : "";
-  if (!summary) {
-    throw new Error("Plan response was incomplete. Try again?");
-  }
-
-  const rawList = obj.priorities;
-  if (!Array.isArray(rawList)) {
-    throw new Error("Plan response was incomplete. Try again?");
-  }
-
-  const priorities: BrainDumpPriority[] = [];
-  for (const item of rawList) {
-    if (priorities.length >= 6) break;
-    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
-    const row = item as Record<string, unknown>;
-    const title = typeof row.title === "string" ? sanitizeText(row.title) : "";
-    const reason = typeof row.reason === "string" ? sanitizeText(row.reason) : "";
-    const urgency = row.urgency;
-    if (!title || !reason || !isUrgency(urgency)) continue;
-    priorities.push({
-      title: title.length > 200 ? `${title.slice(0, 197)}...` : title,
-      reason: reason.length > 300 ? `${reason.slice(0, 297)}...` : reason,
-      urgency,
-    });
-  }
-
-  if (priorities.length === 0) {
-    throw new Error("No clear items came back. Try a slightly longer list or run again?");
-  }
-
-  return { summary, priorities };
-}
-
 /**
  * Preview-only: returns a prioritized plan from messy text. Does not write tasks or persist the dump.
  */
@@ -127,15 +46,11 @@ export const prioritize = action({
       throw new Error("Sign in to use planning on this device.");
     }
 
-    const raw = args.rawText.trim();
-    if (!raw) {
-      throw new Error("Paste something first — even a rough list is enough.");
+    const validated = validateBrainDumpInput(args.rawText);
+    if (!validated.ok) {
+      throw new Error(validated.message);
     }
-    if (raw.length > MAX_RAW_CHARS) {
-      throw new Error(
-        `That is a lot at once (${raw.length} characters). Try the first chunk under ${MAX_RAW_CHARS} characters, then run again on the rest.`,
-      );
-    }
+    const raw = validated.raw;
 
     try {
       const result = await callLLM({

--- a/convex/lib/brainDumpInput.test.ts
+++ b/convex/lib/brainDumpInput.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import {
+	BRAIN_DUMP_MAX_RAW_CHARS,
+	validateBrainDumpInput,
+} from "./brainDumpInput";
+
+describe("validateBrainDumpInput", () => {
+	test("rejects empty or whitespace-only input", () => {
+		expect(validateBrainDumpInput("")).toEqual({
+			ok: false,
+			message: "Paste something first — even a rough list is enough.",
+		});
+		expect(validateBrainDumpInput("   \n\t  ")).toEqual({
+			ok: false,
+			message: "Paste something first — even a rough list is enough.",
+		});
+	});
+
+	test("accepts trimmed non-empty input within limit", () => {
+		expect(validateBrainDumpInput("  pay rent  ")).toEqual({
+			ok: true,
+			raw: "pay rent",
+		});
+	});
+
+	test("rejects input over the character cap", () => {
+		const long = "x".repeat(BRAIN_DUMP_MAX_RAW_CHARS + 1);
+		const result = validateBrainDumpInput(long);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.message).toContain(String(BRAIN_DUMP_MAX_RAW_CHARS + 1));
+			expect(result.message).toContain(String(BRAIN_DUMP_MAX_RAW_CHARS));
+		}
+	});
+});

--- a/convex/lib/brainDumpInput.ts
+++ b/convex/lib/brainDumpInput.ts
@@ -1,0 +1,25 @@
+export const BRAIN_DUMP_MAX_RAW_CHARS = 12_000;
+
+export type BrainDumpInputValidation =
+	| { ok: true; raw: string }
+	| { ok: false; message: string };
+
+/** Trim and validate brain-dump text before calling the model. */
+export function validateBrainDumpInput(
+	rawText: string,
+): BrainDumpInputValidation {
+	const raw = rawText.trim();
+	if (!raw) {
+		return {
+			ok: false,
+			message: "Paste something first — even a rough list is enough.",
+		};
+	}
+	if (raw.length > BRAIN_DUMP_MAX_RAW_CHARS) {
+		return {
+			ok: false,
+			message: `That is a lot at once (${raw.length} characters). Try the first chunk under ${BRAIN_DUMP_MAX_RAW_CHARS} characters, then run again on the rest.`,
+		};
+	}
+	return { ok: true, raw };
+}

--- a/convex/lib/brainDumpParse.ts
+++ b/convex/lib/brainDumpParse.ts
@@ -1,0 +1,89 @@
+export type BrainDumpUrgency = "now" | "soon" | "later";
+
+export type BrainDumpPriority = {
+	title: string;
+	reason: string;
+	urgency: BrainDumpUrgency;
+};
+
+export type BrainDumpPlan = {
+	summary: string;
+	priorities: BrainDumpPriority[];
+};
+
+function isUrgency(x: unknown): x is BrainDumpUrgency {
+	return x === "now" || x === "soon" || x === "later";
+}
+
+function sanitizeText(text: string): string {
+	// Strip C0/C1 control characters that could leak through from a malformed model
+	// response, then collapse internal whitespace. We do not change the visible
+	// characters, just remove ones that should never appear in a task title.
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping C0/C1 control chars is the intent
+	return text.replace(/[\u0000-\u0008\u000B-\u001F\u007F-\u009F]/g, "").trim();
+}
+
+/**
+ * Pure function that converts a model content string into a validated
+ * {@link BrainDumpPlan}. Throws a friendly Error on invalid shape. Strips C0/C1
+ * control chars from string fields.
+ */
+export function parsePlanFromModelContent(content: string): BrainDumpPlan {
+	const trimmed = content.trim();
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch {
+		const fence = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
+		if (fence?.[1]) {
+			try {
+				parsed = JSON.parse(fence[1].trim());
+			} catch {
+				throw new Error("Could not read the plan format. Try again?");
+			}
+		} else {
+			throw new Error("Could not read the plan format. Try again?");
+		}
+	}
+
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("Plan response was incomplete. Try again?");
+	}
+
+	const obj = parsed as Record<string, unknown>;
+	const summary =
+		typeof obj.summary === "string" ? sanitizeText(obj.summary) : "";
+	if (!summary) {
+		throw new Error("Plan response was incomplete. Try again?");
+	}
+
+	const rawList = obj.priorities;
+	if (!Array.isArray(rawList)) {
+		throw new Error("Plan response was incomplete. Try again?");
+	}
+
+	const priorities: BrainDumpPriority[] = [];
+	for (const item of rawList) {
+		if (priorities.length >= 6) break;
+		if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+		const row = item as Record<string, unknown>;
+		const title = typeof row.title === "string" ? sanitizeText(row.title) : "";
+		const reason =
+			typeof row.reason === "string" ? sanitizeText(row.reason) : "";
+		const urgency = row.urgency;
+		if (!title || !reason || !isUrgency(urgency)) continue;
+		priorities.push({
+			title: title.length > 200 ? `${title.slice(0, 197)}...` : title,
+			reason: reason.length > 300 ? `${reason.slice(0, 297)}...` : reason,
+			urgency,
+		});
+	}
+
+	if (priorities.length === 0) {
+		throw new Error(
+			"No clear items came back. Try a slightly longer list or run again?",
+		);
+	}
+
+	return { summary, priorities };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#126 leftover that is not auth or beta gating: extract `validateBrainDumpInput` and `parsePlanFromModelContent` so the existing prioritize messages/limits are unit-testable. `brain_dump.ts` re-exports the parser so current tests still import from `./brain_dump`.

Skipped from #126: `betaGating` (would undo #348), `userResolver` / `accountAccess` / `profileAccess` / `requireUser` (auth — covered by draft #366), RevenueCat / Today filters (already in #353), `ai_router.test.ts` (already in #365).

## Linked task(s)

Task leftover: PR #126 (partial). Private `docs/brain/TASKS.md` is not readable in this cloud clone; no invented T-XXXX ID.

## Screenshots / screen recording

N/A — no user-visible surface.

## Test plan

- [x] `bun test convex/brain_dump.test.ts convex/lib/brainDumpInput.test.ts` — 14 pass
- [x] Existing parse tests still import from `./brain_dump`
- [x] Empty / whitespace / over-cap input messages unchanged
- [ ] CI typecheck / lint / tests

## Acceptance criteria

- Input validation and plan parse live in `convex/lib/` with tests.
- `prioritize` behavior and copy unchanged.
- No beta allowlist and no auth resolver changes in this PR.
- #126 is not closed (other leftovers remain).

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI accept-reject N/A (preview-only action already; no new mutation)
- [x] Schema N/A
- [x] Styling N/A
- [x] Accessibility N/A
- [x] No secrets committed
- [x] Voice rules: existing anti-shame copy unchanged

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`). Low-risk extract + tests; authorized to merge once CI is green.

## Graph / scope notes

Did not invent T-XXXX IDs. #366 stays draft (auth). Phase 2 still gated.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

