### PR TITLE
feat(mobile): add honest tracking streak ring leftover from #184

### DIFF
--- a/apps/mobile/app/(tempo)/tracking.tsx
+++ b/apps/mobile/app/(tempo)/tracking.tsx
@@ -1,21 +1,35 @@
 /**
  * @screen: tracking
  * @platform: mobile
- * @summary: Tracking chart leftover from #188. Sibling of today so the tab home stays put.
+ * @summary: Tracking chart leftover from #188 plus honest streak ring leftover from #184.
+ * @queries: streaks.getCurrent
  */
 import { TrackingDashboardChart } from "@/components/tracking/TrackingDashboardChart";
+import { TrackingStreakRing } from "@/components/tracking/TrackingStreakRing";
+import { api } from "@/convex/_generated/api";
+import { useConvexAuth, useQuery } from "convex/react";
 import { Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Screen() {
+  const { isAuthenticated } = useConvexAuth();
+  const profile = useQuery(api.users.getProfile, isAuthenticated ? {} : "skip");
+  const hasConvexUser = profile != null;
+  const habitStreak = useQuery(
+    api.streaks.getCurrent,
+    isAuthenticated && hasConvexUser ? {} : "skip",
+  );
+  const streakCount = habitStreak?.streakCount ?? 0;
+
   return (
     <SafeAreaView className="flex-1 bg-background">
       <View className="flex-1 p-6 gap-5">
         <Text className="text-2xl font-semibold text-foreground">Tracking</Text>
         <Text className="text-sm text-muted-foreground">
-          Focus minutes from sessions you already logged. An empty chart is
-          still a complete enough start.
+          Focus minutes from sessions you already logged, and the habit streak
+          you already have. An empty ring is still a complete enough start.
         </Text>
+        <TrackingStreakRing streakCount={streakCount} />
         <TrackingDashboardChart sessions={[]} />
       </View>
     </SafeAreaView>

--- a/apps/mobile/components/tracking/TrackingStreakRing.tsx
+++ b/apps/mobile/components/tracking/TrackingStreakRing.tsx
@@ -1,0 +1,82 @@
+import { tempoColors } from "@tempo/ui/theme";
+import { Text, View } from "react-native";
+import Svg, { Circle } from "react-native-svg";
+
+import { buildStreakRingGeometry } from "@/lib/tracking-streak-ring";
+
+type TrackingStreakRingProps = {
+  streakCount: number;
+};
+
+export function TrackingStreakRing({ streakCount }: TrackingStreakRingProps) {
+  const ring = buildStreakRingGeometry({ streakCount });
+  const dayWord = ring.streakCount === 1 ? "day" : "days";
+
+  return (
+    <View className="rounded-3xl border border-border bg-card px-6 py-8 gap-5">
+      <View className="gap-1">
+        <Text className="text-sm font-semibold uppercase tracking-[2px] text-muted-foreground">
+          Habit streak
+        </Text>
+        <Text className="text-2xl font-semibold text-foreground">
+          Keep the thread warm
+        </Text>
+        <Text className="text-sm leading-6 text-muted-foreground">
+          {ring.streakCount === 0
+            ? "No streak yet. A habit you already keep will show up here."
+            : "One gentle check-in is enough to keep today connected to the days before it."}
+        </Text>
+      </View>
+
+      <View className="items-center gap-5">
+        <Svg
+          accessibilityLabel={`Streak progress: ${ring.streakCount} of ${ring.weeklyGoal}`}
+          accessibilityRole="progressbar"
+          accessibilityValue={{
+            min: 0,
+            max: ring.weeklyGoal,
+            now: Math.min(ring.streakCount, ring.weeklyGoal),
+          }}
+          height={ring.size}
+          testID="enso-ring"
+          viewBox={`0 0 ${ring.size} ${ring.size}`}
+          width={ring.size}
+        >
+          <Circle
+            cx={ring.size / 2}
+            cy={ring.size / 2}
+            fill="none"
+            r={ring.radius}
+            stroke={tempoColors.lineSoft}
+            strokeWidth={ring.stroke}
+          />
+          <Circle
+            cx={ring.size / 2}
+            cy={ring.size / 2}
+            fill="none"
+            r={ring.radius}
+            stroke={tempoColors.tempoOrange}
+            strokeDasharray={ring.circumference}
+            strokeDashoffset={ring.dashOffset}
+            strokeLinecap="round"
+            strokeWidth={ring.stroke}
+            testID="enso-ring-progress"
+            transform={`rotate(-90 ${ring.size / 2} ${ring.size / 2})`}
+          />
+        </Svg>
+
+        <View className="items-center gap-1">
+          <Text
+            className="text-5xl font-semibold text-foreground"
+            testID="streak-value"
+          >
+            {ring.streakCount}
+          </Text>
+          <Text className="text-base text-muted-foreground">
+            {dayWord} in a row
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/lib/tracking-streak-ring.ts
+++ b/apps/mobile/lib/tracking-streak-ring.ts
@@ -1,0 +1,47 @@
+export const WEEKLY_STREAK_GOAL = 7;
+export const DEFAULT_RING_SIZE = 160;
+export const DEFAULT_RING_STROKE = 12;
+
+export type StreakRingGeometry = {
+  size: number;
+  stroke: number;
+  radius: number;
+  circumference: number;
+  progress: number;
+  dashOffset: number;
+  streakCount: number;
+  weeklyGoal: number;
+};
+
+/** Map a real streak count onto SVG ring dash geometry. Zero stays empty. */
+export function buildStreakRingGeometry(input: {
+  streakCount: number;
+  weeklyGoal?: number;
+  size?: number;
+  stroke?: number;
+}): StreakRingGeometry {
+  const streakCount = Number.isFinite(input.streakCount)
+    ? Math.max(0, Math.floor(input.streakCount))
+    : 0;
+  const weeklyGoal = Math.max(
+    1,
+    Math.floor(input.weeklyGoal ?? WEEKLY_STREAK_GOAL),
+  );
+  const size = input.size ?? DEFAULT_RING_SIZE;
+  const stroke = input.stroke ?? DEFAULT_RING_STROKE;
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const progress = Math.min(streakCount / weeklyGoal, 1);
+  const dashOffset = circumference * (1 - progress);
+
+  return {
+    size,
+    stroke,
+    radius,
+    circumference,
+    progress,
+    dashOffset,
+    streakCount,
+    weeklyGoal,
+  };
+}

--- a/tests/unit/tracking_streak_ring.test.ts
+++ b/tests/unit/tracking_streak_ring.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  DEFAULT_RING_SIZE,
+  DEFAULT_RING_STROKE,
+  WEEKLY_STREAK_GOAL,
+  buildStreakRingGeometry,
+} from "../../apps/mobile/lib/tracking-streak-ring";
+
+describe("buildStreakRingGeometry", () => {
+  test("keeps a zero streak empty", () => {
+    const ring = buildStreakRingGeometry({ streakCount: 0 });
+    const expectedCircumference =
+      2 * Math.PI * ((DEFAULT_RING_SIZE - DEFAULT_RING_STROKE) / 2);
+
+    expect(ring.progress).toBe(0);
+    expect(ring.dashOffset).toBeCloseTo(expectedCircumference);
+    expect(ring.weeklyGoal).toBe(WEEKLY_STREAK_GOAL);
+    expect(ring.streakCount).toBe(0);
+  });
+
+  test("fills three of seven days", () => {
+    const ring = buildStreakRingGeometry({ streakCount: 3, weeklyGoal: 7 });
+    expect(ring.progress).toBeCloseTo(3 / 7);
+    expect(ring.dashOffset).toBeCloseTo(ring.circumference * (4 / 7));
+  });
+
+  test("clamps a finished week to a full ring", () => {
+    const full = buildStreakRingGeometry({ streakCount: 7, weeklyGoal: 7 });
+    const over = buildStreakRingGeometry({ streakCount: 10, weeklyGoal: 7 });
+
+    expect(full.progress).toBe(1);
+    expect(full.dashOffset).toBe(0);
+    expect(over.progress).toBe(1);
+    expect(over.dashOffset).toBe(0);
+  });
+
+  test("treats a non-finite count as empty instead of inventing a streak", () => {
+    expect(buildStreakRingGeometry({ streakCount: Number.NaN }).streakCount).toBe(
+      0,
+    );
+    expect(buildStreakRingGeometry({ streakCount: -4 }).streakCount).toBe(0);
+  });
+});
+
+describe("mobile streak ring leftover wiring", () => {
+  const root = join(import.meta.dir, "../..");
+
+  test("tracking uses the ring, Convex streaks.getCurrent, and no fake seed", () => {
+    const screen = readFileSync(
+      join(root, "apps/mobile/app/(tempo)/tracking.tsx"),
+      "utf8",
+    );
+    const ring = readFileSync(
+      join(root, "apps/mobile/components/tracking/TrackingStreakRing.tsx"),
+      "utf8",
+    );
+    const today = readFileSync(
+      join(root, "apps/mobile/app/(tempo)/(tabs)/today.tsx"),
+      "utf8",
+    );
+
+    expect(screen).toContain("TrackingStreakRing");
+    expect(screen).toContain("api.streaks.getCurrent");
+    expect(screen).toContain("TrackingDashboardChart");
+    expect(screen).toContain("sessions={[]}");
+    expect(screen).not.toContain("initialStreak");
+    expect(ring).not.toContain("initialStreak");
+    expect(ring).not.toContain("Count today");
+    expect(today).toContain("TempoEmptyState");
+    expect(today).not.toContain("TrackingStreakRing");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the unique leftover from #184 — an SVG enso streak ring — onto the existing mobile `/tracking` sibling. Ring geometry is driven by `streaks.getCurrent`. A zero streak stays an empty ring. The original PR's fake `initialStreak = 3` and local "Count today" button are not ported.

## Linked task(s)

Task: leftover from #184 (docs/brain TASKS.md is a private submodule in this cloud clone; official T-XXXX not invented).

## Screenshots / screen recording

N/A in this draft — Expo screen is not running in this environment. Unit tests cover empty-ring geometry, 3/7 fill, clamp-to-full, and wiring that `today.tsx` stays `TempoEmptyState`.

## Test plan

- [x] Relevant unit tests added (`tests/unit/tracking_streak_ring.test.ts`)
- [x] Existing tracking chart + route-smoke tests still pass (26)
- [ ] CI Typecheck / Lint / Test / Scans / E2E / Security green
- [x] Manual QA: geometry cases run via `bun test`; Expo UI not exercised here

## Acceptance criteria

- Mobile `/tracking` shows an SVG streak ring
- Ring uses real `streaks.getCurrent` (or 0 when unsigned-in / no user)
- Zero streak is an empty ring — no seeded `initialStreak = 3`
- `today.tsx` stays `TempoEmptyState`
- Chart leftover from #379 stays on the same screen with `sessions={[]}`
- No lockfile / package.json / e2e / today overwrite

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI-originated state changes: N/A
- [x] Schema changes: none
- [x] Styling uses `tempoColors` from `@tempo/ui/theme`
- [x] Accessibility: progressbar role + value on the ring
- [x] No secrets committed
- [x] Voice rules honored — empty ring is a complete enough start; no shame copy

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`). Low-risk leftover; mergeable once CI is green.

## Skipped from #184

- Fake `initialStreak = 3` and "Count today" local button
- Dedicated `tracking-dashboard` route (landed sibling is `/tracking`)
- Playwright e2e + lockfile / package.json

## Original #184

Leave open until this PR merges, then close with a leftover-check comment.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

