### PR TITLE
feat(history): add conversation history leftover from #210

### DIFF
--- a/apps/web/app/(tempo)/history/page.tsx
+++ b/apps/web/app/(tempo)/history/page.tsx
@@ -1,0 +1,13 @@
+/**
+ * @screen: history
+ * @category: You
+ * @summary: Reopen past companion conversations.
+ * @queries: conversations.list, conversations.get, messages.list
+ * @mutations: (none)
+ * @auth: required (gentle sign-in card otherwise)
+ */
+import { HistoryScreen } from "@/components/history/HistoryScreen";
+
+export default function Page() {
+  return <HistoryScreen />;
+}

--- a/apps/web/components/history/HistoryScreen.tsx
+++ b/apps/web/components/history/HistoryScreen.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { CoachBubble, Pill } from "@tempo/ui/primitives";
+import { useConvexAuth, useQuery } from "convex/react";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { SoftCard } from "@/components/soft-editorial/SoftCard";
+import { Button } from "@/components/ui/button";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import {
+  companionNameFromTechnique,
+  filterHistoryConversations,
+  formatHistoryDate,
+  getConversationPreview,
+  isLiveConversation,
+  type HistoryConversation,
+  type HistoryMessage,
+} from "@/lib/conversationHistory";
+
+export function HistoryScreen() {
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const profile = useQuery(api.users.getProfile, isAuthenticated ? {} : "skip");
+  const hasConvexUser = profile != null;
+  const conversations = useQuery(
+    api.conversations.list,
+    isAuthenticated && hasConvexUser ? {} : "skip",
+  );
+  const [query, setQuery] = useState("");
+  const [selectedConversationId, setSelectedConversationId] = useState<
+    Id<"conversations"> | null
+  >(null);
+
+  const liveConversations = useMemo(
+    () => (conversations ?? []).filter(isLiveConversation),
+    [conversations],
+  );
+
+  useEffect(() => {
+    if (selectedConversationId !== null) {
+      return;
+    }
+    const first = liveConversations[0];
+    if (first) {
+      setSelectedConversationId(first._id);
+    }
+  }, [liveConversations, selectedConversationId]);
+
+  const selectedConversation = useQuery(
+    api.conversations.get,
+    selectedConversationId ? { conversationId: selectedConversationId } : "skip",
+  );
+  const selectedMessages = useQuery(
+    api.messages.list,
+    selectedConversationId ? { conversationId: selectedConversationId } : "skip",
+  );
+
+  const historyConversations = useMemo((): HistoryConversation[] => {
+    return liveConversations.map((conversation) => {
+      const isSelected = conversation._id === selectedConversationId;
+      const messages: HistoryMessage[] = isSelected
+        ? (selectedMessages ?? []).map((message) => ({
+            id: message._id,
+            conversationId: message.conversationId,
+            role: message.role,
+            content: message.content,
+            createdAt: message.createdAt,
+          }))
+        : [];
+
+      return {
+        id: conversation._id,
+        title: conversation.title,
+        companionName: companionNameFromTechnique(conversation.technique),
+        createdAt: conversation.createdAt,
+        updatedAt: conversation.updatedAt,
+        messages,
+      };
+    });
+  }, [liveConversations, selectedConversationId, selectedMessages]);
+
+  const filteredConversations = useMemo(
+    () => filterHistoryConversations(historyConversations, query),
+    [historyConversations, query],
+  );
+
+  const isLoading =
+    isAuthLoading ||
+    (isAuthenticated &&
+      (profile === undefined || (hasConvexUser && conversations === undefined)));
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto max-w-6xl px-6 py-12">
+        <div className="space-y-6">
+          <div className="h-12 w-64 animate-pulse rounded-xl bg-muted" />
+          <div className="grid gap-6 lg:grid-cols-[minmax(18rem,0.9fr)_minmax(0,1.4fr)]">
+            <div className="h-[28rem] animate-pulse rounded-2xl bg-muted" />
+            <div className="h-[28rem] animate-pulse rounded-2xl bg-muted" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated || !profile || !conversations) {
+    return (
+      <div className="container mx-auto max-w-5xl px-6 py-16 text-center">
+        <SoftCard className="mx-auto max-w-xl">
+          <h1 className="font-heading text-2xl font-semibold text-foreground">
+            Conversation history
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            Sign in to reopen chats you already had. Nothing here is shared.
+          </p>
+          <Button asChild className="mt-6">
+            <Link href="/sign-in?next=/history">Sign in</Link>
+          </Button>
+        </SoftCard>
+      </div>
+    );
+  }
+
+  if (liveConversations.length === 0) {
+    return (
+      <div className="container mx-auto max-w-5xl px-6 py-16 text-center">
+        <SoftCard className="mx-auto max-w-2xl">
+          <h1 className="font-heading text-3xl font-semibold text-foreground">
+            No past conversations yet
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            When you chat with a companion, this page becomes a calm shelf for
+            returning to what you already explored.
+          </p>
+          <Button asChild className="mt-6">
+            <Link href="/coach">Start a companion chat</Link>
+          </Button>
+        </SoftCard>
+      </div>
+    );
+  }
+
+  const locallySelected = selectedConversationId
+    ? liveConversations.find((conversation) => conversation._id === selectedConversationId)
+    : undefined;
+  const activeConversation =
+    (selectedConversation && isLiveConversation(selectedConversation)
+      ? selectedConversation
+      : undefined) ??
+    locallySelected ??
+    liveConversations[0];
+  const activeId = activeConversation._id;
+  const activeMessages =
+    selectedConversationId === activeId ? (selectedMessages ?? []) : [];
+  const activeCompanion = companionNameFromTechnique(activeConversation.technique);
+  const activeHistory = filteredConversations.find((row) => row.id === activeId);
+
+  return (
+    <div className="container mx-auto max-w-6xl px-6 py-12">
+      <div className="space-y-8">
+        <header className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+          <div>
+            <div className="flex flex-wrap items-center gap-2">
+              <Pill tone="slate">Conversation history</Pill>
+              <Pill tone="orange">{liveConversations.length} saved threads</Pill>
+            </div>
+            <h1 className="mt-4 font-heading text-3xl font-semibold text-foreground">
+              Pick up a conversation where you left it
+            </h1>
+            <p className="mt-2 max-w-2xl text-muted-foreground">
+              Browse past companion chats and reopen a thread. Nothing here
+              changes your account.
+            </p>
+          </div>
+          <label className="flex min-w-full flex-col gap-2 lg:min-w-[20rem]" htmlFor="history-search">
+            <span className="text-sm font-medium text-foreground">Search conversations</span>
+            <input
+              id="history-search"
+              value={query}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+              placeholder="Try a companion name or a thread title"
+              className="h-12 rounded-2xl border border-border bg-card px-4 text-base text-foreground outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20"
+              type="search"
+            />
+          </label>
+        </header>
+
+        <section className="grid min-h-[28rem] gap-6 lg:grid-cols-[minmax(18rem,0.9fr)_minmax(0,1.4fr)]">
+          <SoftCard className="p-0">
+            <div className="border-b border-border px-6 py-4">
+              <h2 className="font-heading text-xl font-semibold text-foreground">Threads</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {filteredConversations.length} of {liveConversations.length} shown
+              </p>
+            </div>
+            {filteredConversations.length > 0 ? (
+              <section className="max-h-[36rem] space-y-2 overflow-y-auto p-3" aria-label="Conversation results">
+                {filteredConversations.map((conversation) => {
+                  const isSelected = activeId === conversation.id;
+                  return (
+                    <button
+                      key={conversation.id}
+                      type="button"
+                      aria-pressed={isSelected}
+                      className={[
+                        "w-full rounded-2xl border px-4 py-3 text-left transition",
+                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+                        isSelected
+                          ? "border-primary bg-primary/10"
+                          : "border-transparent hover:border-border hover:bg-muted/40",
+                      ].join(" ")}
+                      onClick={() => {
+                        setSelectedConversationId(conversation.id as Id<"conversations">);
+                      }}
+                    >
+                      <span className="block font-medium text-foreground">{conversation.title}</span>
+                      <span className="mt-2 flex flex-wrap items-center gap-2">
+                        <Pill tone="neutral">{conversation.companionName}</Pill>
+                        {conversation.matchingMessageCount > 0 ? (
+                          <Pill tone="moss">{conversation.matchingMessageCount} message matches</Pill>
+                        ) : null}
+                      </span>
+                      <span className="mt-3 line-clamp-2 block text-sm text-muted-foreground">
+                        {getConversationPreview(conversation.messages)}
+                      </span>
+                      <span className="mt-3 block text-xs text-muted-foreground">
+                        Updated {formatHistoryDate(conversation.updatedAt)}
+                      </span>
+                    </button>
+                  );
+                })}
+              </section>
+            ) : (
+              <div className="p-6">
+                <p className="font-heading text-lg font-semibold text-foreground">
+                  No matching threads yet
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Try a companion name or a shorter phrase from the title.
+                </p>
+              </div>
+            )}
+          </SoftCard>
+
+          <SoftCard className="p-0">
+            <div className="border-b border-border px-6 py-4">
+              <Pill tone="slate">{activeCompanion}</Pill>
+              <h2 className="mt-3 font-heading text-xl font-semibold text-foreground">
+                {activeConversation.title}
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Updated {formatHistoryDate(activeConversation.updatedAt)}
+                {activeHistory ? ` · ${activeHistory.messages.length} messages loaded` : null}
+              </p>
+            </div>
+            <div
+              className="flex max-h-[36rem] flex-col gap-4 overflow-y-auto px-6 py-5"
+              role="log"
+              aria-label={`Messages for ${activeConversation.title}`}
+            >
+              {selectedConversationId !== activeId ? (
+                <p className="text-sm text-muted-foreground">
+                  Choose a thread to open the full conversation.
+                </p>
+              ) : selectedMessages === undefined ? (
+                <div className="h-32 animate-pulse rounded-2xl bg-muted" />
+              ) : activeMessages.length > 0 ? (
+                activeMessages.map((message) => (
+                  <CoachBubble
+                    key={message._id}
+                    role={message.role === "assistant" ? "coach" : message.role}
+                    timestamp={formatHistoryDate(message.createdAt)}
+                  >
+                    {message.content}
+                  </CoachBubble>
+                ))
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  This thread is ready. Messages will show here when they arrive.
+                </p>
+              )}
+            </div>
+          </SoftCard>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/conversationHistory.test.ts
+++ b/apps/web/lib/conversationHistory.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  companionNameFromTechnique,
+  filterHistoryConversations,
+  getConversationPreview,
+  isLiveConversation,
+  type HistoryConversation,
+} from "./conversationHistory";
+
+function thread(
+  overrides: Partial<HistoryConversation> = {},
+): HistoryConversation {
+  return {
+    id: "c1",
+    title: "Morning reset",
+    companionName: "Body Double",
+    createdAt: 1,
+    updatedAt: 2,
+    messages: [
+      {
+        id: "m1",
+        conversationId: "c1",
+        role: "user",
+        content: "Help me start the laundry.",
+        createdAt: 1,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("companionNameFromTechnique", () => {
+  test("titles a missing technique as Tempo companion", () => {
+    expect(companionNameFromTechnique(undefined)).toBe("Tempo companion");
+  });
+
+  test("title-cases hyphenated techniques", () => {
+    expect(companionNameFromTechnique("body_double")).toBe("Body Double");
+    expect(companionNameFromTechnique("eat-the-frog")).toBe("Eat The Frog");
+  });
+});
+
+describe("filterHistoryConversations", () => {
+  test("empty query returns every thread with zero message matches", () => {
+    const rows = filterHistoryConversations([thread()], "");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.matchingMessageCount).toBe(0);
+  });
+
+  test("matches title or companion without needing message text", () => {
+    const rows = [thread(), thread({ id: "c2", title: "Taxes", companionName: "Pomodoro" })];
+    expect(filterHistoryConversations(rows, "body").map((row) => row.id)).toEqual(["c1"]);
+    expect(filterHistoryConversations(rows, "tax").map((row) => row.id)).toEqual(["c2"]);
+  });
+
+  test("counts message hits when messages are attached", () => {
+    const rows = filterHistoryConversations([thread()], "laundry");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.matchingMessageCount).toBe(1);
+  });
+});
+
+describe("getConversationPreview", () => {
+  test("uses the first non-system message and truncates", () => {
+    expect(
+      getConversationPreview([
+        { id: "s", conversationId: "c1", role: "system", content: "hidden", createdAt: 0 },
+        {
+          id: "u",
+          conversationId: "c1",
+          role: "user",
+          content: "x".repeat(200),
+          createdAt: 1,
+        },
+      ]),
+    ).toHaveLength(140);
+  });
+
+  test("empty threads get a gentle preview", () => {
+    expect(getConversationPreview([])).toMatch(/no messages/i);
+  });
+});
+
+describe("isLiveConversation", () => {
+  test("soft-deleted rows are hidden", () => {
+    expect(isLiveConversation({})).toBe(true);
+    expect(isLiveConversation({ deletedAt: 9 })).toBe(false);
+  });
+});
+
+describe("HistoryScreen leftover wiring", () => {
+  test("uses landed conversation and message list APIs", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../components/history/HistoryScreen.tsx"),
+      "utf8",
+    );
+    expect(source).toContain("api.conversations.list");
+    expect(source).toContain("api.conversations.get");
+    expect(source).toContain("api.messages.list");
+    expect(source).toContain("filterHistoryConversations");
+    expect(source).not.toContain("convex.query");
+  });
+});

