### PR TITLE
feat(tasks): add project kanban leftover from #170

### DIFF
--- a/apps/web/app/(tempo)/projects/[id]/kanban/page.tsx
+++ b/apps/web/app/(tempo)/projects/[id]/kanban/page.tsx
@@ -1,15 +1,13 @@
 /**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
  * @screen: project-kanban
  * @category: Library
  * @source: docs/design/claude-export/design-system/screens-4.jsx
- * @summary: Project kanban board.
- * @queries: projects.get, projects.tasks
- * @mutations: tasks.moveColumn
- * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
+ * @summary: Project kanban leftover from #170. Status moves use tasks.update.
+ * @queries: tasks.list
+ * @mutations: tasks.update
+ * @auth: required (gentle sign-in card otherwise)
  */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { TaskKanbanBoard } from "@/components/tasks/TaskKanbanBoard";
 
 type Params = { id: string };
 
@@ -19,12 +17,5 @@ export default async function Page({
   params: Promise<Params>;
 }) {
   const { id } = await params;
-  return (
-    <ScaffoldScreen
-      title="Project kanban"
-      category="Library"
-      source="screens-4.jsx"
-      summary={`Project kanban board. (id: ${id})`}
-    />
-  );
+  return <TaskKanbanBoard projectSlug={id} />;
 }

