### PR TITLE
feat(today): add agenda and habit strip on Today from landed APIs

### DIFF
--- a/apps/web/components/today/TodayAgenda.tsx
+++ b/apps/web/components/today/TodayAgenda.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import { CalendarDays } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { TodayAgendaEvent } from "@/lib/todayAgenda";
+
+type TodayAgendaProps = {
+  events?: TodayAgendaEvent[];
+};
+
+export function TodayAgenda({ events = [] }: TodayAgendaProps) {
+  return (
+    <section
+      className="rounded-3xl border border-border/80 bg-card/90 p-5"
+      aria-labelledby="today-agenda-heading"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <CalendarDays className="h-5 w-5" aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2
+            id="today-agenda-heading"
+            className="font-heading text-xl font-semibold text-foreground"
+          >
+            Today&apos;s agenda
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Calendar events for today, when anything is on the board.
+          </p>
+        </div>
+      </div>
+
+      {events.length > 0 ? (
+        <ol className="mt-5 space-y-3">
+          {events.map((event) => (
+            <li
+              key={event.id}
+              className="rounded-2xl border border-border/70 bg-background/70 px-4 py-3"
+            >
+              <p className="text-sm font-semibold text-primary">{event.timeLabel}</p>
+              <p className="mt-1 font-medium text-foreground">{event.title}</p>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <div className="mt-5 rounded-2xl border border-dashed border-border bg-muted/30 px-4 py-5">
+          <p className="text-sm font-medium text-foreground">
+            No calendar events for today yet.
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            If nothing is scheduled, that can be useful information too. You can
+            keep the day simple or add events from Calendar when you want.
+          </p>
+          <Button asChild variant="outline" className="mt-4 rounded-full">
+            <Link href="/calendar">Open Calendar</Link>
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/today/TodayHabitStrip.tsx
+++ b/apps/web/components/today/TodayHabitStrip.tsx
@@ -1,0 +1,81 @@
+import type { Id } from "@/convex/_generated/dataModel";
+import Link from "next/link";
+import { Flame } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { visibleHabitsFrom } from "@/lib/todayAgenda";
+
+type TodayHabit = {
+  _id: Id<"habits">;
+  name: string;
+  cadence: "daily" | "weekly";
+  currentStreak: number;
+};
+
+type TodayHabitStripProps = {
+  habits: TodayHabit[];
+};
+
+export function TodayHabitStrip({ habits }: TodayHabitStripProps) {
+  const { visible, hiddenCount } = visibleHabitsFrom(habits, 5);
+
+  return (
+    <section
+      className="rounded-3xl border border-border/80 bg-card/90 p-5"
+      aria-labelledby="today-habit-strip-heading"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <Flame className="h-5 w-5" aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2
+            id="today-habit-strip-heading"
+            className="font-heading text-xl font-semibold text-foreground"
+          >
+            Habit strip
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            A small glance at routines you may want to keep in view today.
+          </p>
+        </div>
+      </div>
+
+      {visible.length > 0 ? (
+        <div className="mt-5 flex flex-wrap gap-3">
+          {visible.map((habit) => (
+            <Link
+              key={habit._id}
+              href="/habits"
+              className="min-h-11 rounded-full border border-border bg-background/75 px-4 py-2 text-sm transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+            >
+              <span className="font-medium text-foreground">{habit.name}</span>
+              <span className="ml-2 text-muted-foreground">
+                {habit.currentStreak > 0
+                  ? `${habit.currentStreak} in a row`
+                  : habit.cadence}
+              </span>
+            </Link>
+          ))}
+          {hiddenCount > 0 ? (
+            <span className="inline-flex min-h-11 items-center rounded-full border border-dashed border-border px-4 py-2 text-sm text-muted-foreground">
+              +{hiddenCount} more
+            </span>
+          ) : null}
+        </div>
+      ) : (
+        <div className="mt-5 rounded-2xl border border-dashed border-border bg-muted/30 px-4 py-5">
+          <p className="text-sm font-medium text-foreground">
+            No habits pinned here yet.
+          </p>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Habits can stay gentle. Add one tiny repeatable thing when you want
+            this strip to hold it for you.
+          </p>
+          <Button asChild variant="outline" className="mt-4 rounded-full">
+            <Link href="/habits">Open Habits</Link>
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/today/TodayScreen.tsx
+++ b/apps/web/components/today/TodayScreen.tsx
@@ -7,9 +7,12 @@ import { TaskViewsScreen } from "@/components/tasks/TaskViewsScreen";
 import { Button } from "@/components/ui/button";
 import { api } from "@/convex/_generated/api";
 import { useLocalDayBounds } from "@/lib/useLocalDayBounds";
+import { mapCalendarEventsToAgenda } from "@/lib/todayAgenda";
+import { TodayAgenda } from "./TodayAgenda";
 import { TodayBrainDumpPanel } from "./TodayBrainDumpPanel";
 import { TodayEnergyRecommendations } from "./TodayEnergyRecommendations";
 import { TodayGreeting } from "./TodayGreeting";
+import { TodayHabitStrip } from "./TodayHabitStrip";
 import { TodayQuickAdd } from "./TodayQuickAdd";
 import { TodayTaskList } from "./TodayTaskList";
 
@@ -28,10 +31,25 @@ export function TodayScreen() {
     api.tasks.listToday,
     isAuthenticated && hasConvexUser ? { dueFrom: bounds.startMs, dueTo: bounds.endMs } : "skip"
   );
+  const habits = useQuery(
+    api.habits.list,
+    isAuthenticated && hasConvexUser ? {} : "skip",
+  );
+  const calendarEvents = useQuery(
+    api.calendar_events.listInRange,
+    isAuthenticated && hasConvexUser
+      ? { startMs: bounds.startMs, endMs: bounds.endMs }
+      : "skip",
+  );
 
   const isLoading =
     isAuthLoading ||
-    (isAuthenticated && (profile === undefined || (hasConvexUser && todayTasks === undefined)));
+    (isAuthenticated &&
+      (profile === undefined ||
+        (hasConvexUser &&
+          (todayTasks === undefined ||
+            habits === undefined ||
+            calendarEvents === undefined))));
 
   if (isLoading) {
     return (
@@ -52,7 +70,7 @@ export function TodayScreen() {
     return <TaskViewsScreen view="today" />;
   }
 
-  if (!profile || !todayTasks) {
+  if (!profile || !todayTasks || !habits || !calendarEvents) {
     return (
       <div className="container mx-auto max-w-5xl px-6 py-16 text-center">
         <SoftCard className="mx-auto max-w-xl">
@@ -73,6 +91,10 @@ export function TodayScreen() {
       <div className="space-y-8">
         <TodayGreeting greetingName={profile.greetingName} />
         <TodayBrainDumpPanel dueAt={bounds.endMs - 1} />
+        <div className="grid gap-6 xl:grid-cols-2">
+          <TodayAgenda events={mapCalendarEventsToAgenda(calendarEvents)} />
+          <TodayHabitStrip habits={habits} />
+        </div>
         <div className="grid gap-6 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)] xl:items-start">
           <TodayQuickAdd dueAt={bounds.endMs - 1} />
           <TodayTaskList tasks={todayTasks} />

--- a/apps/web/lib/todayAgenda.test.ts
+++ b/apps/web/lib/todayAgenda.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import {
   mapCalendarEventsToAgenda,
@@ -39,10 +41,11 @@ describe("visibleHabitsFrom", () => {
 });
 
 describe("TodayScreen leftover wiring", () => {
-  test("keeps energy recs and the unauth task-views path", async () => {
-    const source = await Bun.file(
-      "apps/web/components/today/TodayScreen.tsx",
-    ).text();
+  test("keeps energy recs and the unauth task-views path", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../components/today/TodayScreen.tsx"),
+      "utf8",
+    );
     expect(source).toContain("TodayAgenda");
     expect(source).toContain("TodayHabitStrip");
     expect(source).toContain("TodayEnergyRecommendations");

--- a/apps/web/lib/todayAgenda.test.ts
+++ b/apps/web/lib/todayAgenda.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+  mapCalendarEventsToAgenda,
+  visibleHabitsFrom,
+} from "./todayAgenda";
+
+describe("mapCalendarEventsToAgenda", () => {
+  test("sorts by start time and formats a label", () => {
+    const events = mapCalendarEventsToAgenda([
+      { _id: "later", title: "Walk", startsAtMs: 2_000 },
+      { _id: "earlier", title: "Tea", startsAtMs: 1_000 },
+    ]);
+
+    expect(events.map((event) => event.id)).toEqual(["earlier", "later"]);
+    expect(events[0]?.title).toBe("Tea");
+    expect(events[0]?.timeLabel.length).toBeGreaterThan(0);
+  });
+
+  test("empty input stays empty", () => {
+    expect(mapCalendarEventsToAgenda([])).toEqual([]);
+  });
+});
+
+describe("visibleHabitsFrom", () => {
+  test("keeps the first five and counts the rest", () => {
+    const habits = ["a", "b", "c", "d", "e", "f", "g"];
+    expect(visibleHabitsFrom(habits)).toEqual({
+      visible: ["a", "b", "c", "d", "e"],
+      hiddenCount: 2,
+    });
+  });
+
+  test("no overflow when the list is short", () => {
+    expect(visibleHabitsFrom(["one"])).toEqual({
+      visible: ["one"],
+      hiddenCount: 0,
+    });
+  });
+});
+
+describe("TodayScreen leftover wiring", () => {
+  test("keeps energy recs and the unauth task-views path", async () => {
+    const source = await Bun.file(
+      "apps/web/components/today/TodayScreen.tsx",
+    ).text();
+    expect(source).toContain("TodayAgenda");
+    expect(source).toContain("TodayHabitStrip");
+    expect(source).toContain("TodayEnergyRecommendations");
+    expect(source).toContain('view="today"');
+    expect(source).toContain("api.calendar_events.listInRange");
+    expect(source).toContain("api.habits.list");
+  });
+});

--- a/apps/web/lib/todayAgenda.ts
+++ b/apps/web/lib/todayAgenda.ts
@@ -1,0 +1,37 @@
+export type TodayAgendaEvent = {
+  id: string;
+  title: string;
+  timeLabel: string;
+};
+
+const agendaTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+export function formatAgendaTimeLabel(startsAtMs: number): string {
+  return agendaTimeFormatter.format(new Date(startsAtMs));
+}
+
+export function mapCalendarEventsToAgenda(
+  events: ReadonlyArray<{ _id: string; title: string; startsAtMs: number }>,
+): TodayAgendaEvent[] {
+  return events
+    .toSorted((left, right) => left.startsAtMs - right.startsAtMs)
+    .map((event) => ({
+      id: event._id,
+      title: event.title,
+      timeLabel: formatAgendaTimeLabel(event.startsAtMs),
+    }));
+}
+
+export function visibleHabitsFrom<T>(habits: readonly T[], limit = 5): {
+  visible: T[];
+  hiddenCount: number;
+} {
+  const visible = habits.slice(0, limit);
+  return {
+    visible,
+    hiddenCount: Math.max(habits.length - visible.length, 0),
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Port the leftover Today UI from #217 onto current `integration` APIs: a calendar agenda wired to `calendar_events.listInRange`, and a habit strip wired to `habits.list`. Energy recommendations and the unauthenticated `TaskViewsScreen` path stay in place. Habit chips link to `/habits` because there is no `/habits/[id]` route.

This does **not** take #217's `convex/tasks.ts` rewrite, Playwright today spec, todayBounds tweak, or lockfile. Leave #217 open until that leftover is judged separately.

Lint follow-up: the wiring test now reads `TodayScreen.tsx` via `node:fs` so Biome in `apps/web` does not fail on undeclared `Bun`.

## Linked task(s)

Original PR: #217 (FIX leftover). In-repo `docs/TASKS.md` has no T-XXXX for this slice. `docs/brain/TASKS.md` is a private submodule and is empty in this cloud clone.

## Screenshots / screen recording

Will attach after CI + browser verification of Today (signed-in agenda/strip empty states, energy recs still present).

## Test plan

- [x] Local `bun test apps/web/lib/todayAgenda.test.ts` — 5 pass
- [x] Local `bun run lint` in `apps/web` — pass after `node:fs` fix
- [ ] CI typecheck / lint / test / schema-guard / forbidden-tech
- [ ] Manual: Today signed-in shows agenda + habit strip + energy recs; unauth still uses TaskViewsScreen

## Acceptance criteria

- Today signed-in renders agenda events from `listInRange({startMs, endMs})` using `startsAtMs`
- Today signed-in renders up to 5 habits from `habits.list` with overflow count
- Empty states are shame-free and point to Calendar / Habits
- `TodayEnergyRecommendations` and unauth `view="today"` path remain
- No `convex/tasks.ts` rewrite, no Playwright, no lockfile

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] No AI-originated state mutations
- [x] No schema changes
- [x] Styling uses existing token/utility classes (no ad-hoc hex)
- [x] Keyboard/focus-visible on habit chips and empty-state links
- [x] No secrets
- [x] Voice rules honored — empty states are kind

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`). Low-risk UI leftover; mergeable after green CI.

## Skipped from #217 (do not close original on this land)

- `convex/tasks.ts` rewrite (~422 lines) — unique leftover vs landed task APIs
- Playwright `today.spec`
- todayBounds tweak
- lockfile / rgba shadows
- `/habits/[id]` links (no such route)

## Graph note

`docs/brain/` is empty in this clone (known-broken private submodule). Used landed `calendar_events` + `habits` APIs as ground truth instead of #217's older `startAt`/`endAt` / `habitCompletions` shapes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

