### PR TITLE
feat(calendar): gate auto-schedule behind accept/reject leftover from #173 [DO NOT MERGE]

### DIFF
--- a/convex/calendar_events.ts
+++ b/convex/calendar_events.ts
@@ -1,5 +1,10 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
+import {
+  confirmAutoScheduleProposal,
+  createAutoScheduleProposalOnly,
+  rejectAutoScheduleProposal,
+} from "./lib/autoScheduleGate";
 import { requireUser } from "./lib/requireUser";
 
 const maxCalendarRangeMs = 32 * 24 * 60 * 60 * 1000;
@@ -64,5 +69,120 @@ export const create = mutation({
       createdAt: now,
       updatedAt: now,
     });
+  },
+});
+
+const autoScheduleProposalStatusValidator = v.union(
+  v.literal("pending"),
+  v.literal("accepted"),
+  v.literal("rejected"),
+);
+
+const autoScheduleProposalReturnValidator = v.object({
+  _id: v.id("autoScheduleProposals"),
+  _creationTime: v.number(),
+  userId: v.id("users"),
+  taskId: v.id("tasks"),
+  status: autoScheduleProposalStatusValidator,
+  title: v.string(),
+  description: v.optional(v.string()),
+  proposedStartAt: v.number(),
+  proposedEndAt: v.number(),
+  durationMinutes: v.number(),
+  reason: v.string(),
+  calendarEventId: v.optional(v.id("calendarEvents")),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+  deletedAt: v.optional(v.number()),
+});
+
+export const listAutoScheduleProposals = query({
+  args: {
+    status: v.optional(autoScheduleProposalStatusValidator),
+  },
+  returns: v.array(autoScheduleProposalReturnValidator),
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const status = args.status;
+    if (status !== undefined) {
+      return await ctx.db
+        .query("autoScheduleProposals")
+        .withIndex("by_userId_status_deletedAt", (q) =>
+          q.eq("userId", user._id).eq("status", status).eq("deletedAt", undefined),
+        )
+        .collect();
+    }
+
+    return await ctx.db
+      .query("autoScheduleProposals")
+      .withIndex("by_userId_deletedAt", (q) => q.eq("userId", user._id).eq("deletedAt", undefined))
+      .collect();
+  },
+});
+
+export const proposeAutoSchedule = mutation({
+  args: {
+    taskId: v.id("tasks"),
+    preferredStartAt: v.optional(v.number()),
+    dayStartAt: v.optional(v.number()),
+    durationMinutes: v.optional(v.number()),
+  },
+  returns: v.id("autoScheduleProposals"),
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const task = await ctx.db.get(args.taskId);
+    if (!task) {
+      throw new Error("Task not found");
+    }
+
+    return await createAutoScheduleProposalOnly(
+      ctx.db,
+      task,
+      user._id,
+      {
+        preferredStartAt: args.preferredStartAt,
+        dayStartAt: args.dayStartAt,
+        durationMinutes: args.durationMinutes,
+      },
+      Date.now(),
+    );
+  },
+});
+
+export const confirmAutoSchedule = mutation({
+  args: {
+    proposalId: v.id("autoScheduleProposals"),
+  },
+  returns: v.id("calendarEvents"),
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const proposal = await ctx.db.get(args.proposalId);
+    if (!proposal) {
+      throw new Error("Auto-schedule proposal not found");
+    }
+
+    const task = await ctx.db.get(proposal.taskId);
+    if (!task) {
+      throw new Error("Task not found");
+    }
+
+    return await confirmAutoScheduleProposal(ctx.db, proposal, task, user._id, Date.now());
+  },
+});
+
+export const rejectAutoSchedule = mutation({
+  args: {
+    proposalId: v.id("autoScheduleProposals"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const proposal = await ctx.db.get(args.proposalId);
+    if (!proposal) {
+      throw new Error("Auto-schedule proposal not found");
+    }
+
+    await rejectAutoScheduleProposal(ctx.db, proposal, user._id, Date.now());
+    return null;
   },
 });

--- a/convex/lib/accountDeletion.test.ts
+++ b/convex/lib/accountDeletion.test.ts
@@ -17,6 +17,7 @@ describe("USER_OWNED_TABLES", () => {
   test("covers current user-owned schema tables with by_userId", () => {
     expect([...USER_OWNED_TABLES].sort()).toEqual(
       [
+        "autoScheduleProposals",
         "calendarEvents",
         "goals",
         "habits",

--- a/convex/lib/accountDeletion.ts
+++ b/convex/lib/accountDeletion.ts
@@ -10,6 +10,7 @@ export const USER_OWNED_TABLES = [
   "memories",
   "calendarEvents",
   "taskRepeatCfgs",
+  "autoScheduleProposals",
 ] as const;
 
 type UserOwnedTable = (typeof USER_OWNED_TABLES)[number];

--- a/convex/lib/autoScheduleGate.ts
+++ b/convex/lib/autoScheduleGate.ts
@@ -1,0 +1,183 @@
+import type { Doc, Id } from "../_generated/dataModel";
+
+const DEFAULT_AUTO_SCHEDULE_DURATION_MINUTES = 30;
+const MAX_AUTO_SCHEDULE_DURATION_MINUTES = 12 * 60;
+const MS_PER_MINUTE = 60_000;
+
+export type AutoScheduleProposalInsert = {
+  userId: Id<"users">;
+  taskId: Id<"tasks">;
+  status: "pending";
+  title: string;
+  description?: string;
+  proposedStartAt: number;
+  proposedEndAt: number;
+  durationMinutes: number;
+  reason: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+/** Landed calendarEvents shape — title + startsAtMs only. */
+export type CalendarEventInsert = {
+  userId: Id<"users">;
+  title: string;
+  startsAtMs: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type AutoScheduleAcceptPatch = {
+  status: "accepted";
+  calendarEventId: Id<"calendarEvents">;
+  updatedAt: number;
+};
+
+export type AutoScheduleRejectPatch = {
+  status: "rejected";
+  updatedAt: number;
+};
+
+export type AutoScheduleProposalPatch = AutoScheduleAcceptPatch | AutoScheduleRejectPatch;
+
+export type AutoScheduleGateDb = {
+  insert(
+    table: "autoScheduleProposals",
+    doc: AutoScheduleProposalInsert,
+  ): Promise<Id<"autoScheduleProposals">>;
+  insert(table: "calendarEvents", doc: CalendarEventInsert): Promise<Id<"calendarEvents">>;
+  patch(id: Id<"autoScheduleProposals">, patch: AutoScheduleProposalPatch): Promise<void>;
+};
+
+export type AutoSchedulePlacementArgs = {
+  preferredStartAt?: number;
+  dayStartAt?: number;
+  durationMinutes?: number;
+};
+
+function assertPositiveTimestamp(value: number, label: string) {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${label} must be a valid future time.`);
+  }
+}
+
+function normalizeDurationMinutes(durationMinutes: number | undefined) {
+  const duration = durationMinutes ?? DEFAULT_AUTO_SCHEDULE_DURATION_MINUTES;
+  if (
+    !Number.isFinite(duration) ||
+    !Number.isInteger(duration) ||
+    duration <= 0 ||
+    duration > MAX_AUTO_SCHEDULE_DURATION_MINUTES
+  ) {
+    throw new Error("Duration must be between 1 minute and 12 hours.");
+  }
+  return duration;
+}
+
+export function buildAutoScheduleProposalInsert(
+  task: Doc<"tasks">,
+  userId: Id<"users">,
+  args: AutoSchedulePlacementArgs,
+  now: number,
+): AutoScheduleProposalInsert {
+  if (task.userId !== userId || task.deletedAt !== undefined) {
+    throw new Error("Task not found");
+  }
+  if (task.status === "cancelled") {
+    throw new Error("Cancelled tasks cannot be auto-scheduled.");
+  }
+
+  const durationMinutes = normalizeDurationMinutes(args.durationMinutes);
+  const proposedStartAt = args.preferredStartAt ?? task.dueAt ?? args.dayStartAt ?? now;
+  assertPositiveTimestamp(proposedStartAt, "Proposed start");
+  const proposedEndAt = proposedStartAt + durationMinutes * MS_PER_MINUTE;
+
+  return {
+    userId,
+    taskId: task._id,
+    status: "pending",
+    title: task.title,
+    description: task.description,
+    proposedStartAt,
+    proposedEndAt,
+    durationMinutes,
+    reason:
+      task.dueAt === proposedStartAt
+        ? "Uses the task's due time as the suggested calendar slot."
+        : "Suggests the requested calendar slot for this task.",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export async function createAutoScheduleProposalOnly(
+  db: AutoScheduleGateDb,
+  task: Doc<"tasks">,
+  userId: Id<"users">,
+  args: AutoSchedulePlacementArgs,
+  now: number,
+) {
+  const proposal = buildAutoScheduleProposalInsert(task, userId, args, now);
+  return await db.insert("autoScheduleProposals", proposal);
+}
+
+export function buildCalendarEventInsertFromProposal(
+  proposal: Doc<"autoScheduleProposals">,
+  task: Doc<"tasks">,
+  userId: Id<"users">,
+  now: number,
+): CalendarEventInsert {
+  if (proposal.userId !== userId || proposal.deletedAt !== undefined) {
+    throw new Error("Auto-schedule proposal not found");
+  }
+  if (task.userId !== userId || task._id !== proposal.taskId || task.deletedAt !== undefined) {
+    throw new Error("Task not found");
+  }
+  if (proposal.status !== "pending") {
+    throw new Error("Auto-schedule proposal was already handled.");
+  }
+
+  return {
+    userId,
+    title: proposal.title,
+    startsAtMs: proposal.proposedStartAt,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export async function confirmAutoScheduleProposal(
+  db: AutoScheduleGateDb,
+  proposal: Doc<"autoScheduleProposals">,
+  task: Doc<"tasks">,
+  userId: Id<"users">,
+  now: number,
+) {
+  const event = buildCalendarEventInsertFromProposal(proposal, task, userId, now);
+  const calendarEventId = await db.insert("calendarEvents", event);
+  await db.patch(proposal._id, {
+    status: "accepted",
+    calendarEventId,
+    updatedAt: now,
+  });
+  return calendarEventId;
+}
+
+export async function rejectAutoScheduleProposal(
+  db: AutoScheduleGateDb,
+  proposal: Doc<"autoScheduleProposals">,
+  userId: Id<"users">,
+  now: number,
+) {
+  if (proposal.userId !== userId || proposal.deletedAt !== undefined) {
+    throw new Error("Auto-schedule proposal not found");
+  }
+  if (proposal.status !== "pending") {
+    throw new Error("Auto-schedule proposal was already handled.");
+  }
+
+  await db.patch(proposal._id, {
+    status: "rejected",
+    updatedAt: now,
+  });
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -213,6 +213,30 @@ export default defineSchema({
     .index("by_userId_deletedAt_startsAtMs", ["userId", "deletedAt", "startsAtMs"])
     .index("by_userId_deletedAt", ["userId", "deletedAt"]),
 
+  /**
+   * Accept/reject gate for task-to-calendar auto-schedule. Propose writes
+   * this row only; confirm writes a landed calendarEvents row (startsAtMs).
+   */
+  autoScheduleProposals: defineTable({
+    userId: v.id("users"),
+    taskId: v.id("tasks"),
+    status: v.union(v.literal("pending"), v.literal("accepted"), v.literal("rejected")),
+    title: v.string(),
+    description: v.optional(v.string()),
+    proposedStartAt: v.number(),
+    proposedEndAt: v.number(),
+    durationMinutes: v.number(),
+    reason: v.string(),
+    calendarEventId: v.optional(v.id("calendarEvents")),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    deletedAt: v.optional(v.number()),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_userId_status_deletedAt", ["userId", "status", "deletedAt"])
+    .index("by_taskId_status_deletedAt", ["taskId", "status", "deletedAt"])
+    .index("by_userId_deletedAt", ["userId", "deletedAt"]),
+
   notes: defineTable({
     userId: v.id("users"),
     title: v.string(),

--- a/tests/unit/auto_schedule_gate.test.ts
+++ b/tests/unit/auto_schedule_gate.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import type { Doc, Id, TableNames } from "../../convex/_generated/dataModel";
+import {
+  type AutoScheduleGateDb,
+  type AutoScheduleProposalInsert,
+  type AutoScheduleProposalPatch,
+  type CalendarEventInsert,
+  confirmAutoScheduleProposal,
+  createAutoScheduleProposalOnly,
+  rejectAutoScheduleProposal,
+} from "../../convex/lib/autoScheduleGate";
+
+type InsertRecord =
+  | { table: "autoScheduleProposals"; doc: AutoScheduleProposalInsert }
+  | { table: "calendarEvents"; doc: CalendarEventInsert };
+
+function id<TableName extends TableNames>(value: string) {
+  return value as Id<TableName>;
+}
+
+const userId = id<"users">("users:alice");
+const taskId = id<"tasks">("tasks:pay-rent");
+const proposalId = id<"autoScheduleProposals">("autoScheduleProposals:proposal-1");
+const calendarEventId = id<"calendarEvents">("calendarEvents:event-1");
+
+function task(overrides: Partial<Doc<"tasks">> = {}): Doc<"tasks"> {
+  return {
+    _id: taskId,
+    _creationTime: 1,
+    userId,
+    title: "Pay rent",
+    description: "Before the end of the day",
+    status: "todo",
+    priority: "high",
+    dueAt: 1_800_000,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+function pendingProposal(overrides: Partial<Doc<"autoScheduleProposals">> = {}) {
+  return {
+    _id: proposalId,
+    _creationTime: 2,
+    userId,
+    taskId,
+    status: "pending",
+    title: "Pay rent",
+    description: "Before the end of the day",
+    proposedStartAt: 1_800_000,
+    proposedEndAt: 3_600_000,
+    durationMinutes: 30,
+    reason: "Uses the task's due time as the suggested calendar slot.",
+    createdAt: 10,
+    updatedAt: 10,
+    ...overrides,
+  } satisfies Doc<"autoScheduleProposals">;
+}
+
+class FakeGateDb implements AutoScheduleGateDb {
+  readonly inserts: InsertRecord[] = [];
+  readonly patches: Array<{ id: Id<"autoScheduleProposals">; patch: AutoScheduleProposalPatch }> =
+    [];
+
+  async insert(
+    table: "autoScheduleProposals",
+    doc: AutoScheduleProposalInsert,
+  ): Promise<Id<"autoScheduleProposals">>;
+  async insert(table: "calendarEvents", doc: CalendarEventInsert): Promise<Id<"calendarEvents">>;
+  async insert(
+    table: "autoScheduleProposals" | "calendarEvents",
+    doc: AutoScheduleProposalInsert | CalendarEventInsert,
+  ): Promise<Id<"autoScheduleProposals"> | Id<"calendarEvents">> {
+    if (table === "autoScheduleProposals") {
+      this.inserts.push({ table, doc: doc as AutoScheduleProposalInsert });
+      return proposalId;
+    }
+
+    this.inserts.push({ table, doc: doc as CalendarEventInsert });
+    return calendarEventId;
+  }
+
+  async patch(idToPatch: Id<"autoScheduleProposals">, patch: AutoScheduleProposalPatch) {
+    this.patches.push({ id: idToPatch, patch });
+  }
+}
+
+describe("auto-schedule proposal gate", () => {
+  test("auto-schedule creates only a pending proposal", async () => {
+    const db = new FakeGateDb();
+
+    const result = await createAutoScheduleProposalOnly(
+      db,
+      task(),
+      userId,
+      { preferredStartAt: 7_200_000, durationMinutes: 45 },
+      1_000,
+    );
+
+    expect(result).toBe(proposalId);
+    expect(db.inserts).toHaveLength(1);
+    expect(db.patches).toHaveLength(0);
+    expect(db.inserts[0]?.table).toBe("autoScheduleProposals");
+    expect(db.inserts.some((insert) => insert.table === "calendarEvents")).toBe(false);
+
+    const proposal = db.inserts[0];
+    expect(proposal?.doc).toMatchObject({
+      userId,
+      taskId,
+      status: "pending",
+      title: "Pay rent",
+      proposedStartAt: 7_200_000,
+      proposedEndAt: 9_900_000,
+      durationMinutes: 45,
+    });
+  });
+
+  test("confirmation writes a landed startsAtMs event and marks the proposal accepted", async () => {
+    const db = new FakeGateDb();
+
+    const result = await confirmAutoScheduleProposal(db, pendingProposal(), task(), userId, 5_000);
+
+    expect(result).toBe(calendarEventId);
+    expect(db.inserts).toHaveLength(1);
+    expect(db.inserts[0]).toEqual({
+      table: "calendarEvents",
+      doc: {
+        userId,
+        title: "Pay rent",
+        startsAtMs: 1_800_000,
+        createdAt: 5_000,
+        updatedAt: 5_000,
+      },
+    });
+    expect(db.patches).toEqual([
+      {
+        id: proposalId,
+        patch: {
+          status: "accepted",
+          calendarEventId,
+          updatedAt: 5_000,
+        },
+      },
+    ]);
+  });
+
+  test("reject marks the proposal rejected without writing a calendar event", async () => {
+    const db = new FakeGateDb();
+
+    await rejectAutoScheduleProposal(db, pendingProposal(), userId, 5_000);
+
+    expect(db.inserts).toHaveLength(0);
+    expect(db.patches).toEqual([
+      {
+        id: proposalId,
+        patch: {
+          status: "rejected",
+          updatedAt: 5_000,
+        },
+      },
+    ]);
+  });
+
+  test("handled proposals cannot be confirmed again", async () => {
+    const db = new FakeGateDb();
+
+    await expect(
+      confirmAutoScheduleProposal(
+        db,
+        pendingProposal({ status: "accepted", calendarEventId }),
+        task(),
+        userId,
+        5_000,
+      ),
+    ).rejects.toThrow(/already handled/i);
+    expect(db.inserts).toHaveLength(0);
+    expect(db.patches).toHaveLength(0);
+  });
+
+  test("cancelled tasks cannot be auto-scheduled", async () => {
+    const db = new FakeGateDb();
+
+    await expect(
+      createAutoScheduleProposalOnly(db, task({ status: "cancelled" }), userId, {}, 1_000),
+    ).rejects.toThrow(/cancelled/i);
+    expect(db.inserts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Port of the #173 leftover: auto-schedule is proposal-gated. `proposeAutoSchedule` writes an `autoScheduleProposals` row only. `confirmAutoSchedule` writes a **landed** `calendarEvents` row (`title` + `startsAtMs`). `rejectAutoSchedule` marks the proposal handled with no calendar write.

This PR also adds `autoScheduleProposals` to `USER_OWNED_TABLES` so account deletion covers the new table. That is why this stays **draft / DO NOT MERGE** — account-deletion adjacent, needs Amit's eyes. Auto-arm must not land it.

## Linked task(s)

Task: leftover from #173 (TEMPO-150 / T-006c). `docs/brain/` is a private submodule and is empty in this cloud clone — I did not invent a T-XXXX.

## Screenshots / screen recording

N/A — no user-visible surface. Gate is Convex + unit tests.

## Test plan

- [x] Local `bun test tests/unit/auto_schedule_gate.test.ts convex/lib/accountDeletion.test.ts` — 8 pass
- [x] Local `bun run test` — 197 pass
- [x] Local `bunx biome lint` on edited files — clean
- [x] `bun run scan:forbidden-tech` / `scan:ram-only-audit` / `scan:design-tokens` — OK
- [ ] CI green on this draft (waiting)

## Acceptance criteria

Auto-schedule generates a proposal only; no calendar event is written until the user confirms. Reject leaves no event. Confirm writes landed `{ userId, title, startsAtMs, createdAt, updatedAt }` — not the original #173 `startAt`/`endAt`/`taskId`/`source` rewrite.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). Gate mutations exist; no UI card in this leftover.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). New table has `deletedAt` + `by_userId`.
- [x] Styling uses design tokens from `packages/ui` — N/A backend-only.
- [x] Accessibility — N/A backend-only.
- [x] No secrets committed; no new env vars.
- [x] Voice rules honored — error copy stays concrete, not shaming.

## Owner tag (§14)

- [ ] `cursor-ide`
- [x] `cursor-cloud-1`
- [ ] `cursor-cloud-2`
- [ ] `cursor-cloud-3`
- [ ] `twin`
- [ ] `pokee`
- [ ] `zo`
- [ ] `human-amit`

## Reviewer

Amit (`human-amit`). **Do not merge. Do not mark ready.** Account-deletion coverage changed.

## What this PR skipped from #173

- New `convex/calendar.ts` module (would miss committed `api.d.ts`)
- Rewrite of landed `calendarEvents` to `startAt`/`endAt`/`taskId`/`source`
- Edits to `convex/_generated/api.d.ts`
- `coach.ts` / `ai_router.ts` nits
- `tsconfig.json` add

Original #173 stays OPEN until this leftover is judged.

## Graph vs ticket

Landed calendar API is `calendar_events` + `startsAtMs`. The ticket/PR described `calendar.ts` + `startAt`/`endAt`. The graph (and current schema) wins — this port follows landed shape.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

