### PR TITLE
feat(a11y): add comfortable reading toggle on mobile settings

### DIFF
--- a/apps/mobile/app/(tempo)/_layout.tsx
+++ b/apps/mobile/app/(tempo)/_layout.tsx
@@ -13,6 +13,7 @@ export default function TempoLayout() {
       <Stack.Screen name="journal" />
       <Stack.Screen name="routines" />
       <Stack.Screen name="settings" />
+      <Stack.Screen name="accessibility" />
       <Stack.Screen name="templates" />
       <Stack.Screen name="capture" options={{ presentation: "modal" }} />
     </Stack>

--- a/apps/mobile/app/(tempo)/accessibility.tsx
+++ b/apps/mobile/app/(tempo)/accessibility.tsx
@@ -1,0 +1,152 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { accessibleReadingStorageKey } from "@tempo/ui/theme";
+import { useCallback, useEffect, useState } from "react";
+import { Platform, ScrollView, Switch, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import {
+  applyAccessibleReadingToRoot,
+  comfortableReadingStorageValue,
+  isComfortableReadingStored,
+} from "@/lib/comfortable-reading";
+
+function prefersReducedMotion(): boolean {
+  if (Platform.OS !== "web" || typeof window === "undefined") {
+    return false;
+  }
+
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function applyAccessibleReading(enabled: boolean): void {
+  if (Platform.OS !== "web" || typeof document === "undefined") {
+    return;
+  }
+
+  applyAccessibleReadingToRoot(
+    document.documentElement,
+    enabled,
+    prefersReducedMotion(),
+  );
+}
+
+async function readStoredComfortableReading(): Promise<boolean> {
+  if (Platform.OS === "web" && typeof window !== "undefined") {
+    return isComfortableReadingStored(
+      window.localStorage.getItem(accessibleReadingStorageKey),
+    );
+  }
+
+  return isComfortableReadingStored(
+    await AsyncStorage.getItem(accessibleReadingStorageKey),
+  );
+}
+
+async function persistComfortableReading(enabled: boolean): Promise<void> {
+  const nextValue = comfortableReadingStorageValue(enabled);
+
+  if (Platform.OS === "web" && typeof window !== "undefined") {
+    window.localStorage.setItem(accessibleReadingStorageKey, nextValue);
+    return;
+  }
+
+  await AsyncStorage.setItem(accessibleReadingStorageKey, nextValue);
+}
+
+export default function AccessibilitySettingsScreen() {
+  const [isComfortableReading, setIsComfortableReading] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadPreference(): Promise<void> {
+      const storedPreference = await readStoredComfortableReading();
+
+      if (!isMounted) {
+        return;
+      }
+
+      setIsComfortableReading(storedPreference);
+      applyAccessibleReading(storedPreference);
+      setIsLoaded(true);
+    }
+
+    void loadPreference();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (Platform.OS !== "web" || typeof window === "undefined") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const handleMotionPreferenceChange = (): void => {
+      applyAccessibleReading(isComfortableReading);
+    };
+
+    mediaQuery.addEventListener("change", handleMotionPreferenceChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleMotionPreferenceChange);
+    };
+  }, [isComfortableReading]);
+
+  const handleComfortableReadingChange = useCallback((nextValue: boolean) => {
+    setIsComfortableReading(nextValue);
+    applyAccessibleReading(nextValue);
+    void persistComfortableReading(nextValue);
+  }, []);
+
+  return (
+    <SafeAreaView className="flex-1 bg-background">
+      <ScrollView
+        className="flex-1"
+        contentContainerClassName="gap-6 p-6"
+        contentInsetAdjustmentBehavior="automatic"
+      >
+        <View className="gap-2">
+          <Text className="text-2xl font-semibold text-foreground">
+            Accessibility
+          </Text>
+          <Text className="text-base leading-7 text-muted-foreground">
+            Adjust reading comfort without changing your tasks or plans.
+          </Text>
+        </View>
+
+        <View className="gap-4 rounded-2xl border border-border-soft bg-card p-5">
+          <View className="flex-row items-center justify-between gap-4">
+            <View className="flex-1 gap-1">
+              <Text className="text-lg font-semibold text-foreground">
+                Comfortable reading
+              </Text>
+              <Text className="text-sm leading-6 text-muted-foreground">
+                Larger text, roomier lines, and calmer motion defaults.
+              </Text>
+            </View>
+            <Switch
+              accessibilityHint="Turns comfortable reading on or off."
+              accessibilityLabel="Comfortable reading"
+              accessibilityRole="switch"
+              accessibilityState={{ checked: isComfortableReading }}
+              disabled={!isLoaded}
+              onValueChange={handleComfortableReadingChange}
+              value={isComfortableReading}
+            />
+          </View>
+        </View>
+
+        <View className="rounded-2xl border border-border-soft bg-card p-5">
+          <Text className="text-sm leading-6 text-muted-foreground">
+            If your device asks apps to reduce motion, Tempo uses the reduced
+            motion token set automatically.
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}

--- a/apps/mobile/app/(tempo)/settings.tsx
+++ b/apps/mobile/app/(tempo)/settings.tsx
@@ -6,6 +6,7 @@
  * @summary: Mobile settings.
  * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
  */
+import { Link } from "expo-router";
 import { Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
@@ -15,6 +16,17 @@ export default function Screen() {
       <View className="flex-1 p-6 gap-3">
         <Text className="text-2xl font-semibold text-foreground">Settings</Text>
         <Text className="text-sm text-muted-foreground">Mobile settings.</Text>
+        <Link href="/accessibility" asChild>
+          <Text
+            accessibilityRole="link"
+            className="text-base text-foreground"
+          >
+            Accessibility
+          </Text>
+        </Link>
+        <Text className="text-xs text-muted-foreground">
+          Comfortable reading and calmer motion live here.
+        </Text>
         <Text className="text-xs text-muted-foreground font-mono">
           scaffold · port from mobile/mobile-screens-b.jsx
         </Text>

--- a/apps/mobile/lib/comfortable-reading.ts
+++ b/apps/mobile/lib/comfortable-reading.ts
@@ -1,0 +1,112 @@
+import {
+  accessibleReadingTokens,
+} from "@tempo/ui/theme";
+
+export const comfortableReadingOn = "on";
+export const comfortableReadingOff = "off";
+
+export type ReadingDocumentRoot = {
+  style: {
+    setProperty: (name: string, value: string) => void;
+    removeProperty: (name: string) => void;
+    fontSize: string;
+    lineHeight: string;
+  };
+  setAttribute: (name: string, value: string) => void;
+  removeAttribute: (name: string) => void;
+};
+
+export function isComfortableReadingStored(value: string | null): boolean {
+  return value === comfortableReadingOn;
+}
+
+export function comfortableReadingStorageValue(enabled: boolean): string {
+  return enabled ? comfortableReadingOn : comfortableReadingOff;
+}
+
+export function computeAccessibleReadingRoot(
+  enabled: boolean,
+  reducedMotion: boolean,
+): {
+  attributes: {
+    "data-accessible-motion": "reduced" | "standard";
+    "data-comfortable-reading": "on" | null;
+  };
+  cssVars: {
+    "--tempo-reading-font-step-px": string;
+    "--tempo-reading-line-height": string;
+    "--tempo-reading-paragraph-spacing": string;
+    "--tempo-reading-motion-duration": string;
+  };
+  style: {
+    fontSize: string | null;
+    lineHeight: string | null;
+  };
+} {
+  const motionDuration = reducedMotion
+    ? accessibleReadingTokens.motion.reducedDuration
+    : accessibleReadingTokens.motion.standardDuration;
+
+  return {
+    attributes: {
+      "data-accessible-motion": reducedMotion ? "reduced" : "standard",
+      "data-comfortable-reading": enabled ? comfortableReadingOn : null,
+    },
+    cssVars: {
+      "--tempo-reading-font-step-px": `${accessibleReadingTokens.fontSizeStepPx}px`,
+      "--tempo-reading-line-height": String(accessibleReadingTokens.lineHeight),
+      "--tempo-reading-paragraph-spacing": `${accessibleReadingTokens.paragraphSpacingPx}px`,
+      "--tempo-reading-motion-duration": motionDuration,
+    },
+    style: enabled
+      ? {
+          fontSize: `${accessibleReadingTokens.rootFontSizePx}px`,
+          lineHeight: String(accessibleReadingTokens.lineHeight),
+        }
+      : { fontSize: null, lineHeight: null },
+  };
+}
+
+export function applyAccessibleReadingToRoot(
+  root: ReadingDocumentRoot,
+  enabled: boolean,
+  reducedMotion: boolean,
+): void {
+  const next = computeAccessibleReadingRoot(enabled, reducedMotion);
+
+  root.style.setProperty(
+    "--tempo-reading-font-step-px",
+    next.cssVars["--tempo-reading-font-step-px"],
+  );
+  root.style.setProperty(
+    "--tempo-reading-line-height",
+    next.cssVars["--tempo-reading-line-height"],
+  );
+  root.style.setProperty(
+    "--tempo-reading-paragraph-spacing",
+    next.cssVars["--tempo-reading-paragraph-spacing"],
+  );
+  root.style.setProperty(
+    "--tempo-reading-motion-duration",
+    next.cssVars["--tempo-reading-motion-duration"],
+  );
+
+  root.setAttribute(
+    "data-accessible-motion",
+    next.attributes["data-accessible-motion"],
+  );
+
+  if (next.attributes["data-comfortable-reading"] === null) {
+    root.removeAttribute("data-comfortable-reading");
+    root.style.removeProperty("font-size");
+    root.style.removeProperty("line-height");
+    return;
+  }
+
+  root.setAttribute(
+    "data-comfortable-reading",
+    next.attributes["data-comfortable-reading"],
+  );
+  root.style.fontSize = next.style.fontSize ?? "";
+  root.style.lineHeight = next.style.lineHeight ?? "";
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,7 +14,10 @@
 export { BrandMark, Wordmark } from "./brand";
 export * from "./primitives";
 export {
+  type AccessibleReadingTokens,
   type TempoColorToken,
+  accessibleReadingStorageKey,
+  accessibleReadingTokens,
   tempoColors,
   tempoColorsDark,
   tempoFonts,
@@ -22,3 +25,4 @@ export {
   tempoRadii,
   tempoSpacing,
 } from "./theme/tokens";
+

--- a/packages/ui/src/theme/tokens.accessible.ts
+++ b/packages/ui/src/theme/tokens.accessible.ts
@@ -1,0 +1,21 @@
+/**
+ * Comfortable-reading token overlay.
+ *
+ * Additive: base Tempo tokens stay in `tokens.ts`. This module describes
+ * the alternate reading / accessibility set only — no hex, no new palette.
+ */
+
+export const accessibleReadingStorageKey = "tempo.comfortableReading";
+
+export const accessibleReadingTokens = {
+  fontSizeStepPx: 2,
+  rootFontSizePx: 18,
+  lineHeight: 1.7,
+  paragraphSpacingPx: 20,
+  motion: {
+    standardDuration: "220ms",
+    reducedDuration: "0ms",
+  },
+} as const;
+
+export type AccessibleReadingTokens = typeof accessibleReadingTokens;

--- a/packages/ui/src/theme/tokens.ts
+++ b/packages/ui/src/theme/tokens.ts
@@ -83,3 +83,10 @@ export const tempoMotion = {
 } as const;
 
 export type TempoColorToken = keyof typeof tempoColors;
+
+export {
+  accessibleReadingStorageKey,
+  accessibleReadingTokens,
+  type AccessibleReadingTokens,
+} from "./tokens.accessible";
+

--- a/tests/unit/comfortable_reading.test.ts
+++ b/tests/unit/comfortable_reading.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import {
+  accessibleReadingStorageKey,
+  accessibleReadingTokens,
+} from "../../packages/ui/src/theme/tokens.accessible";
+import {
+  applyAccessibleReadingToRoot,
+  comfortableReadingOff,
+  comfortableReadingOn,
+  comfortableReadingStorageValue,
+  computeAccessibleReadingRoot,
+  isComfortableReadingStored,
+  type ReadingDocumentRoot,
+} from "../../apps/mobile/lib/comfortable-reading";
+
+function createFakeRoot(): ReadingDocumentRoot & {
+  attributes: Record<string, string>;
+  cssVars: Record<string, string>;
+} {
+  const attributes: Record<string, string> = {};
+  const cssVars: Record<string, string> = {};
+  const styleProps: Record<string, string> = {};
+
+  return {
+    attributes,
+    cssVars,
+    style: {
+      setProperty(name, value) {
+        cssVars[name] = value;
+      },
+      removeProperty(name) {
+        delete cssVars[name];
+        delete styleProps[name];
+      },
+      get fontSize() {
+        return styleProps["font-size"] ?? "";
+      },
+      set fontSize(value: string) {
+        styleProps["font-size"] = value;
+      },
+      get lineHeight() {
+        return styleProps["line-height"] ?? "";
+      },
+      set lineHeight(value: string) {
+        styleProps["line-height"] = value;
+      },
+    },
+    setAttribute(name, value) {
+      attributes[name] = value;
+    },
+    removeAttribute(name) {
+      delete attributes[name];
+    },
+  };
+}
+
+describe("comfortable reading tokens", () => {
+  test("uses the same storage key as the original accessibility PR", () => {
+    expect(accessibleReadingStorageKey).toBe("tempo.comfortableReading");
+  });
+
+  test("steps root type by 2px with roomier line height", () => {
+    expect(accessibleReadingTokens.fontSizeStepPx).toBe(2);
+    expect(accessibleReadingTokens.rootFontSizePx).toBe(18);
+    expect(accessibleReadingTokens.lineHeight).toBe(1.7);
+    expect(accessibleReadingTokens.paragraphSpacingPx).toBe(20);
+  });
+});
+
+describe("comfortable reading storage helpers", () => {
+  test("treats only the on token as enabled", () => {
+    expect(isComfortableReadingStored("on")).toBe(true);
+    expect(isComfortableReadingStored("off")).toBe(false);
+    expect(isComfortableReadingStored(null)).toBe(false);
+  });
+
+  test("persists on/off tokens", () => {
+    expect(comfortableReadingStorageValue(true)).toBe(comfortableReadingOn);
+    expect(comfortableReadingStorageValue(false)).toBe(comfortableReadingOff);
+  });
+});
+
+describe("computeAccessibleReadingRoot", () => {
+  test("enables comfortable reading and standard motion", () => {
+    const next = computeAccessibleReadingRoot(true, false);
+
+    expect(next.attributes["data-comfortable-reading"]).toBe("on");
+    expect(next.attributes["data-accessible-motion"]).toBe("standard");
+    expect(next.style.fontSize).toBe("18px");
+    expect(next.style.lineHeight).toBe("1.7");
+    expect(next.cssVars["--tempo-reading-font-step-px"]).toBe("2px");
+    expect(next.cssVars["--tempo-reading-motion-duration"]).toBe("220ms");
+  });
+
+  test("uses reduced motion tokens when the device asks", () => {
+    const next = computeAccessibleReadingRoot(false, true);
+
+    expect(next.attributes["data-comfortable-reading"]).toBeNull();
+    expect(next.attributes["data-accessible-motion"]).toBe("reduced");
+    expect(next.style.fontSize).toBeNull();
+    expect(next.cssVars["--tempo-reading-motion-duration"]).toBe("0ms");
+  });
+});
+
+describe("applyAccessibleReadingToRoot", () => {
+  test("writes CSS vars and attributes, then clears them on disable", () => {
+    const root = createFakeRoot();
+
+    applyAccessibleReadingToRoot(root, true, false);
+    expect(root.attributes["data-comfortable-reading"]).toBe("on");
+    expect(root.attributes["data-accessible-motion"]).toBe("standard");
+    expect(root.cssVars["--tempo-reading-line-height"]).toBe("1.7");
+    expect(root.style.fontSize).toBe("18px");
+
+    applyAccessibleReadingToRoot(root, false, true);
+    expect(root.attributes["data-comfortable-reading"]).toBeUndefined();
+    expect(root.attributes["data-accessible-motion"]).toBe("reduced");
+    expect(root.cssVars["--tempo-reading-motion-duration"]).toBe("0ms");
+    expect(root.style.fontSize).toBe("");
+  });
+});

--- a/tests/unit/mobile_route_smoke.test.ts
+++ b/tests/unit/mobile_route_smoke.test.ts
@@ -21,6 +21,7 @@ const TEMPO_SCREENS = [
   ["journal", "apps/mobile/app/(tempo)/journal.tsx"],
   ["routines", "apps/mobile/app/(tempo)/routines.tsx"],
   ["settings", "apps/mobile/app/(tempo)/settings.tsx"],
+  ["accessibility", "apps/mobile/app/(tempo)/accessibility.tsx"],
   ["templates", "apps/mobile/app/(tempo)/templates.tsx"],
   ["capture", "apps/mobile/app/(tempo)/capture.tsx"],
 ] as const;
@@ -41,6 +42,7 @@ describe("mobile tempo route smoke", () => {
       "journal",
       "routines",
       "settings",
+      "accessibility",
       "templates",
       "capture",
     ]) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the unique leftover from #224 onto `integration`. Comfortable reading is a local, user-controlled overlay: larger type, roomier lines, and calmer motion. Tokens live in `@tempo/ui` (no new `packages/theme` package, no lockfile churn). The screen is a `(tempo)/accessibility` sibling so it does not convert or overwrite the existing settings scaffold.

## Linked task(s)

Task: leftover of #224 (docs/brain TASKS.md is a private submodule in this clone — not inventing a T-XXXX id).

## Screenshots / screen recording

N/A in this cloud clone — Expo web is not booted here. Coverage is unit tests for token apply/persist plus route smoke.

## Test plan

- [x] `bun test tests/unit/comfortable_reading.test.ts tests/unit/mobile_route_smoke.test.ts` (20 pass)
- [x] `bun test` collected suite (164 pass)
- [ ] CI Typecheck / Lint / Test / Scans / E2E
- [ ] Manual: Settings → Accessibility → toggle Comfortable reading (web applies `data-comfortable-reading` + 18px root)

## Acceptance criteria

- Comfortable reading tokens exist as an additive overlay (no hex, no new palette).
- Toggle persists (`tempo.comfortableReading` = `on` / `off`).
- Web apply writes CSS vars, `data-comfortable-reading`, and `data-accessible-motion`.
- `prefers-reduced-motion: reduce` uses the 0ms motion token.
- Settings links to the accessibility screen.
- `(tempo)` stack declares `accessibility`.
- Original #224 Playwright Expo-web e2e and `packages/theme` package **not** ported.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios. Local prefs use AsyncStorage / localStorage.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). N/A — no AI writes.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). N/A — no Convex schema.
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7).
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8). Switch has a label; reduced-motion token applied.
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13).
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9).

## Owner tag (§14)

- [x] `cursor-cloud-3`

## Reviewer

Amit (`human-amit`). Low-risk a11y leftover; mergeable after CI green.

## Skipped from #224

- `packages/theme/` package scaffold (tokens go in `@tempo/ui` instead)
- Playwright Expo-web e2e (`apps/mobile/e2e/accessibility-toggle.spec.ts`) — CI does not run Expo web; helpers are unit-tested
- `bun.lock` / root `package.json` / empty root `tsconfig.json`
- `(tabs)/settings/` route group — integration routes live under `(tempo)/`

## What the graph / checkout contradicted

AGENTS.md points at `docs/brain/TASKS.md`; that submodule is empty in this clone. Used the in-repo leftover of #224 instead of inventing a T-XXXX id.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

