### PR TITLE
feat(habits): wire web HabitsScreen to landed streak API

### DIFF
--- a/apps/web/app/(tempo)/habits/page.tsx
+++ b/apps/web/app/(tempo)/habits/page.tsx
@@ -1,23 +1,14 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: habits
  * @category: Library
  * @source: docs/design/claude-export/design-system/screens-3.jsx
- * @summary: Habit rings with weekly progress.
+ * @summary: Habit check-off with streak history.
  * @queries: habits.list
- * @mutations: habits.logComplete
- * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @mutations: habits.create, habits.completeToday
+ * @auth: required (gentle sign-in card otherwise)
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { HabitsScreen } from "@/components/habits/HabitsScreen";
 
 export default function Page() {
-  return (
-    <ScaffoldScreen
-      title="Habits"
-      category="Library"
-      source="screens-3.jsx"
-      summary="Habit rings with weekly progress."
-    />
-  );
+  return <HabitsScreen />;
 }

--- a/apps/web/components/habits/HabitsScreen.tsx
+++ b/apps/web/components/habits/HabitsScreen.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import type { Id } from "@/convex/_generated/dataModel";
+import { isHabitCompletedOnUtcDay } from "@/convex/lib/habitStreak";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { CheckCircle2, Circle, Flame, Plus } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { SoftCard } from "@/components/soft-editorial/SoftCard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { api } from "@/convex/_generated/api";
+import { cn } from "@/lib/utils";
+
+type HabitRowData = {
+  _id: Id<"habits">;
+  name: string;
+  cadence: "daily" | "weekly";
+  currentStreak: number;
+  longestStreak: number;
+  lastCompletedAt?: number;
+};
+
+function HabitRow({ habit, now }: { habit: HabitRowData; now: number }) {
+  const completeToday = useMutation(api.habits.completeToday);
+  const completedToday = isHabitCompletedOnUtcDay(habit.lastCompletedAt, now);
+
+  return (
+    <li className="rounded-3xl border border-border/80 bg-card/90 p-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="font-heading text-xl font-semibold text-foreground">
+              {habit.name}
+            </h2>
+            <span className="rounded-full border border-border bg-background px-2.5 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {habit.cadence}
+            </span>
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Current streak: {habit.currentStreak}{" "}
+            {habit.currentStreak === 1 ? "day" : "days"} · Longest:{" "}
+            {habit.longestStreak}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => {
+            if (!completedToday) {
+              void completeToday({ habitId: habit._id });
+            }
+          }}
+          disabled={completedToday}
+          className={cn(
+            "inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-full border px-4 py-2 text-sm font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-default",
+            completedToday
+              ? "border-primary/30 bg-primary/10 text-primary"
+              : "border-border bg-background text-foreground hover:border-primary hover:text-primary",
+          )}
+          aria-label={
+            completedToday
+              ? `${habit.name} is checked today`
+              : `Check ${habit.name} today`
+          }
+        >
+          {completedToday ? (
+            <CheckCircle2 className="h-4 w-4" aria-hidden />
+          ) : (
+            <Circle className="h-4 w-4" aria-hidden />
+          )}
+          {completedToday ? "Checked today" : "Check today"}
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function NewHabitForm() {
+  const createHabit = useMutation(api.habits.create);
+  const [name, setName] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  return (
+    <form
+      className="rounded-3xl border border-dashed border-border bg-muted/30 p-5"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const trimmed = name.trim();
+        if (!trimmed) {
+          return;
+        }
+        setIsSubmitting(true);
+        void createHabit({ name: trimmed, cadence: "daily" })
+          .then(() => setName(""))
+          .finally(() => setIsSubmitting(false));
+      }}
+    >
+      <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
+        <div className="space-y-2">
+          <Label htmlFor="habit-name">Add a tiny habit</Label>
+          <Input
+            id="habit-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Drink water, take meds, step outside..."
+            autoComplete="off"
+          />
+        </div>
+        <Button type="submit" disabled={isSubmitting || name.trim().length === 0}>
+          <Plus className="h-4 w-4" aria-hidden />
+          Add habit
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export function HabitsScreen() {
+  const now = Date.now();
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const profile = useQuery(api.users.getProfile, isAuthenticated ? {} : "skip");
+  const hasConvexUser = profile != null;
+  const habits = useQuery(
+    api.habits.list,
+    isAuthenticated && hasConvexUser ? {} : "skip",
+  );
+  const isLoading =
+    isAuthLoading ||
+    (isAuthenticated &&
+      (profile === undefined || (hasConvexUser && habits === undefined)));
+
+  if (isLoading) {
+    return (
+      <main className="mx-auto w-full max-w-4xl p-8">
+        <div className="space-y-4">
+          <div className="h-12 w-48 animate-pulse rounded-xl bg-muted" />
+          <div className="h-28 animate-pulse rounded-3xl bg-muted" />
+          <div className="h-24 animate-pulse rounded-3xl bg-muted" />
+        </div>
+      </main>
+    );
+  }
+
+  if (!isAuthenticated || !profile || !habits) {
+    return (
+      <main className="mx-auto w-full max-w-4xl p-8 text-center">
+        <SoftCard className="mx-auto max-w-xl">
+          <h1 className="font-heading text-2xl font-semibold text-foreground">
+            Habits
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            Sign in again to check off habits and keep today in sync.
+          </p>
+          <Button asChild className="mt-6">
+            <Link href="/sign-in">Sign in</Link>
+          </Button>
+        </SoftCard>
+      </main>
+    );
+  }
+
+  const checkedCount = habits.filter((habit) =>
+    isHabitCompletedOnUtcDay(habit.lastCompletedAt, now),
+  ).length;
+
+  return (
+    <main className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-8">
+      <header className="space-y-3">
+        <div className="flex items-center gap-3">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            <Flame className="h-5 w-5" aria-hidden />
+          </div>
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Library
+            </p>
+            <h1 className="font-heading text-4xl font-semibold text-foreground">
+              Habits
+            </h1>
+          </div>
+        </div>
+        <p className="max-w-2xl text-muted-foreground">
+          Check off the tiny repeats that help today feel workable. Streaks
+          count consecutive calendar days, and coming back still counts as
+          progress.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          {habits.length === 0
+            ? "No habits yet."
+            : `${checkedCount} of ${habits.length} checked today.`}
+        </p>
+      </header>
+
+      <NewHabitForm />
+
+      {habits.length === 0 ? (
+        <div className="rounded-3xl border border-border/80 bg-card/90 px-6 py-10 text-center">
+          <p className="text-base font-medium text-foreground">
+            Start with one small repeat.
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            A tiny habit is enough; you can rename or reshape it later.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {habits.map((habit) => (
+            <HabitRow key={habit._id} habit={habit} now={now} />
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/apps/web/lib/habitCompletedToday.test.ts
+++ b/apps/web/lib/habitCompletedToday.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { isHabitCompletedOnUtcDay } from "../../../convex/lib/habitStreak";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("HabitsScreen completedToday derivation", () => {
+  test("matches the landed completeToday alreadyDone window", () => {
+    const last = 1_700_000_000_000;
+    expect(isHabitCompletedOnUtcDay(undefined, last)).toBe(false);
+    expect(isHabitCompletedOnUtcDay(last, last + 3 * 60 * 60 * 1000)).toBe(true);
+    expect(isHabitCompletedOnUtcDay(last, last + DAY_MS)).toBe(false);
+  });
+});

--- a/convex/lib/habitStreak.test.ts
+++ b/convex/lib/habitStreak.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { computeHabitStreakUpdate } from "./habitStreak";
+import { computeHabitStreakUpdate, isHabitCompletedOnUtcDay } from "./habitStreak";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -55,5 +55,21 @@ describe("computeHabitStreakUpdate", () => {
 			expect(result.currentStreak).toBe(3);
 			expect(result.longestStreak).toBe(7);
 		}
+	});
+});
+
+describe("isHabitCompletedOnUtcDay", () => {
+	test("never-completed habit is not done today", () => {
+		expect(isHabitCompletedOnUtcDay(undefined, 1_700_000_000_000)).toBe(false);
+	});
+
+	test("same UTC day counts as done", () => {
+		const last = 1_700_000_000_000;
+		expect(isHabitCompletedOnUtcDay(last, last + 6 * 60 * 60 * 1000)).toBe(true);
+	});
+
+	test("next UTC day is not done", () => {
+		const last = 1_700_000_000_000;
+		expect(isHabitCompletedOnUtcDay(last, last + DAY_MS)).toBe(false);
 	});
 });

--- a/convex/lib/habitStreak.ts
+++ b/convex/lib/habitStreak.ts
@@ -1,5 +1,16 @@
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/** True when `lastCompletedAt` falls on the same UTC day as `now`. */
+export function isHabitCompletedOnUtcDay(
+	lastCompletedAt: number | undefined,
+	now: number,
+): boolean {
+	if (lastCompletedAt === undefined) {
+		return false;
+	}
+	return Math.floor((now - lastCompletedAt) / DAY_MS) === 0;
+}
+
 export type HabitStreakUpdate =
 	| { alreadyDone: true; currentStreak: number }
 	| { alreadyDone: false; currentStreak: number; longestStreak: number };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the unique leftover from #172 onto `integration`. The web `/habits` scaffold becomes a real check-off screen. Streak persistence already landed in #365 (`habitStreak` + `completeToday`). This PR adapts the UI to that API: `habits.list` takes no `dayKey`, `completeToday` takes only `habitId`, and `completedToday` is derived from `lastCompletedAt` with the same UTC-day window as streak math.

## Linked task(s)

Task: leftover of #172 (`docs/brain/TASKS.md` is empty in this clone — not inventing a T-XXXX id).

## Screenshots / screen recording

N/A in this cloud clone — no signed-in Convex session here. Coverage is unit tests for the UTC-day helper plus the existing habit-streak suite.

## Test plan

- [x] `bun test convex/lib/habitStreak.test.ts apps/web/lib/habitCompletedToday.test.ts` (9 pass)
- [x] collected suite (182 pass)
- [ ] CI Typecheck / Lint / Test / Scans / E2E
- [ ] Manual: sign in → `/habits` → add a tiny habit → Check today → button becomes "Checked today"

## Acceptance criteria

- Web `/habits` renders `HabitsScreen` instead of `ScaffoldScreen`.
- Create + completeToday use the landed Convex API (no `dayKey`, no `habitCompletions`).
- Same-UTC-day completions show as already checked.
- Copy is anti-shame ("coming back still counts as progress").
- #172 Playwright e2e, preview flag, and schema rewrite **not** ported.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2).
- [x] AI-originated state changes N/A.
- [x] Schema changes N/A — uses existing `habits` table.
- [x] Styling uses existing token classes — no ad-hoc hex.
- [x] Accessibility: check button has an `aria-label`; focus-visible ring.
- [x] No secrets committed.
- [x] Voice rules honored (§1, §9).

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`). Low-risk web UI leftover; mergeable after CI green.

## Skipped from #172

- `convex/schema.ts` `habitCompletions` table
- `habits.list({ dayKey })` / `completeToday({ dayKey })`
- `NEXT_PUBLIC_TEMPO_E2E_HABITS` localStorage preview
- Playwright `habit-checkin.spec.ts` and lockfile churn

## What the graph / checkout contradicted

#172 assumed a `dayKey` + completions table. Integration already has `lastCompletedAt` + `computeHabitStreakUpdate`. The graph/code won; the UI was adapted rather than reintroducing the old model.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

