### PR TITLE
feat(tasks): add taskRepeatCfgs leftover from #170

### DIFF
--- a/apps/web/components/tasks/TaskViewsScreen.tsx
+++ b/apps/web/components/tasks/TaskViewsScreen.tsx
@@ -35,12 +35,15 @@ type LocalTaskRecord = TaskViewRecord & {
   createdAt: number;
 };
 
+type RepeatDraft = "none" | "daily" | "weekly";
+
 type Draft = {
   title: string;
   projectName: string;
   priority: TaskPriority;
   energy: TaskEnergy;
   dueToday: boolean;
+  repeat: RepeatDraft;
 };
 
 const localStorageKey = "tempo:task-views-core:v1";
@@ -59,6 +62,7 @@ const defaultDraft: Draft = {
   priority: "medium",
   energy: "medium",
   dueToday: false,
+  repeat: "none",
 };
 
 const allowLocalTaskViews =
@@ -125,6 +129,8 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
   const convexTasks = useQuery(api.tasks.list, isAuthenticated ? {} : "skip");
   const createTask = useMutation(api.tasks.create);
+  const createRepeatCfg = useMutation(api.tasks.createRepeatCfg);
+  const setTaskRepeatCfg = useMutation(api.tasks.setTaskRepeatCfg);
   const updateTask = useMutation(api.tasks.update);
   const toggleCompletion = useMutation(api.tasks.toggleCompletion);
   const [localTasks, setLocalTasks] = useState<LocalTaskRecord[]>([]);