--- a/apps/web/lib/conversationHistory.ts
+++ b/apps/web/lib/conversationHistory.ts
@@ -1,0 +1,92 @@
+export type HistoryMessageRole = "user" | "assistant" | "system";
+
+export type HistoryMessage = {
+  id: string;
+  conversationId: string;
+  role: HistoryMessageRole;
+  content: string;
+  createdAt: number;
+};
+
+export type HistoryConversation = {
+  id: string;
+  title: string;
+  companionName: string;
+  updatedAt: number;
+  createdAt: number;
+  messages: HistoryMessage[];
+  deletedAt?: number;
+};
+
+export type HistoryConversationSearchResult = HistoryConversation & {
+  matchingMessageCount: number;
+};
+
+export function isLiveConversation<T extends { deletedAt?: number }>(row: T): boolean {
+  return row.deletedAt === undefined;
+}
+
+export function normalizeSearchQuery(query: string): string {
+  return query.trim().toLocaleLowerCase();
+}
+
+export function filterHistoryConversations(
+  conversations: HistoryConversation[],
+  rawQuery: string,
+): HistoryConversationSearchResult[] {
+  const query = normalizeSearchQuery(rawQuery);
+
+  return conversations.flatMap((conversation) => {
+    if (!query) {
+      return [{ ...conversation, matchingMessageCount: 0 }];
+    }
+
+    const titleMatches = conversation.title.toLocaleLowerCase().includes(query);
+    const companionMatches = conversation.companionName.toLocaleLowerCase().includes(query);
+    const matchingMessageCount = conversation.messages.reduce((count, message) => {
+      return message.content.toLocaleLowerCase().includes(query) ? count + 1 : count;
+    }, 0);
+
+    if (titleMatches || companionMatches || matchingMessageCount > 0) {
+      return [{ ...conversation, matchingMessageCount }];
+    }
+
+    return [];
+  });
+}
+
+export function getConversationPreview(messages: HistoryMessage[]): string {
+  const firstUserOrAssistantMessage = messages.find((message) => message.role !== "system");
+  if (firstUserOrAssistantMessage) {
+    return truncateText(firstUserOrAssistantMessage.content, 140);
+  }
+
+  return "No messages have been added to this thread yet.";
+}
+
+export function formatHistoryDate(timestamp: number): string {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(timestamp));
+}
+
+export function companionNameFromTechnique(technique: string | undefined): string {
+  if (!technique) {
+    return "Tempo companion";
+  }
+
+  return technique
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toLocaleUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return `${text.slice(0, maxLength - 3).trimEnd()}...`;
+}

