### PR TITLE
feat(breathwork): elapsed snapshot leftover from #189

### DIFF
--- a/packages/utils/src/breathwork.ts
+++ b/packages/utils/src/breathwork.ts
@@ -58,14 +58,44 @@ export function buildBreathCycle(pattern: BreathPatternConfig): BreathCycle {
   };
 }
 
-export function getBreathPhaseAt(pattern: BreathPatternConfig, elapsedMs: number): BreathPhase {
-  const cycle = buildBreathCycle(pattern);
-  const cycleOffsetMs =
-    ((elapsedMs % cycle.totalDurationMs) + cycle.totalDurationMs) % cycle.totalDurationMs;
+export type BreathworkSnapshot = {
+  elapsedMs: number;
+  cycleMs: number;
+  cycleIndex: number;
+  phase: BreathPhase;
+  phaseElapsedMs: number;
+  phaseRemainingMs: number;
+  phaseIndex: number;
+};
 
-  for (const step of cycle.steps) {
-    if (cycleOffsetMs >= step.startsAtMs && cycleOffsetMs < step.endsAtMs) {
-      return step.phase;
+function cycleOffsetMs(elapsedMs: number, cycleMs: number): number {
+  return ((elapsedMs % cycleMs) + cycleMs) % cycleMs;
+}
+
+export function getBreathPhaseAt(pattern: BreathPatternConfig, elapsedMs: number): BreathPhase {
+  return getBreathworkSnapshot(pattern, elapsedMs).phase;
+}
+
+/** Elapsed-time leftover from #189. Same cycle math as getBreathPhaseAt, with remaining ms. */
+export function getBreathworkSnapshot(
+  pattern: BreathPatternConfig,
+  elapsedMs: number,
+): BreathworkSnapshot {
+  const cycle = buildBreathCycle(pattern);
+  const offsetMs = cycleOffsetMs(elapsedMs, cycle.totalDurationMs);
+
+  for (const [phaseIndex, step] of cycle.steps.entries()) {
+    if (offsetMs >= step.startsAtMs && offsetMs < step.endsAtMs) {
+      const phaseElapsedMs = offsetMs - step.startsAtMs;
+      return {
+        elapsedMs: Math.max(0, elapsedMs),
+        cycleMs: cycle.totalDurationMs,
+        cycleIndex: Math.floor(Math.max(0, elapsedMs) / cycle.totalDurationMs),
+        phase: step.phase,
+        phaseElapsedMs,
+        phaseRemainingMs: step.endsAtMs - offsetMs,
+        phaseIndex,
+      };
     }
   }
 
@@ -74,5 +104,13 @@ export function getBreathPhaseAt(pattern: BreathPatternConfig, elapsedMs: number
     throw new Error("Breath pattern must include at least one step");
   }
 
-  return firstStep.phase;
+  return {
+    elapsedMs: Math.max(0, elapsedMs),
+    cycleMs: cycle.totalDurationMs,
+    cycleIndex: 0,
+    phase: firstStep.phase,
+    phaseElapsedMs: 0,
+    phaseRemainingMs: firstStep.endsAtMs - firstStep.startsAtMs,
+    phaseIndex: 0,
+  };
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -6,8 +6,10 @@ export {
   type BreathPatternConfig,
   type BreathPatternStep,
   type BreathPhase,
+  type BreathworkSnapshot,
   buildBreathCycle,
   getBreathPhaseAt,
+  getBreathworkSnapshot,
 } from "./breathwork";
 
 export {

--- a/tests/unit/breathwork_patterns.test.ts
+++ b/tests/unit/breathwork_patterns.test.ts
@@ -3,6 +3,7 @@ import {
 	type BreathPatternConfig,
 	buildBreathCycle,
 	getBreathPhaseAt,
+	getBreathworkSnapshot,
 } from "../../packages/utils/src/breathwork";
 
 const coherence: BreathPatternConfig = {
@@ -54,5 +55,32 @@ describe("getBreathPhaseAt", () => {
 		expect(getBreathPhaseAt(coherence, 9_999)).toBe("exhale");
 		expect(getBreathPhaseAt(coherence, 10_000)).toBe("inhale");
 		expect(getBreathPhaseAt(coherence, -1)).toBe("exhale");
+	});
+});
+
+describe("getBreathworkSnapshot leftover from #189", () => {
+	test("reports remaining time inside the current phase", () => {
+		expect(getBreathworkSnapshot(coherence, 1_250)).toMatchObject({
+			phase: "inhale",
+			phaseIndex: 0,
+			phaseElapsedMs: 1_250,
+			phaseRemainingMs: 3_750,
+			cycleIndex: 0,
+			cycleMs: 10_000,
+		});
+		expect(getBreathworkSnapshot(coherence, 12_000)).toMatchObject({
+			phase: "inhale",
+			phaseIndex: 0,
+			phaseElapsedMs: 2_000,
+			phaseRemainingMs: 3_000,
+			cycleIndex: 1,
+		});
+		expect(getBreathworkSnapshot(coherence, 16_000)).toMatchObject({
+			phase: "exhale",
+			phaseIndex: 1,
+			phaseElapsedMs: 1_000,
+			phaseRemainingMs: 4_000,
+			cycleIndex: 1,
+		});
 	});
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#189's remaining unique leftover after #354 / #364 / #380 is an elapsed-time snapshot (`phaseElapsedMs`, `phaseRemainingMs`, `cycleIndex`). The landed timer is event-driven `advancePhase`; cycle math already lives in `@tempo/utils`. This adds `getBreathworkSnapshot` next to `getBreathPhaseAt` so remaining-ms is available without a second timer implementation.

## Linked task(s)

Original PR: #189.

`docs/brain/TASKS.md` is a private submodule and empty in this cloud clone. I am not inventing a `T-XXXX` id.

## Screenshots / screen recording

N/A — helper + unit tests only. No new user-visible surface.

## Test plan

- [x] `bun test ./tests/unit/breathwork_patterns.test.ts` — 5 pass
- [ ] CI typecheck / lint / test / schema-guard / forbidden-tech
- [x] Existing wrap-around `getBreathPhaseAt` cases still pass (now delegated to the snapshot)

## Acceptance criteria

- `getBreathworkSnapshot` reports phase, remaining ms, and cycle index from elapsed time.
- `getBreathPhaseAt` stays the same public contract.
- Original #189 e2e, lockfile, and `BreathworkTimer` overwrite are **not** in this PR.

## HARD_RULES compliance checklist

- [x] No forbidden tech added.
- [x] AI-originated state — N/A.
- [x] Schema — N/A.
- [x] Tokens — N/A (no UI).
- [x] Accessibility — N/A.
- [x] No secrets.
- [x] Voice — N/A.

## Owner tag (§14)

- [x] `cursor-cloud-3`

## Reviewer

Amit (`human-amit`).

## MERGE

Low-risk helper leftover. Mark ready after CI green. Then close #189.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