@@ -210,7 +216,7 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
     const dueAt = draft.dueToday ? bounds.endMs - 1 : undefined;
 
     if (usesConvex) {
-      await createTask({
+      const taskId = await createTask({
         title,
         priority: draft.priority,
         energy: draft.energy,
@@ -218,6 +224,15 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
         projectId: normalizedProjectId,
         projectName: normalizedProjectName,
       });
+      if (draft.repeat === "daily" || draft.repeat === "weekly") {
+        const cfgId = await createRepeatCfg({
+          repeatCycle: draft.repeat === "daily" ? "DAILY" : "WEEKLY",
+          repeatEvery: 1,
+          weekdays: draft.repeat === "weekly" ? [new Date().getUTCDay()] : [],
+          skipOverdue: true,
+        });
+        await setTaskRepeatCfg({ taskId, repeatCfgId: cfgId });
+      }
     } else if (usesLocalStore) {
       const now = Date.now();
       persistLocal((tasks) => [
@@ -319,7 +334,7 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
         </header>
 
         <section className="rounded-3xl border border-border bg-card p-5 shadow-card" aria-label="Create task">
-          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_180px_150px_150px_auto] lg:items-end">
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_180px_150px_150px_150px_auto] lg:items-end">
             <label className="space-y-2">
               <span className="text-sm font-medium text-foreground">Task title</span>
               <input
@@ -379,6 +394,25 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
                 <option value="low">Low</option>
                 <option value="medium">Medium</option>
                 <option value="high">High</option>
+              </select>
+            </label>
+            <label className="space-y-2">
+              <span className="text-sm font-medium text-foreground">Repeat</span>
+              <select
+                aria-label="Repeat"
+                value={draft.repeat}
+                disabled={!taskStoreReady}
+                onChange={(event) =>
+                  setDraft((current) => ({
+                    ...current,
+                    repeat: event.target.value as RepeatDraft,
+                  }))
+                }
+                className="min-h-11 w-full rounded-xl border border-border bg-background px-3 text-foreground outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                <option value="none">Does not repeat</option>
+                <option value="daily">Every day</option>
+                <option value="weekly">Every week</option>
               </select>
             </label>
             <Button

--- a/convex/lib/taskRepeat.ts
+++ b/convex/lib/taskRepeat.ts
@@ -1,0 +1,163 @@
+/** Landed `taskRepeatCfgs` cycle names — not the #170 `{frequency,interval}` shape. */
+export type RepeatCycle = "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
+
+export type RepeatCfgInput = {
+  repeatCycle: RepeatCycle;
+  /** Every N cycles. Must be an integer >= 1. */
+  repeatEvery: number;
+  /** 0–6 Sunday-first. Empty WEEKLY list means “same weekday as `fromMs`”. */
+  weekdays: readonly number[];
+  monthlyLastDay?: boolean;
+  /** When true, keep advancing until the next due is >= `nowMs`. */
+  skipOverdue: boolean;
+};
+
+export const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function assertRepeatEvery(repeatEvery: number): number {
+  if (!Number.isInteger(repeatEvery) || repeatEvery < 1) {
+    throw new Error("repeatEvery interval must be an integer >= 1");
+  }
+  return repeatEvery;
+}
+
+function utcParts(ms: number): {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  ms: number;
+  weekday: number;
+} {
+  const d = new Date(ms);
+  return {
+    year: d.getUTCFullYear(),
+    month: d.getUTCMonth(),
+    day: d.getUTCDate(),
+    hour: d.getUTCHours(),
+    minute: d.getUTCMinutes(),
+    second: d.getUTCSeconds(),
+    ms: d.getUTCMilliseconds(),
+    weekday: d.getUTCDay(),
+  };
+}
+
+function utcFromParts(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  ms: number,
+): number {
+  return Date.UTC(year, month, day, hour, minute, second, ms);
+}
+
+function lastUtcDayOfMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}
+
+function addUtcDays(fromMs: number, days: number): number {
+  return fromMs + days * DAY_MS;
+}
+
+function addUtcMonths(fromMs: number, months: number, monthlyLastDay: boolean): number {
+  const p = utcParts(fromMs);
+  const rawMonth = p.month + months;
+  const year = p.year + Math.floor(rawMonth / 12);
+  const month = ((rawMonth % 12) + 12) % 12;
+  const lastDay = lastUtcDayOfMonth(year, month);
+  const day = monthlyLastDay ? lastDay : Math.min(p.day, lastDay);
+  return utcFromParts(year, month, day, p.hour, p.minute, p.second, p.ms);
+}
+
+function nextWeeklyDueAt(fromMs: number, repeatEvery: number, weekdays: readonly number[]): number {
+  const fromWeekday = utcParts(fromMs).weekday;
+  const allowed =
+    weekdays.length > 0
+      ? [...new Set(weekdays.filter((d) => Number.isInteger(d) && d >= 0 && d <= 6))]
+      : [fromWeekday];
+
+  if (allowed.length === 0) {
+    return addUtcDays(fromMs, 7 * repeatEvery);
+  }
+
+  if (allowed.length === 1 && allowed[0] === fromWeekday) {
+    return addUtcDays(fromMs, 7 * repeatEvery);
+  }
+
+  for (let offset = 1; offset <= 7; offset += 1) {
+    const candidate = addUtcDays(fromMs, offset);
+    if (allowed.includes(utcParts(candidate).weekday)) {
+      if (utcParts(candidate).weekday === fromWeekday) {
+        return addUtcDays(fromMs, 7 * repeatEvery);
+      }
+      return candidate;
+    }
+  }
+
+  return addUtcDays(fromMs, 7 * repeatEvery);
+}
+
+function stepOnce(fromMs: number, cfg: RepeatCfgInput): number {
+  const every = assertRepeatEvery(cfg.repeatEvery);
+  switch (cfg.repeatCycle) {
+    case "DAILY":
+      return addUtcDays(fromMs, every);
+    case "WEEKLY":
+      return nextWeeklyDueAt(fromMs, every, cfg.weekdays);
+    case "MONTHLY":
+      return addUtcMonths(fromMs, every, cfg.monthlyLastDay === true);
+    case "YEARLY":
+      return addUtcMonths(fromMs, 12 * every, cfg.monthlyLastDay === true);
+    default: {
+      const _exhaustive: never = cfg.repeatCycle;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Next due after `fromMs`. When `skipOverdue` is set, keep stepping until
+ * the result is >= `nowMs` so missed days do not pile up.
+ */
+export function computeNextRepeatDueAt(
+  fromMs: number,
+  cfg: RepeatCfgInput,
+  nowMs: number,
+): number {
+  assertRepeatEvery(cfg.repeatEvery);
+  let next = stepOnce(fromMs, cfg);
+  if (!cfg.skipOverdue) {
+    return next;
+  }
+  let guard = 0;
+  while (next < nowMs && guard < 400) {
+    next = stepOnce(next, cfg);
+    guard += 1;
+  }
+  return next;
+}
+
+export function repeatDraftToCfg(
+  draft: "daily" | "weekly",
+  weekdayFromMs: number,
+): RepeatCfgInput {
+  if (draft === "daily") {
+    return {
+      repeatCycle: "DAILY",
+      repeatEvery: 1,
+      weekdays: [],
+      skipOverdue: true,
+    };
+  }
+  return {
+    repeatCycle: "WEEKLY",
+    repeatEvery: 1,
+    weekdays: [utcParts(weekdayFromMs).weekday],
+    skipOverdue: true,
+  };
+}

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { requireUser } from "./lib/requireUser";
 import { filterTasksDueInRange } from "./lib/task_filters";
+import { assertRepeatEvery } from "./lib/taskRepeat";
 import { fetchCurrentUser } from "./users";
 
 const taskStatusValidator = v.union(
@@ -279,5 +280,125 @@ export const toggleCompletion = mutation({
     const next: "todo" | "done" = task.status === "done" ? "todo" : "done";
     await ctx.db.patch(args.taskId, { status: next, updatedAt: Date.now() });
     return { taskId: args.taskId, status: next };
+  },
+});
+
+const repeatCycleValidator = v.union(
+  v.literal("DAILY"),
+  v.literal("WEEKLY"),
+  v.literal("MONTHLY"),
+  v.literal("YEARLY"),
+);
+
+const repeatCfgReturnValidator = v.object({
+  _id: v.id("taskRepeatCfgs"),
+  _creationTime: v.number(),
+  userId: v.id("users"),
+  repeatCycle: repeatCycleValidator,
+  repeatEvery: v.number(),
+  weekdays: v.array(v.number()),
+  monthlyWeekOfMonth: v.optional(v.number()),
+  monthlyWeekday: v.optional(v.number()),
+  monthlyLastDay: v.optional(v.boolean()),
+  deletedInstanceDates: v.array(v.string()),
+  skipOverdue: v.boolean(),
+  waitForCompletion: v.boolean(),
+  repeatFromCompletionDate: v.boolean(),
+  isPaused: v.boolean(),
+  defaultEstimate: v.optional(v.number()),
+  lastTaskCreationDay: v.optional(v.string()),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+  deletedAt: v.optional(v.number()),
+});
+
+export const listRepeatCfgs = query({
+  args: {},
+  returns: v.array(repeatCfgReturnValidator),
+  handler: async (ctx) => {
+    const user = await requireUser(ctx);
+    const rows = await ctx.db
+      .query("taskRepeatCfgs")
+      .withIndex("by_userId", (q) => q.eq("userId", user._id))
+      .collect();
+    return rows.filter((row) => row.deletedAt === undefined);
+  },
+});
+
+export const createRepeatCfg = mutation({
+  args: {
+    repeatCycle: repeatCycleValidator,
+    repeatEvery: v.optional(v.number()),
+    weekdays: v.optional(v.array(v.number())),
+    monthlyLastDay: v.optional(v.boolean()),
+    skipOverdue: v.optional(v.boolean()),
+    waitForCompletion: v.optional(v.boolean()),
+    repeatFromCompletionDate: v.optional(v.boolean()),
+  },
+  returns: v.id("taskRepeatCfgs"),
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const repeatEvery = assertRepeatEvery(args.repeatEvery ?? 1);
+    const now = Date.now();
+    return ctx.db.insert("taskRepeatCfgs", {
+      userId: user._id,
+      repeatCycle: args.repeatCycle,
+      repeatEvery,
+      weekdays: args.weekdays ?? [],
+      monthlyLastDay: args.monthlyLastDay,
+      deletedInstanceDates: [],
+      skipOverdue: args.skipOverdue ?? true,
+      waitForCompletion: args.waitForCompletion ?? false,
+      repeatFromCompletionDate: args.repeatFromCompletionDate ?? false,
+      isPaused: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+  },
+});
+
+export const pauseRepeatCfg = mutation({
+  args: {
+    repeatCfgId: v.id("taskRepeatCfgs"),
+    isPaused: v.boolean(),
+  },
+  returns: v.id("taskRepeatCfgs"),
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const cfg = await ctx.db.get(args.repeatCfgId);
+    if (!cfg || cfg.userId !== user._id || cfg.deletedAt !== undefined) {
+      throw new Error("Repeat series not found");
+    }
+    await ctx.db.patch(args.repeatCfgId, {
+      isPaused: args.isPaused,
+      updatedAt: Date.now(),
+    });
+    return args.repeatCfgId;
+  },
+});
+
+export const setTaskRepeatCfg = mutation({
+  args: {
+    taskId: v.id("tasks"),
+    repeatCfgId: v.union(v.id("taskRepeatCfgs"), v.null()),
+  },
+  returns: v.id("tasks"),
+  handler: async (ctx, args) => {
+    const user = await requireUser(ctx);
+    const task = await ctx.db.get(args.taskId);
+    if (!task || task.userId !== user._id || task.deletedAt !== undefined) {
+      throw new Error("Task not found");
+    }
+    if (args.repeatCfgId !== null) {
+      const cfg = await ctx.db.get(args.repeatCfgId);
+      if (!cfg || cfg.userId !== user._id || cfg.deletedAt !== undefined) {
+        throw new Error("Repeat series not found");
+      }
+    }
+    await ctx.db.patch(args.taskId, {
+      repeatCfgId: args.repeatCfgId === null ? undefined : args.repeatCfgId,
+      updatedAt: Date.now(),
+    });
+    return args.taskId;
   },
 });

--- a/tests/unit/task_repeat.test.ts
+++ b/tests/unit/task_repeat.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  assertRepeatEvery,
+  computeNextRepeatDueAt,
+  repeatDraftToCfg,
+} from "../../convex/lib/taskRepeat";
+
+const jan31NoonUtc = Date.UTC(2026, 0, 31, 12);
+const jul14NineUtc = Date.UTC(2026, 6, 14, 9);
+
+describe("taskRepeat leftover from #170 (landed taskRepeatCfgs shape)", () => {
+  test("weekly every 1 steps from the current due to the next week", () => {
+    const next = computeNextRepeatDueAt(
+      jul14NineUtc,
+      {
+        repeatCycle: "WEEKLY",
+        repeatEvery: 1,
+        weekdays: [],
+        skipOverdue: false,
+      },
+      jul14NineUtc,
+    );
+    expect(next).toBe(Date.UTC(2026, 6, 21, 9));
+  });
+
+  test("skipOverdue advances past a stale due instead of stacking missed days", () => {
+    const now = Date.UTC(2026, 6, 30, 9);
+    const next = computeNextRepeatDueAt(
+      jul14NineUtc,
+      {
+        repeatCycle: "WEEKLY",
+        repeatEvery: 1,
+        weekdays: [],
+        skipOverdue: true,
+      },
+      now,
+    );
+    expect(next).toBeGreaterThanOrEqual(now);
+    expect(next).toBe(Date.UTC(2026, 7, 4, 9));
+  });
+
+  test("clamps monthly recurrences to the target month's last day", () => {
+    expect(
+      computeNextRepeatDueAt(
+        jan31NoonUtc,
+        {
+          repeatCycle: "MONTHLY",
+          repeatEvery: 1,
+          weekdays: [],
+          skipOverdue: false,
+        },
+        jan31NoonUtc,
+      ),
+    ).toBe(Date.UTC(2026, 1, 28, 12));
+  });
+
+  test("rejects invalid intervals instead of creating ambiguous recurrences", () => {
+    expect(() => assertRepeatEvery(0)).toThrow(/interval/i);
+    expect(() =>
+      computeNextRepeatDueAt(
+        jul14NineUtc,
+        {
+          repeatCycle: "DAILY",
+          repeatEvery: 0,
+          weekdays: [],
+          skipOverdue: false,
+        },
+        jul14NineUtc,
+      ),
+    ).toThrow(/interval/i);
+  });
+
+  test("repeatDraftToCfg maps the create-form leftover onto landed fields", () => {
+    expect(repeatDraftToCfg("daily", jul14NineUtc)).toEqual({
+      repeatCycle: "DAILY",
+      repeatEvery: 1,
+      weekdays: [],
+      skipOverdue: true,
+    });
+    expect(repeatDraftToCfg("weekly", jul14NineUtc).weekdays).toEqual([2]);
+  });
+});
+
+describe("taskRepeat leftover wiring", () => {
+  test("tasks.ts exposes create/list/pause/set on the existing module", () => {
+    const source = readFileSync(join(import.meta.dir, "../../convex/tasks.ts"), "utf8");
+    expect(source).toContain("export const createRepeatCfg");
+    expect(source).toContain("export const listRepeatCfgs");
+    expect(source).toContain("export const pauseRepeatCfg");
+    expect(source).toContain("export const setTaskRepeatCfg");
+    expect(source).toContain("taskRepeatCfgs");
+    expect(source).not.toContain('frequency: "weekly"');
+  });
+
+  test("task create form offers a Repeat control without a new Convex module", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../../apps/web/components/tasks/TaskViewsScreen.tsx"),
+      "utf8",
+    );
+    expect(source).toContain("api.tasks.createRepeatCfg");
+    expect(source).toContain("api.tasks.setTaskRepeatCfg");
+    expect(source).toContain('aria-label="Repeat"');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the remaining #170 leftover — recurring tasks — onto the **landed** `taskRepeatCfgs` table (`DAILY`/`WEEKLY`/`MONTHLY`/`YEARLY` + `skipOverdue`). Does not revive #170’s `{frequency,interval,endAt}` columns or rewrite `convex/schema.ts`.

Kanban from #170 already landed in #376. This slice is the recurrence API + a Repeat control on the existing task create form.

Low-risk. No auth, payments, account deletion, or secrets.

## Linked task(s)

Task: leftover from PR #170 (docs/brain TASKS.md is a private submodule in this clone; no T-XXXX invented)

## Screenshots / screen recording

N/A for this leftover slice — unit coverage of next-due math + wiring. Vercel preview is SSO-gated from this environment.

## Test plan

- [x] `bun test ./tests/unit/task_repeat.test.ts` — 7 pass
- [x] biome lint on edited files
- [ ] CI green on this branch

## Acceptance criteria

- Next-due helper uses landed cycle names; weekly +1 week; monthly clamps Jan 31 → Feb 28 UTC; `repeatEvery < 1` throws.
- `skipOverdue` advances past missed days instead of stacking a backlog.
- Public functions live on existing `tasks` module: `listRepeatCfgs`, `createRepeatCfg`, `pauseRepeatCfg`, `setTaskRepeatCfg` (owner-checked, indexed by `by_userId`).
- Create form Repeat select can attach a daily/weekly series after `tasks.create`.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2).
- [x] AI-originated state changes: N/A — user-initiated Repeat select.
- [x] Schema unchanged. Uses existing `taskRepeatCfgs` + `tasks.repeatCfgId`. Soft-delete field left intact. `undefined` detach deletes the id field (Convex patch).
- [x] Styling uses existing form token classes.
- [x] Repeat `<select>` has `aria-label="Repeat"`.
- [x] No secrets committed.
- [x] Voice: “Does not repeat” / “Every day” / “Every week”. skipOverdue avoids overdue walls.

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`).

## Skipped from original #170

- `{frequency,interval,endAt}` on the tasks document.
- Auto-spawning extra occurrence rows.
- Playwright `task-kanban.spec.ts` / lockfile.
- Kanban (already in #376).

## Graph / instruction notes

`docs/brain/` is empty in this cloud clone. Landed `convex/schema.ts` `taskRepeatCfgs` is ground truth; #170’s recurrence shape lost.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

