### PR TITLE
feat(mobile): persist session logs onto the tracking chart leftover from #212

### DIFF
--- a/apps/mobile/app/(tempo)/tracking.tsx
+++ b/apps/mobile/app/(tempo)/tracking.tsx
@@ -1,13 +1,21 @@
 /**
  * @screen: tracking
  * @platform: mobile
- * @summary: Tracking chart leftover from #188 plus honest streak ring leftover from #184.
+ * @summary: Tracking chart leftover from #188, streak ring from #184, persisted session logs from #212.
  * @queries: streaks.getCurrent
  */
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { TrackingDashboardChart } from "@/components/tracking/TrackingDashboardChart";
 import { TrackingStreakRing } from "@/components/tracking/TrackingStreakRing";
 import { api } from "@/convex/_generated/api";
+import {
+  parseSessionLogEntries,
+  sessionLogsToTrackingSessions,
+} from "@/lib/focus-session-log";
+import { sessionLogStorageKey } from "@/lib/session-player";
+import type { LoggedTrackingSession } from "@/lib/tracking-dashboard-data";
 import { useConvexAuth, useQuery } from "convex/react";
+import { useEffect, useState } from "react";
 import { Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
@@ -20,6 +28,20 @@ export default function Screen() {
     isAuthenticated && hasConvexUser ? {} : "skip",
   );
   const streakCount = habitStreak?.streakCount ?? 0;
+  const [sessions, setSessions] = useState<LoggedTrackingSession[]>([]);
+
+  useEffect(() => {
+    let isMounted = true;
+    void AsyncStorage.getItem(sessionLogStorageKey).then((raw) => {
+      if (!isMounted) {
+        return;
+      }
+      setSessions(sessionLogsToTrackingSessions(parseSessionLogEntries(raw)));
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   return (
     <SafeAreaView className="flex-1 bg-background">
@@ -30,7 +52,7 @@ export default function Screen() {
           you already have. An empty ring is still a complete enough start.
         </Text>
         <TrackingStreakRing streakCount={streakCount} />
-        <TrackingDashboardChart sessions={[]} />
+        <TrackingDashboardChart sessions={sessions} />
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/components/session-player/SessionPlayer.tsx
+++ b/apps/mobile/components/session-player/SessionPlayer.tsx
@@ -1,6 +1,12 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useEffect, useState } from "react";
 import { Pressable, Text, View } from "react-native";
 
+import {
+  appendSessionLogEntry,
+  parseSessionLogEntries,
+  serializeSessionLogEntries,
+} from "@/lib/focus-session-log";
 import {
   advanceSession,
   createIdleSession,
@@ -9,6 +15,7 @@ import {
   pauseSession,
   resumeSession,
   seededRoutines,
+  sessionLogStorageKey,
   startSession,
   type SessionLogEntry,
   type SessionPlayerState,
@@ -27,6 +34,19 @@ export function SessionPlayer() {
   const [log, setLog] = useState<SessionLogEntry[]>([]);
 
   useEffect(() => {
+    let isMounted = true;
+    void AsyncStorage.getItem(sessionLogStorageKey).then((raw) => {
+      if (!isMounted) {
+        return;
+      }
+      setLog(parseSessionLogEntries(raw));
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
     if (state.status !== "running") {
       return;
     }
@@ -37,11 +57,14 @@ export function SessionPlayer() {
         if (next.status === "finished" && current.status !== "finished") {
           try {
             const entry = createSessionLogEntry(next, routine);
-            setLog((entries) =>
-              entries.some((item) => item.id === entry.id)
-                ? entries
-                : [...entries, entry],
-            );
+            setLog((entries) => {
+              const nextEntries = appendSessionLogEntry(entries, entry);
+              void AsyncStorage.setItem(
+                sessionLogStorageKey,
+                serializeSessionLogEntries(nextEntries),
+              );
+              return nextEntries;
+            });
           } catch {
             // Only finished sessions can be logged; ignore races.
           }
@@ -123,7 +146,7 @@ export function SessionPlayer() {
 
       {log.length > 0 ? (
         <Text className="text-sm text-muted-foreground">
-          Logged {log.length} {log.length === 1 ? "loop" : "loops"} this visit.
+          Logged {log.length} {log.length === 1 ? "loop" : "loops"}.
         </Text>
       ) : null}
     </View>

--- a/apps/mobile/lib/focus-session-log.ts
+++ b/apps/mobile/lib/focus-session-log.ts
@@ -1,0 +1,62 @@
+import type { SessionLogEntry } from "./session-player";
+import type { LoggedTrackingSession } from "./tracking-dashboard-data";
+
+function isSessionLogEntry(value: unknown): value is SessionLogEntry {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<SessionLogEntry>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.routineId === "string" &&
+    typeof candidate.startedAt === "number" &&
+    typeof candidate.completedAt === "number" &&
+    typeof candidate.elapsedMs === "number" &&
+    typeof candidate.stepCount === "number"
+  );
+}
+
+/** Parse stored session-player logs. Invalid JSON or rows become an empty list. */
+export function parseSessionLogEntries(rawValue: string | null): SessionLogEntry[] {
+  if (!rawValue) {
+    return [];
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(rawValue);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(isSessionLogEntry);
+  } catch {
+    return [];
+  }
+}
+
+export function serializeSessionLogEntries(
+  entries: ReadonlyArray<SessionLogEntry>,
+): string {
+  return JSON.stringify(entries);
+}
+
+/** Append a finished session. Same id is a no-op so a retry does not double-count. */
+export function appendSessionLogEntry(
+  entries: ReadonlyArray<SessionLogEntry>,
+  entry: SessionLogEntry,
+): SessionLogEntry[] {
+  if (entries.some((item) => item.id === entry.id)) {
+    return [...entries];
+  }
+  return [...entries, entry];
+}
+
+export function sessionLogsToTrackingSessions(
+  entries: ReadonlyArray<SessionLogEntry>,
+): LoggedTrackingSession[] {
+  return entries.map((entry) => ({
+    id: entry.id,
+    loggedAt: entry.completedAt,
+    focusMinutes: entry.elapsedMs / 60_000,
+  }));
+}

--- a/tests/unit/focus_session_log.test.ts
+++ b/tests/unit/focus_session_log.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  appendSessionLogEntry,
+  parseSessionLogEntries,
+  serializeSessionLogEntries,
+  sessionLogsToTrackingSessions,
+} from "../../apps/mobile/lib/focus-session-log";
+import type { SessionLogEntry } from "../../apps/mobile/lib/session-player";
+
+const finished: SessionLogEntry = {
+  id: "seed-morning-reset:5000",
+  routineId: "seed-morning-reset",
+  startedAt: 1000,
+  completedAt: 5000,
+  elapsedMs: 3000,
+  stepCount: 3,
+};
+
+describe("focus session log leftover from #212", () => {
+  test("empty or invalid storage stays empty", () => {
+    expect(parseSessionLogEntries(null)).toEqual([]);
+    expect(parseSessionLogEntries("")).toEqual([]);
+    expect(parseSessionLogEntries("{")).toEqual([]);
+    expect(parseSessionLogEntries("{\"oops\":true}")).toEqual([]);
+  });
+
+  test("round-trips a finished session and skips a duplicate id", () => {
+    const stored = serializeSessionLogEntries([finished]);
+    const loaded = parseSessionLogEntries(stored);
+    expect(loaded).toEqual([finished]);
+    expect(appendSessionLogEntry(loaded, finished)).toEqual([finished]);
+  });
+
+  test("maps elapsedMs onto tracking chart minutes without inventing a 25-minute block", () => {
+    const [point] = sessionLogsToTrackingSessions([finished]);
+    expect(point).toEqual({
+      id: finished.id,
+      loggedAt: 5000,
+      focusMinutes: 3000 / 60_000,
+    });
+  });
+});
+
+describe("session log leftover wiring", () => {
+  const root = join(import.meta.dir, "../..");
+
+  test("player persists, tracking reads, today stays empty", () => {
+    const player = readFileSync(
+      join(root, "apps/mobile/components/session-player/SessionPlayer.tsx"),
+      "utf8",
+    );
+    const tracking = readFileSync(
+      join(root, "apps/mobile/app/(tempo)/tracking.tsx"),
+      "utf8",
+    );
+    const today = readFileSync(
+      join(root, "apps/mobile/app/(tempo)/(tabs)/today.tsx"),
+      "utf8",
+    );
+
+    expect(player).toContain("sessionLogStorageKey");
+    expect(player).toContain("appendSessionLogEntry");
+    expect(tracking).toContain("sessionLogsToTrackingSessions");
+    expect(tracking).toContain("sessionLogStorageKey");
+    expect(tracking).not.toContain("sessions={[]}");
+    expect(today).toContain("TempoEmptyState");
+    expect(today).not.toContain("sessionLogStorageKey");
+  });
+});

--- a/tests/unit/tracking_dashboard_chart.test.ts
+++ b/tests/unit/tracking_dashboard_chart.test.ts
@@ -65,7 +65,7 @@ describe("mobile tracking leftover wiring", () => {
     );
 
     expect(screen).toContain("TrackingDashboardChart");
-    expect(screen).toContain("sessions={[]}");
+    expect(screen).toContain("sessionLogsToTrackingSessions");
     expect(today).toContain("TempoEmptyState");
     expect(today).not.toContain("TrackingDashboardChart");
   });

--- a/tests/unit/tracking_streak_ring.test.ts
+++ b/tests/unit/tracking_streak_ring.test.ts
@@ -64,7 +64,7 @@ describe("mobile streak ring leftover wiring", () => {
     expect(screen).toContain("TrackingStreakRing");
     expect(screen).toContain("api.streaks.getCurrent");
     expect(screen).toContain("TrackingDashboardChart");
-    expect(screen).toContain("sessions={[]}");
+    expect(screen).toContain("sessions={sessions}");
     expect(screen).not.toContain("initialStreak");
     expect(ring).not.toContain("initialStreak");
     expect(ring).not.toContain("Count today");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the unique leftover from #212: persist finished session-player loops and feed them to the `/tracking` chart. Storage key is the landed `tempo.sessionPlayer.log.v1`. Chart minutes come from real `elapsedMs`. Empty storage stays empty. `today.tsx` stays `TempoEmptyState`.

## Linked task(s)

Task: leftover from #212 (docs/brain TASKS.md is a private submodule in this cloud clone; official T-XXXX not invented).

## Screenshots / screen recording

N/A in this draft — Expo screen is not running here. Unit tests cover parse/dedup/map and wiring.

## Test plan

- [x] Unit tests added (`tests/unit/focus_session_log.test.ts`)
- [x] Tracking chart / streak-ring / session-player / route-smoke tests still pass (35)
- [ ] CI Typecheck / Lint / Test / Scans / E2E / Security green

## Acceptance criteria

- Finished session-player loops persist to `tempo.sessionPlayer.log.v1`
- `/tracking` reads that store and maps `elapsedMs` onto chart minutes
- Empty or invalid storage stays an empty chart
- No hardcoded 25-minute block
- `today.tsx` stays `TempoEmptyState`
- No lockfile / package.json / e2e

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI-originated state changes: N/A
- [x] Schema changes: none
- [x] Styling unchanged (existing tokens)
- [x] Accessibility: existing player/chart labels kept
- [x] No secrets committed
- [x] Voice rules honored — empty chart is still a complete enough start

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`). Low-risk leftover; mergeable once CI is green.

## Skipped from #212

- Overwrite of `(tabs)/today.tsx`
- Hardcoded `durationMinutes: 25` / title "Focus session"
- Playwright e2e + lockfile / package.json

## Original #212

Leave open until this PR merges, then close with a leftover-check comment.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

