### PR TITLE
feat(mobile): style empty states on scaffold Tempo routes

### DIFF
--- a/apps/mobile/app/(tempo)/(tabs)/coach.tsx
+++ b/apps/mobile/app/(tempo)/(tabs)/coach.tsx
@@ -6,19 +6,9 @@
  * @summary: Coach conversation.
  * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
  */
-import { Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { TempoEmptyState } from "@/components/TempoEmptyState";
+import { getTempoEmptyStateCopy } from "@/lib/tempo-empty-state";
 
 export default function Screen() {
-  return (
-    <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Coach</Text>
-        <Text className="text-sm text-muted-foreground">Coach conversation.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-a.jsx
-        </Text>
-      </View>
-    </SafeAreaView>
-  );
+  return <TempoEmptyState {...getTempoEmptyStateCopy("coach")} />;
 }

--- a/apps/mobile/app/(tempo)/(tabs)/notes.tsx
+++ b/apps/mobile/app/(tempo)/(tabs)/notes.tsx
@@ -6,19 +6,9 @@
  * @summary: Notes list.
  * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
  */
-import { Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { TempoEmptyState } from "@/components/TempoEmptyState";
+import { getTempoEmptyStateCopy } from "@/lib/tempo-empty-state";
 
 export default function Screen() {
-  return (
-    <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Notes</Text>
-        <Text className="text-sm text-muted-foreground">Notes list.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-a.jsx
-        </Text>
-      </View>
-    </SafeAreaView>
-  );
+  return <TempoEmptyState {...getTempoEmptyStateCopy("notes")} />;
 }

--- a/apps/mobile/app/(tempo)/(tabs)/tasks.tsx
+++ b/apps/mobile/app/(tempo)/(tabs)/tasks.tsx
@@ -6,19 +6,9 @@
  * @summary: Tasks list with quick-check.
  * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
  */
-import { Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { TempoEmptyState } from "@/components/TempoEmptyState";
+import { getTempoEmptyStateCopy } from "@/lib/tempo-empty-state";
 
 export default function Screen() {
-  return (
-    <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Tasks</Text>
-        <Text className="text-sm text-muted-foreground">Tasks list with quick-check.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-a.jsx
-        </Text>
-      </View>
-    </SafeAreaView>
-  );
+  return <TempoEmptyState {...getTempoEmptyStateCopy("tasks")} />;
 }

--- a/apps/mobile/app/(tempo)/(tabs)/today.tsx
+++ b/apps/mobile/app/(tempo)/(tabs)/today.tsx
@@ -6,19 +6,9 @@
  * @summary: Tab home: today capsule + coach suggestion.
  * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
  */
-import { Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { TempoEmptyState } from "@/components/TempoEmptyState";
+import { getTempoEmptyStateCopy } from "@/lib/tempo-empty-state";
 
 export default function Screen() {
-  return (
-    <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Today</Text>
-        <Text className="text-sm text-muted-foreground">Tab home: today capsule + coach suggestion.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-a.jsx
-        </Text>
-      </View>
-    </SafeAreaView>
-  );
+  return <TempoEmptyState {...getTempoEmptyStateCopy("today")} />;
 }

--- a/apps/mobile/app/(tempo)/calendar.tsx
+++ b/apps/mobile/app/(tempo)/calendar.tsx
@@ -6,19 +6,9 @@
  * @summary: Mobile calendar week view.
  * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
  */
-import { Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { TempoEmptyState } from "@/components/TempoEmptyState";
+import { getTempoEmptyStateCopy } from "@/lib/tempo-empty-state";
 
 export default function Screen() {
-  return (
-    <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Calendar</Text>
-        <Text className="text-sm text-muted-foreground">Mobile calendar week view.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-b.jsx
-        </Text>
-      </View>
-    </SafeAreaView>
-  );
+  return <TempoEmptyState {...getTempoEmptyStateCopy("calendar")} />;
 }

--- a/apps/mobile/app/(tempo)/capture.tsx
+++ b/apps/mobile/app/(tempo)/capture.tsx
@@ -6,19 +6,9 @@
  * @summary: Modal capture composer with voice + text.
  * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
  */
-import { Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { TempoEmptyState } from "@/components/TempoEmptyState";
+import { getTempoEmptyStateCopy } from "@/lib/tempo-empty-state";
 
 export default function Screen() {
-  return (
-    <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Capture</Text>
-        <Text className="text-sm text-muted-foreground">Modal capture composer with voice + text.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-a.jsx
-        </Text>
-      </View>
-    </SafeAreaView>
-  );
+  return <TempoEmptyState {...getTempoEmptyStateCopy("capture")} />;
 }

--- a/apps/mobile/app/(tempo)/habits.tsx
+++ b/apps/mobile/app/(tempo)/habits.tsx
@@ -6,19 +6,9 @@
  * @summary: Mobile habits with ring rows.
  * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
  */
-import { Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { TempoEmptyState } from "@/components/TempoEmptyState";
+import { getTempoEmptyStateCopy } from "@/lib/tempo-empty-state";
 
 export default function Screen() {
-  return (
-    <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Habits</Text>
-        <Text className="text-sm text-muted-foreground">Mobile habits with ring rows.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-b.jsx
-        </Text>
-      </View>
-    </SafeAreaView>
-  );
+  return <TempoEmptyState {...getTempoEmptyStateCopy("habits")} />;
 }

--- a/apps/mobile/app/(tempo)/journal.tsx
+++ b/apps/mobile/app/(tempo)/journal.tsx
@@ -6,19 +6,9 @@
  * @summary: Mobile journal.
  * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
  */
-import { Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { TempoEmptyState } from "@/components/TempoEmptyState";
+import { getTempoEmptyStateCopy } from "@/lib/tempo-empty-state";
 
 export default function Screen() {
-  return (
-    <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Journal</Text>
-        <Text className="text-sm text-muted-foreground">Mobile journal.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-b.jsx
-        </Text>
-      </View>
-    </SafeAreaView>
-  );
+  return <TempoEmptyState {...getTempoEmptyStateCopy("journal")} />;
 }

--- a/apps/mobile/app/(tempo)/templates.tsx
+++ b/apps/mobile/app/(tempo)/templates.tsx
@@ -6,19 +6,9 @@
  * @summary: Mobile templates.
  * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
  */
-import { Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { TempoEmptyState } from "@/components/TempoEmptyState";
+import { getTempoEmptyStateCopy } from "@/lib/tempo-empty-state";
 
 export default function Screen() {
-  return (
-    <SafeAreaView className="flex-1 bg-background">
-      <View className="flex-1 p-6 gap-3">
-        <Text className="text-2xl font-semibold text-foreground">Templates</Text>
-        <Text className="text-sm text-muted-foreground">Mobile templates.</Text>
-        <Text className="text-xs text-muted-foreground font-mono">
-          scaffold · port from mobile/mobile-screens-b.jsx
-        </Text>
-      </View>
-    </SafeAreaView>
-  );
+  return <TempoEmptyState {...getTempoEmptyStateCopy("templates")} />;
 }

--- a/apps/mobile/components/TempoEmptyState.tsx
+++ b/apps/mobile/components/TempoEmptyState.tsx
@@ -1,0 +1,60 @@
+import { Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import {
+  emptyStateActionLabel,
+  emptyStateLeaveQuiet,
+  emptyStateReassurance,
+} from "@/lib/tempo-empty-state";
+
+type TempoEmptyStateProps = {
+  screenId: string;
+  title: string;
+  summary: string;
+  actionLabel?: string;
+};
+
+export function TempoEmptyState({
+  screenId,
+  title,
+  summary,
+  actionLabel,
+}: TempoEmptyStateProps) {
+  return (
+    <SafeAreaView
+      className="flex-1 bg-background"
+      testID={`${screenId}-empty-state`}
+      accessible={true}
+      accessibilityLabel={`${title} empty state`}
+    >
+      <View className="flex-1 justify-center gap-5 px-6 py-8">
+        <View className="self-start rounded-full border border-border bg-card px-3 py-1">
+          <Text className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Empty state
+          </Text>
+        </View>
+
+        <View className="gap-3 rounded-3xl border border-border bg-card p-6 shadow-sm">
+          <Text className="text-3xl font-semibold text-foreground">{title}</Text>
+          <Text className="text-base leading-7 text-muted-foreground">
+            {summary}
+          </Text>
+          <View className="rounded-2xl bg-muted px-4 py-3">
+            <Text className="text-sm leading-6 text-muted-foreground">
+              {emptyStateReassurance}
+            </Text>
+          </View>
+        </View>
+
+        <View className="gap-2 rounded-2xl border border-border bg-card px-4 py-3">
+          <Text className="text-sm font-semibold text-foreground">
+            {emptyStateActionLabel(actionLabel)}
+          </Text>
+          <Text className="text-xs leading-5 text-muted-foreground">
+            {emptyStateLeaveQuiet}
+          </Text>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}

--- a/apps/mobile/lib/tempo-empty-state.ts
+++ b/apps/mobile/lib/tempo-empty-state.ts
@@ -1,0 +1,94 @@
+export type TempoEmptyStateCopy = {
+  screenId: string;
+  title: string;
+  summary: string;
+  actionLabel: string;
+};
+
+const DEFAULT_ACTION_LABEL = "Start gently";
+
+export const tempoEmptyStateCopy = {
+  today: {
+    screenId: "today",
+    title: "Today",
+    summary:
+      "No plans are waiting here yet. You can begin with one gentle next step when you want to shape the day.",
+    actionLabel: "Plan one small thing",
+  },
+  tasks: {
+    screenId: "tasks",
+    title: "Tasks",
+    summary:
+      "Your task list is clear. Add something only when it would make today feel easier to hold.",
+    actionLabel: "Add a task",
+  },
+  notes: {
+    screenId: "notes",
+    title: "Notes",
+    summary:
+      "No notes are saved yet. This can stay quiet until a thought feels worth catching.",
+    actionLabel: "Capture a note",
+  },
+  coach: {
+    screenId: "coach",
+    title: "Coach",
+    summary:
+      "No coach thread has started yet. When you want company, the first message can be simple.",
+    actionLabel: "Open a gentle check-in",
+  },
+  calendar: {
+    screenId: "calendar",
+    title: "Calendar",
+    summary:
+      "No events are connected yet. The calendar can stay open space until a real commitment belongs here.",
+    actionLabel: "Connect a calendar",
+  },
+  capture: {
+    screenId: "capture",
+    title: "Capture",
+    summary:
+      "Nothing has been captured yet. You can drop a thought here without sorting it first.",
+    actionLabel: "Capture a loose thought",
+  },
+  habits: {
+    screenId: "habits",
+    title: "Habits",
+    summary:
+      "No habits are tracked yet. Start with something kind and repeatable when it feels useful.",
+    actionLabel: "Choose a tiny habit",
+  },
+  journal: {
+    screenId: "journal",
+    title: "Journal",
+    summary:
+      "No journal entries are here yet. A blank page is allowed to stay blank until reflection helps.",
+    actionLabel: "Write one line",
+  },
+  templates: {
+    screenId: "templates",
+    title: "Templates",
+    summary:
+      "No templates are saved yet. Reuse can come later, after you notice what helps more than once.",
+    actionLabel: "Browse starter shapes",
+  },
+} as const satisfies Record<string, TempoEmptyStateCopy>;
+
+export type TempoEmptyStateScreenId = keyof typeof tempoEmptyStateCopy;
+
+export function getTempoEmptyStateCopy(
+  screenId: TempoEmptyStateScreenId,
+): TempoEmptyStateCopy {
+  return tempoEmptyStateCopy[screenId];
+}
+
+export function emptyStateActionLabel(
+  actionLabel?: string,
+): string {
+  return actionLabel ?? DEFAULT_ACTION_LABEL;
+}
+
+export const emptyStateReassurance =
+  "Nothing is missing. When you are ready, this screen will hold the next small step without making the blank space feel like a problem.";
+
+export const emptyStateLeaveQuiet =
+  "You can leave this empty until the next step feels clear.";

--- a/tests/unit/tempo_empty_state.test.ts
+++ b/tests/unit/tempo_empty_state.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import {
+  emptyStateActionLabel,
+  emptyStateLeaveQuiet,
+  emptyStateReassurance,
+  getTempoEmptyStateCopy,
+  tempoEmptyStateCopy,
+} from "../../apps/mobile/lib/tempo-empty-state";
+
+const SHAME_WORDS = [
+  /\bbehind\b/i,
+  /\bfailing\b/i,
+  /\blazy\b/i,
+  /\boverdue\b/i,
+  /\bforgot\b/i,
+  /\bshould have\b/i,
+];
+
+const SCAFFOLD_SCREENS = [
+  ["today", "apps/mobile/app/(tempo)/(tabs)/today.tsx"],
+  ["tasks", "apps/mobile/app/(tempo)/(tabs)/tasks.tsx"],
+  ["notes", "apps/mobile/app/(tempo)/(tabs)/notes.tsx"],
+  ["coach", "apps/mobile/app/(tempo)/(tabs)/coach.tsx"],
+  ["calendar", "apps/mobile/app/(tempo)/calendar.tsx"],
+  ["capture", "apps/mobile/app/(tempo)/capture.tsx"],
+  ["habits", "apps/mobile/app/(tempo)/habits.tsx"],
+  ["journal", "apps/mobile/app/(tempo)/journal.tsx"],
+  ["templates", "apps/mobile/app/(tempo)/templates.tsx"],
+] as const;
+
+describe("tempo empty-state copy", () => {
+  test("covers the nine scaffold screens", () => {
+    expect(Object.keys(tempoEmptyStateCopy).toSorted()).toEqual(
+      SCAFFOLD_SCREENS.map(([id]) => id).toSorted(),
+    );
+  });
+
+  test("every screen has a title, summary, and action", () => {
+    for (const [screenId] of SCAFFOLD_SCREENS) {
+      const copy = getTempoEmptyStateCopy(screenId);
+      expect(copy.screenId).toBe(screenId);
+      expect(copy.title.length).toBeGreaterThan(0);
+      expect(copy.summary.length).toBeGreaterThan(20);
+      expect(copy.actionLabel.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("copy stays shame-free", () => {
+    const blobs = [
+      emptyStateReassurance,
+      emptyStateLeaveQuiet,
+      ...Object.values(tempoEmptyStateCopy).flatMap((copy) => [
+        copy.title,
+        copy.summary,
+        copy.actionLabel,
+      ]),
+    ];
+
+    for (const text of blobs) {
+      for (const shame of SHAME_WORDS) {
+        expect(text).not.toMatch(shame);
+      }
+    }
+  });
+
+  test("default action label is gentle", () => {
+    expect(emptyStateActionLabel()).toBe("Start gently");
+    expect(emptyStateActionLabel("Write one line")).toBe("Write one line");
+  });
+});
+
+describe("tempo empty-state screens", () => {
+  test.each([...SCAFFOLD_SCREENS])(
+    "%s uses TempoEmptyState and keeps a default export",
+    async (screenId, filePath) => {
+      const source = await Bun.file(filePath).text();
+      expect(source).toContain('from "@/components/TempoEmptyState"');
+      expect(source).toContain(`getTempoEmptyStateCopy("${screenId}")`);
+      expect(source).toMatch(/export default function \w+/);
+    },
+  );
+
+  test("routines and settings keep their landed content", async () => {
+    const routines = await Bun.file(
+      "apps/mobile/app/(tempo)/routines.tsx",
+    ).text();
+    const settings = await Bun.file(
+      "apps/mobile/app/(tempo)/settings.tsx",
+    ).text();
+
+    expect(routines).toContain("BreathworkTimer");
+    expect(routines).not.toContain("TempoEmptyState");
+    expect(settings).toContain('href="/accessibility"');
+    expect(settings).not.toContain("TempoEmptyState");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the unique leftover from #178 onto `integration`. Scaffold Tempo screens now share a shame-free `TempoEmptyState` instead of "scaffold · port" placeholders. Routines (breathwork timer) and Settings (comfortable-reading link) are left alone so landed work is not overwritten.

## Linked task(s)

Task: leftover of #178 (`docs/brain/TASKS.md` is empty in this clone — not inventing a T-XXXX id).

## Screenshots / screen recording

N/A in this cloud clone — Expo web is not booted here. Coverage is copy + route-source tests.

## Test plan

- [x] `bun test tests/unit/tempo_empty_state.test.ts tests/unit/mobile_route_smoke.test.ts` (27 pass)
- [x] collected suite (178 pass)
- [ ] CI Typecheck / Lint / Test / Scans / E2E

## Acceptance criteria

- Shared `TempoEmptyState` exists and is used by the nine still-empty screens.
- Copy is anti-shame (no behind / failing / lazy / overdue).
- `routines.tsx` still mounts `BreathworkTimer`.
- `settings.tsx` still links to `/accessibility`.
- Playwright Expo-web e2e and lockfile churn **not** ported.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2).
- [x] AI-originated state changes N/A.
- [x] Schema changes N/A.
- [x] Styling uses design tokens from `packages/ui` / existing Tailwind token classes — no ad-hoc hex.
- [x] Accessibility: empty-state container has `accessibilityLabel`.
- [x] No secrets committed.
- [x] Voice rules honored — empty states are kind (§1, §9).

## Owner tag (§14)

- [x] `cursor-cloud-3`

## Reviewer

Amit (`human-amit`). Low-risk UI leftover; mergeable after CI green.

## Skipped from #178

- `routines.tsx` / `settings.tsx` replacements (would regress #354 and #368)
- Playwright `navigation.spec.ts`
- `bun.lock` / package.json

## What the graph / checkout contradicted

AGENTS.md points at `docs/brain/TASKS.md`; that submodule is empty here. Used the in-repo leftover of #178 instead of inventing a T-XXXX id.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