--- a/apps/web/lib/tempo-nav.ts
+++ b/apps/web/lib/tempo-nav.ts
@@ -45,6 +45,7 @@ export const TEMPO_SCREENS: readonly TempoScreen[] = [
 
   // ---- You -----------------------------------------------------------------
   { slug: "analytics", title: "Insights", route: "/insights", category: "You", icon: "Chart" },
+  { slug: "history", title: "Conversation history", route: "/history", category: "You", icon: "Book" },
   { slug: "activity", title: "Recent activity", route: "/activity", category: "You", icon: "Clock" },
   { slug: "templates", title: "Templates", route: "/templates", category: "You", icon: "Layers" },
   { slug: "search", title: "Search", route: "/search", category: "You", icon: "Search" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the unique leftover from #210 onto current `integration`: a `/history` surface that lists saved companion conversations, searches by title or companion, and opens one thread at a time. It uses the landed `conversations.list` / `conversations.get` / `messages.list` contracts — no new Convex module and no N+1 message fetch across every thread.

## Linked task(s)

Task: leftover from #210 (original cited AGENT-229 / AIRI-V1-28). `docs/brain/TASKS.md` is a private submodule and is empty in this cloud clone — I did not invent a `T-XXXX` id.

## Screenshots / screen recording

UI change. Browser walkthrough will be attached after CI / local verification. Vercel previews in this environment require SSO, so local unit wiring is the gate until then.

## Test plan

- [x] `bun test apps/web/lib/conversationHistory.test.ts` (9 tests)
- [x] `bun test` collected suite (201 pass)
- [x] `bunx biome lint` on the new history files (clean after `section` + `aria-label` fix)
- [ ] CI typecheck / lint / test / schema-guard / forbidden-tech
- [ ] Manual QA of `/history` once a preview is reachable

## Acceptance criteria

Copied from #210, then reconciled to what this PR actually ships:

* History lists live (non-deleted) conversations scoped to the signed-in user.
* Opening a thread loads that conversation's messages via `messages.list`.
* Search filters by companion name and title (message text only on the open thread — original N+1 `convex.query` of every thread is skipped).
* Empty and sign-in states use real, shame-free copy.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2): no Firebase, Supabase, Prisma/Drizzle, Clerk/Auth0/NextAuth, direct OpenAI/Anthropic/Google AI SDKs, Redux/Zustand/Jotai, Axios.
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). N/A — read-only history.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). N/A — no schema change. Soft-deleted conversations are filtered client-side via `deletedAt`.
- [x] Styling uses design tokens from `packages/ui` — no ad-hoc hex or rogue Tailwind utilities (§7). Uses SoftCard + `@tempo/ui` Pill / CoachBubble.
- [x] Accessibility: keyboard nav, focus-visible, `prefers-reduced-motion`, color contrast (§8). List is a `section` with `aria-label`; search input is labeled.
- [x] No secrets committed; new env vars documented in `.env.example` with a one-line comment (§13).
- [x] Voice rules honored — never shame the user; empty states are kind (§1, §9).

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`).

## Files changed

- `apps/web/lib/conversationHistory.ts`
- `apps/web/lib/conversationHistory.test.ts`
- `apps/web/components/history/HistoryScreen.tsx`
- `apps/web/app/(tempo)/history/page.tsx`
- `apps/web/lib/tempo-nav.ts`

## Skipped from original #210

- `apps/web/src/features/history/` path (integration uses `app/(tempo)` + `components/`)
- Playwright `history.spec.ts`
- N+1 `convex.query(messages.list)` for every conversation
- `bun.lock` / `package.json` / `tsconfig.json` churn

## Graph note

`docs/brain/` is empty here. Landed conversations API is `list` / `get` / `create`; messages are `list({conversationId})`. This PR follows that graph, not the original `src/features/history` layout.

Replaces #210.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