--- a/apps/web/components/tasks/TaskKanbanBoard.tsx
+++ b/apps/web/components/tasks/TaskKanbanBoard.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import type { Id } from "@/convex/_generated/dataModel";
+import { api } from "@/convex/_generated/api";
+import { SoftCard } from "@/components/soft-editorial/SoftCard";
+import { Button } from "@/components/ui/button";
+import {
+  KANBAN_COLUMNS,
+  groupTasksByKanbanStatus,
+  nextKanbanStatus,
+  projectIdFromSlug,
+  tasksForProject,
+} from "@/lib/taskKanban";
+import { titleFromProjectSlug, type TaskPriority, type TaskStatus } from "@/lib/task-view-filters";
+import { cn } from "@/lib/utils";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { ArrowRight, KanbanSquare } from "lucide-react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+type KanbanTask = {
+  _id: Id<"tasks">;
+  title: string;
+  description?: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  dueAt?: number;
+  projectId?: string;
+};
+
+const priorityLabel: Record<TaskPriority, string> = {
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+function formatDueAt(dueAt: number | undefined) {
+  if (dueAt === undefined) {
+    return null;
+  }
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(dueAt));
+}
+
+export function TaskKanbanBoard({ projectSlug }: { projectSlug: string }) {
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const profile = useQuery(api.users.getProfile, isAuthenticated ? {} : "skip");
+  const hasConvexUser = profile != null;
+  const tasks = useQuery(
+    api.tasks.list,
+    isAuthenticated && hasConvexUser ? {} : "skip",
+  );
+  const updateTask = useMutation(api.tasks.update);
+  const [draggedTaskId, setDraggedTaskId] = useState<Id<"tasks"> | null>(null);
+  const [localStatuses, setLocalStatuses] = useState<
+    Partial<Record<Id<"tasks">, TaskStatus>>
+  >({});
+
+  const projectId = projectIdFromSlug(projectSlug);
+  const projectTitle = titleFromProjectSlug(projectId);
+
+  const projectTasks = useMemo(() => {
+    const rows = tasksForProject((tasks ?? []) as KanbanTask[], projectSlug);
+    return rows.map((task) => ({
+      ...task,
+      status: localStatuses[task._id] ?? task.status,
+    }));
+  }, [localStatuses, projectSlug, tasks]);
+
+  const grouped = useMemo(
+    () => groupTasksByKanbanStatus(projectTasks),
+    [projectTasks],
+  );
+
+  const isLoading =
+    isAuthLoading ||
+    (isAuthenticated &&
+      (profile === undefined || (hasConvexUser && tasks === undefined)));
+
+  async function moveTask(taskId: Id<"tasks">, status: TaskStatus) {
+    const previousStatus = projectTasks.find((task) => task._id === taskId)?.status;
+    if (previousStatus === status) {
+      return;
+    }
+    setLocalStatuses((current) => ({ ...current, [taskId]: status }));
+    try {
+      await updateTask({ taskId, status });
+    } catch {
+      setLocalStatuses((current) => {
+        const next = { ...current };
+        if (previousStatus) {
+          next[taskId] = previousStatus;
+        } else {
+          delete next[taskId];
+        }
+        return next;
+      });
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <main className="mx-auto w-full max-w-6xl p-8">
+        <div className="space-y-4">
+          <div className="h-12 w-56 animate-pulse rounded-xl bg-muted" />
+          <div className="h-40 animate-pulse rounded-3xl bg-muted" />
+        </div>
+      </main>
+    );
+  }
+
+  if (!isAuthenticated || !profile || !tasks) {
+    return (
+      <main className="mx-auto w-full max-w-4xl p-8 text-center">
+        <SoftCard className="mx-auto max-w-xl">
+          <h1 className="font-heading text-2xl font-semibold text-foreground">
+            Project board
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            Sign in again to move cards on this board.
+          </p>
+          <Button asChild className="mt-6">
+            <Link href={`/sign-in?next=/projects/${projectSlug}/kanban`}>
+              Sign in
+            </Link>
+          </Button>
+        </SoftCard>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-8">
+      <header className="flex flex-col gap-3">
+        <div className="flex items-center gap-3 text-primary">
+          <KanbanSquare className="h-6 w-6" aria-hidden />
+          <span className="text-sm font-semibold uppercase tracking-wide">
+            Project board
+          </span>
+        </div>
+        <div>
+          <h1 className="font-heading text-4xl font-semibold text-foreground">
+            {projectTitle}
+          </h1>
+          <p className="mt-2 max-w-2xl text-muted-foreground">
+            Move a card when its real-world state changes. The board saves each
+            move, so a refresh keeps the card in its new column.
+          </p>
+          <p className="mt-3 text-sm text-muted-foreground">
+            <Link
+              href={`/projects/${projectSlug}`}
+              className="underline underline-offset-4"
+            >
+              Back to the project list
+            </Link>
+          </p>
+        </div>
+      </header>
+
+      <section className="grid gap-4 lg:grid-cols-4" aria-label="Task status columns">
+        {KANBAN_COLUMNS.map((column) => {
+          const columnTasks = grouped[column.status];
+          return (
+            <section
+              key={column.status}
+              aria-labelledby={`kanban-column-${column.status}-heading`}
+              onDragOver={(event) => event.preventDefault()}
+              onDrop={(event) => {
+                event.preventDefault();
+                if (draggedTaskId) {
+                  void moveTask(draggedTaskId, column.status);
+                  setDraggedTaskId(null);
+                }
+              }}
+              className="min-h-80 rounded-3xl border border-border bg-card/80 p-4"
+            >
+              <div className="mb-4 flex items-center justify-between gap-3">
+                <h2
+                  id={`kanban-column-${column.status}-heading`}
+                  className="font-heading text-xl font-semibold text-foreground"
+                >
+                  {column.title}
+                </h2>
+                <span className="rounded-full border border-border bg-background px-2.5 py-1 text-xs font-semibold text-muted-foreground">
+                  {columnTasks.length}
+                </span>
+              </div>
+
+              {columnTasks.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+                  {column.empty}
+                </p>
+              ) : (
+                <ul className="space-y-3">
+                  {columnTasks.map((task) => {
+                    const dueLabel = formatDueAt(task.dueAt);
+                    const next = nextKanbanStatus(task.status);
+                    return (
+                      <li
+                        key={task._id}
+                        draggable
+                        onDragStart={() => setDraggedTaskId(task._id)}
+                        onDragEnd={() => setDraggedTaskId(null)}
+                        className="rounded-2xl border border-border bg-background p-4"
+                      >
+                        <div className="min-w-0">
+                          <h3 className="font-medium text-foreground">{task.title}</h3>
+                          {task.description ? (
+                            <p className="mt-1 text-sm text-muted-foreground">
+                              {task.description}
+                            </p>
+                          ) : null}
+                          <div className="mt-3 flex flex-wrap items-center gap-2">
+                            <span className="rounded-full border border-border bg-muted px-2.5 py-1 text-xs font-semibold text-muted-foreground">
+                              {priorityLabel[task.priority]}
+                            </span>
+                            {dueLabel ? (
+                              <span className="text-xs text-muted-foreground">
+                                Due {dueLabel}
+                              </span>
+                            ) : null}
+                          </div>
+                        </div>
+                        {next !== task.status ? (
+                          <button
+                            type="button"
+                            className={cn(
+                              "mt-3 inline-flex min-h-11 items-center gap-2 rounded-full border border-border px-3 py-1.5 text-sm font-semibold text-foreground transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+                            )}
+                            onClick={() => {
+                              void moveTask(task._id, next);
+                            }}
+                          >
+                            Move to {KANBAN_COLUMNS.find((item) => item.status === next)?.title}
+                            <ArrowRight className="h-4 w-4" aria-hidden />
+                          </button>
+                        ) : null}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </section>
+          );
+        })}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/components/tasks/TaskViewsScreen.tsx
+++ b/apps/web/components/tasks/TaskViewsScreen.tsx
@@ -307,6 +307,14 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
                 {link.label}
               </Link>
             ))}
+            {view === "project" && projectSlug ? (
+              <Link
+                href={`/projects/${projectSlug}/kanban`}
+                className="rounded-pill border border-border bg-card px-4 py-2 text-sm font-medium text-foreground transition hover:bg-surface-sunken"
+              >
+                Board
+              </Link>
+            ) : null}
           </nav>
         </header>
 

--- a/apps/web/lib/taskKanban.test.ts
+++ b/apps/web/lib/taskKanban.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  groupTasksByKanbanStatus,
+  nextKanbanStatus,
+  projectIdFromSlug,
+  tasksForProject,
+} from "./taskKanban";
+
+describe("task kanban leftover", () => {
+  test("advances status one column without wrapping past set-aside", () => {
+    expect(nextKanbanStatus("todo")).toBe("in_progress");
+    expect(nextKanbanStatus("in_progress")).toBe("done");
+    expect(nextKanbanStatus("done")).toBe("cancelled");
+    expect(nextKanbanStatus("cancelled")).toBe("cancelled");
+  });
+
+  test("groups live tasks into the four board columns", () => {
+    const groups = groupTasksByKanbanStatus([
+      { id: "a", status: "todo" as const },
+      { id: "b", status: "done" as const },
+      { id: "c", status: "todo" as const },
+    ]);
+    expect(groups.todo.map((task) => task.id)).toEqual(["a", "c"]);
+    expect(groups.done.map((task) => task.id)).toEqual(["b"]);
+    expect(groups.in_progress).toEqual([]);
+    expect(groups.cancelled).toEqual([]);
+  });
+
+  test("reuses the landed project slug id, including irregular names", () => {
+    expect(projectIdFromSlug("Home Reset")).toBe("home-reset");
+    expect(projectIdFromSlug("  Café / Desk!! ")).toBe("caf-desk");
+    expect(
+      tasksForProject(
+        [
+          { id: "keep", projectId: "home-reset" },
+          { id: "other", projectId: "elsewhere" },
+        ],
+        "home-reset",
+      ).map((task) => task.id),
+    ).toEqual(["keep"]);
+  });
+});
+
+describe("TaskKanbanBoard leftover wiring", () => {
+  test("moves cards with tasks.update and filters by project slug", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../components/tasks/TaskKanbanBoard.tsx"),
+      "utf8",
+    );
+    expect(source).toContain("api.tasks.list");
+    expect(source).toContain("api.tasks.update");
+    expect(source).toContain("tasksForProject");
+    expect(source).not.toContain("api.tasks.moveStatus");
+    expect(source).not.toContain("recurrence");
+  });
+
+  test("project list links to the kanban board", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../components/tasks/TaskViewsScreen.tsx"),
+      "utf8",
+    );
+    expect(source).toContain("/kanban");
+    expect(source).toContain("projectSlug");
+  });
+});

--- a/apps/web/lib/taskKanban.ts
+++ b/apps/web/lib/taskKanban.ts
@@ -1,0 +1,66 @@
+import { slugifyProjectName, type TaskStatus } from "./task-view-filters";
+
+export const KANBAN_STATUSES = [
+  "todo",
+  "in_progress",
+  "done",
+  "cancelled",
+] as const satisfies readonly TaskStatus[];
+
+export type KanbanStatus = (typeof KANBAN_STATUSES)[number];
+
+export type KanbanColumn = {
+  status: KanbanStatus;
+  title: string;
+  empty: string;
+};
+
+export const KANBAN_COLUMNS: readonly KanbanColumn[] = [
+  { status: "todo", title: "To do", empty: "Nothing waiting in this column." },
+  {
+    status: "in_progress",
+    title: "In progress",
+    empty: "Nothing actively moving right now.",
+  },
+  { status: "done", title: "Done", empty: "Finished cards will land here." },
+  {
+    status: "cancelled",
+    title: "Set aside",
+    empty: "Cards you set aside stay visible here.",
+  },
+];
+
+export function nextKanbanStatus(status: TaskStatus): TaskStatus {
+  const index = KANBAN_STATUSES.indexOf(status as KanbanStatus);
+  if (index < 0 || index >= KANBAN_STATUSES.length - 1) {
+    return status;
+  }
+  return KANBAN_STATUSES[index + 1] ?? status;
+}
+
+export function projectIdFromSlug(projectSlug: string): string {
+  return slugifyProjectName(projectSlug) || "home-reset";
+}
+
+export function tasksForProject<T extends { projectId?: string }>(
+  tasks: readonly T[],
+  projectSlug: string,
+): T[] {
+  const projectId = projectIdFromSlug(projectSlug);
+  return tasks.filter((task) => task.projectId === projectId);
+}
+
+export function groupTasksByKanbanStatus<T extends { status: TaskStatus }>(
+  tasks: readonly T[],
+): Record<KanbanStatus, T[]> {
+  const groups: Record<KanbanStatus, T[]> = {
+    todo: [],
+    in_progress: [],
+    done: [],
+    cancelled: [],
+  };
+  for (const task of tasks) {
+    groups[task.status].push(task);
+  }
+  return groups;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the unique leftover from #170 that still fits current `integration`: a project kanban board. Cards move with landed `tasks.update({ status })`. The project filter reuses `slugifyProjectName`, same as the project task list.

#170’s recurrence helpers (`frequency` / `interval` / `endAt`) are **not** ported. Integration already has `taskRepeatCfgs` with a different series model; landing the simpler recurrence would fight that schema.

## Linked task(s)

Task: leftover from #170. `docs/brain/TASKS.md` is empty in this cloud clone — I did not invent a `T-XXXX` id.

## Screenshots / screen recording

UI change. Browser walkthrough after CI / when a preview is reachable. Vercel previews in this environment require SSO.

## Test plan

- [x] `bun test apps/web/lib/taskKanban.test.ts` (5 tests)
- [x] `bunx biome lint` on the kanban files
- [ ] CI typecheck / lint / test / schema-guard / forbidden-tech
- [ ] Manual QA of `/projects/:id/kanban` once a preview is reachable

## Acceptance criteria

Reconciled from #170 to what this PR ships:

* Project kanban lists live tasks in todo / in progress / done / set-aside columns.
* Moving a card persists via `tasks.update` (no new `moveStatus` mutation).
* Project slug filtering matches the landed project list.
* Empty and sign-in states use shame-free copy.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2).
- [x] AI-originated state changes surface an accept / edit / reject card with preview (§1, §6). N/A — user-initiated status moves.
- [x] Schema changes respect `v.*` validators, indexes, soft-delete, and RAM-only fields (§5). N/A — no schema change.
- [x] Styling uses design tokens / SoftCard; no ad-hoc hex shadows.
- [x] Accessibility: labeled columns, keyboard “Move to …” buttons, focus-visible.
- [x] No secrets committed.
- [x] Voice rules honored — “Set aside” instead of shame language.

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`).

## Files changed

- `apps/web/lib/taskKanban.ts`
- `apps/web/lib/taskKanban.test.ts`
- `apps/web/components/tasks/TaskKanbanBoard.tsx`
- `apps/web/app/(tempo)/projects/[id]/kanban/page.tsx`
- `apps/web/components/tasks/TaskViewsScreen.tsx` (Board link)

## Skipped from original #170

- `tasks.moveStatus` (status already on `tasks.update`)
- Recurrence helpers + `convex/tasks.ts` / `schema.ts` rewrite
- Playwright `task-kanban.spec.ts`
- `bun.lock` / `package.json`

## Graph note

Landed tasks already have `status` and `taskRepeatCfgs`. This PR follows that graph, not #170’s inline recurrence shape.

Does **not** close #170 — recurrence leftover remains.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

