### PR TITLE
feat(habits): add energy suggestion accept/reject leftover from #171

### DIFF
--- a/apps/web/components/habits/HabitEnergySuggestions.tsx
+++ b/apps/web/components/habits/HabitEnergySuggestions.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useMutation } from "convex/react";
+import { Sparkles } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { Id } from "@/convex/_generated/dataModel";
+import { api } from "@/convex/_generated/api";
+import {
+  habitRoutineCopy,
+  resolveEnergySuggestion,
+  type EnergySuggestion,
+} from "@tempo/utils";
+
+type HabitEnergySource = {
+  _id: Id<"habits">;
+  name: string;
+  completedToday: boolean;
+};
+
+function suggestionsFromHabits(
+  habits: readonly HabitEnergySource[],
+): EnergySuggestion[] {
+  return habits
+    .filter((habit) => !habit.completedToday)
+    .slice(0, 3)
+    .map((habit) => ({
+      id: habit._id,
+      habitName: habit.name,
+      energy: "low",
+      title: `A gentle ${habit.name} step`,
+      body: "One small repeat is enough for now.",
+      status: "pending",
+    }));
+}
+
+export function HabitEnergySuggestions({
+  habits,
+}: {
+  habits: readonly HabitEnergySource[];
+}) {
+  const completeToday = useMutation(api.habits.completeToday);
+  const [suggestions, setSuggestions] = useState<EnergySuggestion[]>(() =>
+    suggestionsFromHabits(habits),
+  );
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  const pending = useMemo(
+    () => suggestions.filter((suggestion) => suggestion.status !== "rejected"),
+    [suggestions],
+  );
+
+  if (pending.length === 0) {
+    return null;
+  }
+
+  const accept = async (suggestionId: string) => {
+    setPendingId(suggestionId);
+    try {
+      await completeToday({ habitId: suggestionId as Id<"habits"> });
+      setSuggestions((current) =>
+        resolveEnergySuggestion(current, suggestionId, "accepted"),
+      );
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const reject = (suggestionId: string) => {
+    setSuggestions((current) =>
+      resolveEnergySuggestion(current, suggestionId, "rejected"),
+    );
+  };
+
+  return (
+    <section
+      className="rounded-3xl border border-border/80 bg-card/90 p-5"
+      aria-labelledby="habit-energy-heading"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <Sparkles className="h-5 w-5" aria-hidden />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2
+            id="habit-energy-heading"
+            className="font-heading text-xl font-semibold text-foreground"
+          >
+            Energy-aware suggestions
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {habitRoutineCopy.habits.suggestionPrompt}
+          </p>
+        </div>
+      </div>
+
+      <ul className="mt-5 space-y-3">
+        {pending.map((suggestion) => (
+          <li
+            key={suggestion.id}
+            className="rounded-2xl border border-border/70 bg-background/70 px-4 py-3"
+          >
+            <p className="font-medium text-foreground">{suggestion.title}</p>
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              {suggestion.body}
+            </p>
+            {suggestion.status === "accepted" ? (
+              <p className="mt-3 text-sm font-medium text-primary">
+                Added as today&apos;s check for {suggestion.habitName}.
+              </p>
+            ) : (
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  disabled={pendingId === suggestion.id}
+                  onClick={() => {
+                    void accept(suggestion.id);
+                  }}
+                  className="inline-flex min-h-11 items-center rounded-full border border-primary/30 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary transition hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-70"
+                >
+                  {habitRoutineCopy.habits.acceptLabel}
+                </button>
+                <button
+                  type="button"
+                  disabled={pendingId === suggestion.id}
+                  onClick={() => reject(suggestion.id)}
+                  className="inline-flex min-h-11 items-center rounded-full border border-border px-4 py-2 text-sm font-semibold text-foreground transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                >
+                  {habitRoutineCopy.habits.rejectLabel}
+                </button>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/components/habits/HabitsScreen.tsx
+++ b/apps/web/components/habits/HabitsScreen.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/convex/_generated/api";
 import { cn } from "@/lib/utils";
+import { HabitEnergySuggestions } from "./HabitEnergySuggestions";
 
 type HabitRowData = {
   _id: Id<"habits">;
@@ -194,6 +195,14 @@ export function HabitsScreen() {
       </header>
 
       <NewHabitForm />
+
+      <HabitEnergySuggestions
+        habits={habits.map((habit) => ({
+          _id: habit._id,
+          name: habit.name,
+          completedToday: isHabitCompletedOnUtcDay(habit.lastCompletedAt, now),
+        }))}
+      />
 
       {habits.length === 0 ? (
         <div className="rounded-3xl border border-border/80 bg-card/90 px-6 py-10 text-center">

--- a/apps/web/lib/habitCompletedToday.test.ts
+++ b/apps/web/lib/habitCompletedToday.test.ts
@@ -1,7 +1,20 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { isHabitCompletedOnUtcDay } from "../../../convex/lib/habitStreak";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("HabitsScreen leftover wiring", () => {
+  test("keeps energy suggestion accept/reject on the landed screen", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../components/habits/HabitsScreen.tsx"),
+      "utf8",
+    );
+    expect(source).toContain("HabitEnergySuggestions");
+    expect(source).toContain("isHabitCompletedOnUtcDay");
+  });
+});
 
 describe("HabitsScreen completedToday derivation", () => {
   test("matches the landed completeToday alreadyDone window", () => {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -26,6 +26,9 @@
       "@/convex/*": [
         "../../convex/*"
       ],
+      "@tempo/utils": [
+        "../../packages/utils/src/index.ts"
+      ],
       "@/*": [
         "./*"
       ]

--- a/packages/utils/src/habit-energy-suggestions.ts
+++ b/packages/utils/src/habit-energy-suggestions.ts
@@ -1,0 +1,59 @@
+export type EnergyLevel = "low" | "medium" | "high";
+export type EnergySuggestionStatus = "pending" | "accepted" | "rejected";
+
+export type EnergySuggestion = {
+  id: string;
+  habitName: string;
+  energy: EnergyLevel;
+  title: string;
+  body: string;
+  status?: EnergySuggestionStatus;
+};
+
+export const habitRoutineCopy = {
+  habits: {
+    title: "Habits",
+    summary: "Habit rings with weekly progress.",
+    mobileSummary: "Mobile habits with ring rows.",
+    suggestionPrompt: "Pick the habit that fits your energy right now.",
+    acceptLabel: "Add this gentle step",
+    rejectLabel: "Not for now",
+    emptyState:
+      "No habit rhythm here yet. Start with one tiny repeatable action.",
+  },
+  routines: {
+    title: "Routines",
+    summary: "Routine library.",
+    mobileSummary: "Mobile routines.",
+    suggestionPrompt: "Choose a routine that meets today's energy.",
+    acceptLabel: "Use this routine",
+    rejectLabel: "Leave it for later",
+    emptyState:
+      "No routine saved yet. A calm starter flow can begin with one step.",
+  },
+} as const;
+
+export function resolveEnergySuggestion(
+  suggestions: readonly EnergySuggestion[],
+  suggestionId: string,
+  status: Exclude<EnergySuggestionStatus, "pending">,
+): EnergySuggestion[] {
+  let found = false;
+  const resolved = suggestions.map((suggestion) => {
+    if (suggestion.id !== suggestionId) {
+      return suggestion;
+    }
+
+    found = true;
+    return {
+      ...suggestion,
+      status,
+    };
+  });
+
+  if (!found) {
+    throw new Error("Suggestion not found");
+  }
+
+  return resolved;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,6 +10,14 @@ export {
   getBreathPhaseAt,
 } from "./breathwork";
 
+export {
+  type EnergyLevel,
+  type EnergySuggestion,
+  type EnergySuggestionStatus,
+  habitRoutineCopy,
+  resolveEnergySuggestion,
+} from "./habit-energy-suggestions";
+
 /**
  * Format a Unix timestamp (ms) to a locale date string
  */

--- a/tests/unit/habit_energy_suggestions.test.ts
+++ b/tests/unit/habit_energy_suggestions.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import {
+  habitRoutineCopy,
+  resolveEnergySuggestion,
+  type EnergySuggestion,
+} from "../../packages/utils/src/habit-energy-suggestions";
+
+const shameBasedPhrases = [
+  /\bbehind\b/i,
+  /\bbroken\b/i,
+  /\bfailed?\b/i,
+  /\bfailing\b/i,
+  /\blazy\b/i,
+  /\bmust\b/i,
+  /\bshould\b/i,
+  /\bstreak broken\b/i,
+  /\byou missed\b/i,
+  /\byou need to\b/i,
+  /\bwhat'?s wrong\b/i,
+];
+
+function collectCopy(
+  value: unknown,
+  path: string,
+  rows: Array<{ path: string; text: string }>,
+) {
+  if (typeof value === "string") {
+    rows.push({ path, text: value });
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      collectCopy(item, `${path}[${index}]`, rows);
+    });
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      collectCopy(child, `${path}.${key}`, rows);
+    }
+  }
+}
+
+describe("energy-aware habit suggestions", () => {
+  const suggestion: EnergySuggestion = {
+    id: "low-energy-water",
+    habitName: "Drink water",
+    energy: "low",
+    title: "Try a gentle water reset",
+    body: "A small sip can count. Keep it light.",
+  };
+
+  test("accepting a suggestion returns accepted state without mutating the original", () => {
+    const suggestions = [suggestion];
+
+    const resolved = resolveEnergySuggestion(
+      suggestions,
+      suggestion.id,
+      "accepted",
+    );
+
+    expect(resolved).toEqual([
+      {
+        ...suggestion,
+        status: "accepted",
+      },
+    ]);
+    expect(suggestions).toEqual([suggestion]);
+  });
+
+  test("rejecting a suggestion keeps the item visible as rejected without breaking state", () => {
+    const suggestions = [{ ...suggestion, status: "pending" as const }];
+
+    const resolved = resolveEnergySuggestion(
+      suggestions,
+      suggestion.id,
+      "rejected",
+    );
+
+    expect(resolved[0]).toEqual({
+      ...suggestion,
+      status: "rejected",
+    });
+  });
+
+  test("throws a clear error when resolving an unknown suggestion", () => {
+    expect(() =>
+      resolveEnergySuggestion([suggestion], "missing", "accepted"),
+    ).toThrow(/Suggestion not found/i);
+  });
+});
+
+describe("habit and routine brand voice", () => {
+  test("habit/routine copy avoids shame-based phrasing", () => {
+    const rows: Array<{ path: string; text: string }> = [];
+    collectCopy(habitRoutineCopy, "habitRoutineCopy", rows);
+
+    expect(rows.length).toBeGreaterThan(0);
+
+    const violations = rows.flatMap(({ path, text }) =>
+      shameBasedPhrases
+        .filter((phrase) => phrase.test(text))
+        .map((phrase) => `${path}: ${phrase} matched "${text}"`),
+    );
+
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Port the unique leftover from #171: `resolveEnergySuggestion` plus shame-free habit/routine copy. Wire accept / reject onto the landed `HabitsScreen` (accept calls `habits.completeToday`; reject is local). Nothing applies without a click.

Skip #171's scaffold copy swaps on mobile habits/routines and web routines — those would overwrite #369 empty states, #354 breathwork, and #370 HabitsScreen. Skip lockfile / package.json.

## Linked task(s)

Original PR: #171 (FIX leftover). In-repo `docs/TASKS.md` has no T-XXXX for this slice. `docs/brain/TASKS.md` is empty in this cloud clone.

## Screenshots / screen recording

Will attach after green CI if the preview is reachable without Vercel SSO.

## Test plan

- [x] Local `bun test convex apps/web/lib tests/unit` — 192 pass
- [x] Local `apps/web` and `packages/utils` biome lint
- [x] Local `apps/web` typecheck
- [ ] CI typecheck / lint / test / scans

## Acceptance criteria

- Accept / reject is an explicit user click (HARD_RULES §1)
- `resolveEnergySuggestion` does not mutate the input list
- Copy stays shame-free
- Landed HabitsScreen, breathwork routines, and mobile empty states are not overwritten

## HARD_RULES compliance checklist

- [x] No forbidden tech
- [x] AI-originated habit complete is previewed as a suggestion card with accept / reject
- [x] No schema changes
- [x] Existing token/utility classes
- [x] Keyboard/focus-visible on accept/reject
- [x] No secrets
- [x] Voice rules honored

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`). Low-risk leftover; mergeable after green CI.

## Skipped from #171

- Mobile `habits.tsx` / `routines.tsx` scaffold copy (would overwrite #369 / #354)
- Web `habits/page.tsx` scaffold (already `HabitsScreen` from #370)
- Web `routines/page.tsx` scaffold
- `package.json` / `bun.lock`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

