### PR TITLE
feat(mobile): open guided movement loops in the session player leftover from #221

### DIFF
--- a/apps/mobile/app/(tempo)/movement.tsx
+++ b/apps/mobile/app/(tempo)/movement.tsx
@@ -4,12 +4,15 @@
  * @summary: Movement-library leftover from #186. Sibling of routines so the breath timer stays put.
  */
 
-import { useLocalSearchParams } from 'expo-router';
+import { Link, useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
 import { Pressable, ScrollView, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
+  getGuidedMovementRoutineById,
   getMovementRoutineById,
+  guidedMovementRoutines,
+  isGuidedMovementRoutineId,
   isMovementRoutineId,
   movementRoutineSections,
 } from '@/lib/movement-routines';
@@ -17,12 +20,17 @@ import {
 export default function Screen() {
   const params = useLocalSearchParams<{ routine?: string }>();
   const initialId =
-    typeof params.routine === 'string' && isMovementRoutineId(params.routine)
+    typeof params.routine === 'string' &&
+    (isMovementRoutineId(params.routine) ||
+      isGuidedMovementRoutineId(params.routine))
       ? params.routine
       : undefined;
   const [routineId, setRoutineId] = useState<string | undefined>(initialId);
   const selected = routineId ? getMovementRoutineById(routineId) : undefined;
-  const unknownSelected = Boolean(routineId) && !selected;
+  const guided = routineId
+    ? getGuidedMovementRoutineById(routineId)
+    : undefined;
+  const unknownSelected = Boolean(routineId) && !selected && !guided;
 
   if (unknownSelected) {
     return (
@@ -45,6 +53,73 @@ export default function Screen() {
             </Text>
           </Pressable>
         </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (guided) {
+    return (
+      <SafeAreaView className="flex-1 bg-background">
+        <ScrollView
+          className="flex-1"
+          contentContainerClassName="gap-6 px-6 pb-10 pt-6"
+        >
+          <Pressable
+            accessibilityRole="button"
+            className="min-h-11 self-start justify-center rounded-full border border-border px-4"
+            onPress={() => setRoutineId(undefined)}
+          >
+            <Text className="text-sm font-semibold text-foreground">
+              Back to the library
+            </Text>
+          </Pressable>
+
+          <View className="gap-3 rounded-2xl border border-border bg-card p-5">
+            <Text className="text-sm font-semibold uppercase text-muted-foreground">
+              Guided loop
+            </Text>
+            <Text className="text-3xl font-semibold leading-9 text-foreground">
+              {guided.title}
+            </Text>
+            <Text className="text-base leading-6 text-muted-foreground">
+              {guided.summary}
+            </Text>
+            <Text className="text-sm text-muted-foreground">
+              {guided.durationMinutes} min
+            </Text>
+          </View>
+
+          <Link href={`/session-player?routine=${guided.id}`} asChild>
+            <Text
+              accessibilityRole="link"
+              className="text-base font-semibold text-foreground"
+            >
+              Open in the session player
+            </Text>
+          </Link>
+
+          <View className="gap-3">
+            <Text className="text-xl font-semibold text-foreground">
+              Sequence
+            </Text>
+            {guided.steps.map((step, index) => (
+              <View
+                className="gap-2 rounded-2xl border border-border bg-card p-4"
+                key={step.id}
+              >
+                <Text className="text-xs font-semibold uppercase text-muted-foreground">
+                  Step {index + 1} · {step.durationMinutes} min
+                </Text>
+                <Text className="text-lg font-semibold text-foreground">
+                  {step.title}
+                </Text>
+                <Text className="text-sm leading-6 text-muted-foreground">
+                  {step.guidance}
+                </Text>
+              </View>
+            ))}
+          </View>
+        </ScrollView>
       </SafeAreaView>
     );
   }
@@ -133,7 +208,7 @@ export default function Screen() {
             Movement
           </Text>
           <Text className="text-sm leading-6 text-muted-foreground">
-            Five short sessions, grouped by how they feel. Open one when moving
+            Category sessions plus three guided loops. Open one when moving
             would help. Nothing here is required.
           </Text>
         </View>
@@ -168,6 +243,35 @@ export default function Screen() {
             ))}
           </View>
         ))}
+
+        <View className="gap-3">
+          <View className="gap-1">
+            <Text className="text-lg font-semibold text-foreground">
+              Gentle resets
+            </Text>
+            <Text className="text-sm leading-6 text-muted-foreground">
+              Timed loops you can open in the session player.
+            </Text>
+          </View>
+          {guidedMovementRoutines.map((routine) => (
+            <Pressable
+              accessibilityRole="button"
+              className="gap-2 rounded-2xl border border-border bg-card p-4"
+              key={routine.id}
+              onPress={() => setRoutineId(routine.id)}
+            >
+              <Text className="text-base font-semibold text-foreground">
+                {routine.title}
+              </Text>
+              <Text className="text-sm leading-6 text-muted-foreground">
+                {routine.summary}
+              </Text>
+              <Text className="text-xs text-muted-foreground">
+                {routine.durationMinutes} min
+              </Text>
+            </Pressable>
+          ))}
+        </View>
       </ScrollView>
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tempo)/session-player.tsx
+++ b/apps/mobile/app/(tempo)/session-player.tsx
@@ -3,20 +3,40 @@
  * @platform: mobile
  * @summary: Session player leftover from #187. Sibling of routines so BreathworkTimer stays put.
  */
-import { SessionPlayer } from "@/components/session-player/SessionPlayer";
-import { Text, View } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+
+import { useLocalSearchParams } from 'expo-router';
+import { Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { SessionPlayer } from '@/components/session-player/SessionPlayer';
+import {
+  getGuidedMovementRoutineById,
+  guidedMovementToSession,
+} from '@/lib/movement-routines';
+import { seededRoutines } from '@/lib/session-player';
 
 export default function Screen() {
+  const params = useLocalSearchParams<{ routine?: string }>();
+  const guided =
+    typeof params.routine === 'string'
+      ? getGuidedMovementRoutineById(params.routine)
+      : undefined;
+  const routine = guided ? guidedMovementToSession(guided) : seededRoutines[0];
+
+  if (!routine) {
+    throw new Error('Expected a session routine');
+  }
+
   return (
     <SafeAreaView className="flex-1 bg-background">
       <View className="flex-1 p-6 gap-5">
-        <Text className="text-2xl font-semibold text-foreground">Session player</Text>
+        <Text className="text-2xl font-semibold text-foreground">
+          Session player
+        </Text>
         <Text className="text-sm text-muted-foreground">
           A short loop you can start, pause, and finish. Coming back later is
           still a complete enough day.
         </Text>
-        <SessionPlayer />
+        <SessionPlayer routine={routine} />
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/components/session-player/SessionPlayer.tsx
+++ b/apps/mobile/components/session-player/SessionPlayer.tsx
@@ -1,37 +1,46 @@
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { useEffect, useState } from "react";
-import { Pressable, Text, View } from "react-native";
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useEffect, useState } from 'react';
+import { Pressable, Text, View } from 'react-native';
 
 import {
   appendSessionLogEntry,
   parseSessionLogEntries,
   serializeSessionLogEntries,
-} from "@/lib/focus-session-log";
+} from '@/lib/focus-session-log';
 import {
   advanceSession,
   createIdleSession,
   createSessionLogEntry,
   getCurrentStep,
   pauseSession,
+  type Routine,
   resumeSession,
+  type SessionLogEntry,
+  type SessionPlayerState,
   seededRoutines,
   sessionLogStorageKey,
   startSession,
-  type SessionLogEntry,
-  type SessionPlayerState,
-} from "@/lib/session-player";
+} from '@/lib/session-player';
 
-const routine = seededRoutines[0];
+const fallbackRoutine = seededRoutines[0];
 
-if (!routine) {
-  throw new Error("Expected seeded routine");
+if (!fallbackRoutine) {
+  throw new Error('Expected seeded routine');
 }
 
-export function SessionPlayer() {
+export function SessionPlayer({
+  routine = fallbackRoutine,
+}: {
+  routine?: Routine;
+}) {
   const [state, setState] = useState<SessionPlayerState>(() =>
-    createIdleSession(routine.id),
+    createIdleSession(routine.id)
   );
   const [log, setLog] = useState<SessionLogEntry[]>([]);
+
+  useEffect(() => {
+    setState(createIdleSession(routine.id));
+  }, [routine.id]);
 
   useEffect(() => {
     let isMounted = true;
@@ -47,21 +56,21 @@ export function SessionPlayer() {
   }, []);
 
   useEffect(() => {
-    if (state.status !== "running") {
+    if (state.status !== 'running') {
       return;
     }
 
     const timer = setInterval(() => {
       setState((current) => {
         const next = advanceSession(current, routine, Date.now());
-        if (next.status === "finished" && current.status !== "finished") {
+        if (next.status === 'finished' && current.status !== 'finished') {
           try {
             const entry = createSessionLogEntry(next, routine);
             setLog((entries) => {
               const nextEntries = appendSessionLogEntry(entries, entry);
               void AsyncStorage.setItem(
                 sessionLogStorageKey,
-                serializeSessionLogEntries(nextEntries),
+                serializeSessionLogEntries(nextEntries)
               );
               return nextEntries;
             });
@@ -76,7 +85,7 @@ export function SessionPlayer() {
     return () => {
       clearInterval(timer);
     };
-  }, [state.status]);
+  }, [state.status, routine]);
 
   const current = getCurrentStep(routine, state.elapsedMs);
 
@@ -86,28 +95,32 @@ export function SessionPlayer() {
         <Text className="text-sm font-semibold uppercase text-muted-foreground">
           Session
         </Text>
-        <Text className="text-2xl font-semibold text-foreground">{routine.title}</Text>
+        <Text className="text-2xl font-semibold text-foreground">
+          {routine.title}
+        </Text>
         <Text className="text-sm leading-6 text-muted-foreground">
           {routine.subtitle}
         </Text>
       </View>
 
       <View className="gap-2 rounded-2xl border border-border bg-card p-5">
-        <Text className="text-lg font-semibold text-foreground">{current.step.title}</Text>
+        <Text className="text-lg font-semibold text-foreground">
+          {current.step.title}
+        </Text>
         <Text className="text-sm leading-6 text-muted-foreground">
           {current.step.guidance}
         </Text>
         <Text className="text-xs text-muted-foreground">
-          {state.status === "idle"
-            ? "Ready when you are."
-            : state.status === "finished"
-              ? "That loop is complete enough."
+          {state.status === 'idle'
+            ? 'Ready when you are.'
+            : state.status === 'finished'
+              ? 'That loop is complete enough.'
               : `Step ${current.index + 1} of ${routine.steps.length}`}
         </Text>
       </View>
 
       <View className="flex-row flex-wrap gap-3">
-        {state.status === "idle" || state.status === "finished" ? (
+        {state.status === 'idle' || state.status === 'finished' ? (
           <Pressable
             accessibilityRole="button"
             className="min-h-11 rounded-full border border-border bg-background px-4 py-2"
@@ -116,11 +129,11 @@ export function SessionPlayer() {
             }}
           >
             <Text className="text-sm font-semibold text-foreground">
-              {state.status === "finished" ? "Play again" : "Start this loop"}
+              {state.status === 'finished' ? 'Play again' : 'Start this loop'}
             </Text>
           </Pressable>
         ) : null}
-        {state.status === "running" ? (
+        {state.status === 'running' ? (
           <Pressable
             accessibilityRole="button"
             className="min-h-11 rounded-full border border-border bg-background px-4 py-2"
@@ -131,7 +144,7 @@ export function SessionPlayer() {
             <Text className="text-sm font-semibold text-foreground">Pause</Text>
           </Pressable>
         ) : null}
-        {state.status === "paused" ? (
+        {state.status === 'paused' ? (
           <Pressable
             accessibilityRole="button"
             className="min-h-11 rounded-full border border-border bg-background px-4 py-2"
@@ -139,14 +152,16 @@ export function SessionPlayer() {
               setState((current) => resumeSession(current, Date.now()));
             }}
           >
-            <Text className="text-sm font-semibold text-foreground">Resume</Text>
+            <Text className="text-sm font-semibold text-foreground">
+              Resume
+            </Text>
           </Pressable>
         ) : null}
       </View>
 
       {log.length > 0 ? (
         <Text className="text-sm text-muted-foreground">
-          Logged {log.length} {log.length === 1 ? "loop" : "loops"}.
+          Logged {log.length} {log.length === 1 ? 'loop' : 'loops'}.
         </Text>
       ) : null}
     </View>

--- a/apps/mobile/lib/movement-routines.ts
+++ b/apps/mobile/lib/movement-routines.ts
@@ -1,3 +1,5 @@
+import type { Routine } from './session-player';
+
 export type MovementCategoryId =
   | 'animal-flow'
   | 'fighter-yoga-mobility'
@@ -153,4 +155,153 @@ export function getMovementRoutineById(
   routineId: string
 ): MovementRoutine | undefined {
   return movementRoutines.find((routine) => routine.id === routineId);
+}
+
+export type GuidedMovementStep = {
+  id: string;
+  title: string;
+  guidance: string;
+  durationMinutes: number;
+};
+
+export type GuidedMovementRoutine = {
+  id: string;
+  title: string;
+  subtitle: string;
+  summary: string;
+  durationMinutes: number;
+  steps: readonly GuidedMovementStep[];
+};
+
+/** Leftover from #221 — timed, guided loops that can open in the session player. */
+export const guidedMovementRoutines: readonly GuidedMovementRoutine[] = [
+  {
+    id: 'morning-reset',
+    title: 'Morning reset',
+    subtitle: 'A gentle start for stiff or scattered mornings.',
+    summary: 'Arrive in your body before the day asks anything from you.',
+    durationMinutes: 6,
+    steps: [
+      {
+        id: 'stand',
+        title: 'Stand and notice',
+        guidance: 'Plant both feet. Let your shoulders drop once.',
+        durationMinutes: 1,
+      },
+      {
+        id: 'roll',
+        title: 'Shoulder rolls',
+        guidance: 'Roll slowly forward, then back. Keep it easy.',
+        durationMinutes: 2,
+      },
+      {
+        id: 'reach',
+        title: 'Side reach',
+        guidance: 'Reach one arm overhead, switch sides, and breathe out.',
+        durationMinutes: 2,
+      },
+      {
+        id: 'choose',
+        title: 'Choose the next tiny move',
+        guidance: 'Name one small thing you can do next.',
+        durationMinutes: 1,
+      },
+    ],
+  },
+  {
+    id: 'desk-unlock',
+    title: 'Desk unlock',
+    subtitle: 'Loosen up after a long sit without changing clothes.',
+    summary: 'Release neck, wrists, and hips enough to keep going.',
+    durationMinutes: 5,
+    steps: [
+      {
+        id: 'neck',
+        title: 'Neck half-circles',
+        guidance: 'Draw small half-circles from shoulder to shoulder.',
+        durationMinutes: 1,
+      },
+      {
+        id: 'wrists',
+        title: 'Wrist circles',
+        guidance: 'Circle both wrists, then shake your hands out.',
+        durationMinutes: 1,
+      },
+      {
+        id: 'hips',
+        title: 'Seated hip shift',
+        guidance: 'Shift your weight side to side and notice what softens.',
+        durationMinutes: 2,
+      },
+      {
+        id: 'eyes',
+        title: 'Look far away',
+        guidance: 'Rest your eyes on something across the room.',
+        durationMinutes: 1,
+      },
+    ],
+  },
+  {
+    id: 'shutdown-stretch',
+    title: 'Shutdown stretch',
+    subtitle: 'Close the day with a low-pressure body check.',
+    summary: 'Signal that work can loosen its grip now.',
+    durationMinutes: 7,
+    steps: [
+      {
+        id: 'breath',
+        title: 'Long exhale',
+        guidance: 'Breathe in naturally, then make the exhale a little longer.',
+        durationMinutes: 2,
+      },
+      {
+        id: 'fold',
+        title: 'Easy forward fold',
+        guidance: 'Bend your knees and let your head be heavy.',
+        durationMinutes: 2,
+      },
+      {
+        id: 'twist',
+        title: 'Gentle twist',
+        guidance: 'Twist from the ribs, not from force.',
+        durationMinutes: 2,
+      },
+      {
+        id: 'done',
+        title: 'Mark one good-enough thing',
+        guidance: 'Say one thing that counted today, even if it was small.',
+        durationMinutes: 1,
+      },
+    ],
+  },
+];
+
+export const guidedMovementRoutineIds = guidedMovementRoutines.map(
+  (routine) => routine.id
+);
+
+export function isGuidedMovementRoutineId(value: string | undefined): boolean {
+  return typeof value === 'string' && guidedMovementRoutineIds.includes(value);
+}
+
+export function getGuidedMovementRoutineById(
+  routineId: string
+): GuidedMovementRoutine | undefined {
+  return guidedMovementRoutines.find((routine) => routine.id === routineId);
+}
+
+export function guidedMovementToSession(
+  routine: GuidedMovementRoutine
+): Routine {
+  return {
+    id: routine.id,
+    title: routine.title,
+    subtitle: routine.subtitle,
+    steps: routine.steps.map((step) => ({
+      id: step.id,
+      title: step.title,
+      guidance: step.guidance,
+      durationMs: step.durationMinutes * 60_000,
+    })),
+  };
 }

--- a/tests/unit/movement_routines.test.ts
+++ b/tests/unit/movement_routines.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+  getGuidedMovementRoutineById,
   getMovementRoutineById,
+  guidedMovementToSession,
+  guidedMovementRoutineIds,
+  isGuidedMovementRoutineId,
   isMovementRoutineId,
   movementCategories,
   movementRoutineIds,
@@ -47,6 +51,32 @@ describe("movement library leftover from #186", () => {
   });
 });
 
+describe("guided movement leftover from #221", () => {
+  test("maps minute steps onto the session player without inventing duration", () => {
+    expect(guidedMovementRoutineIds).toEqual([
+      "morning-reset",
+      "desk-unlock",
+      "shutdown-stretch",
+    ]);
+    expect(isGuidedMovementRoutineId("desk-unlock")).toBe(true);
+    expect(isGuidedMovementRoutineId("sprint")).toBe(false);
+    expect(getGuidedMovementRoutineById("sprint")).toBeUndefined();
+
+    const desk = getGuidedMovementRoutineById("desk-unlock");
+    expect(desk).toBeDefined();
+    if (!desk) {
+      throw new Error("Expected desk-unlock");
+    }
+    const session = guidedMovementToSession(desk);
+    expect(session.steps.map((step) => step.durationMs)).toEqual([
+      60_000, 60_000, 120_000, 60_000,
+    ]);
+    expect(session.steps[0]?.guidance).toBe(
+      "Draw small half-circles from shoulder to shoulder.",
+    );
+  });
+});
+
 describe("movement route leftover wiring", () => {
   const root = join(import.meta.dir, "../..");
 
@@ -59,10 +89,16 @@ describe("movement route leftover wiring", () => {
       join(root, "apps/mobile/app/(tempo)/routines.tsx"),
       "utf8",
     );
+    const player = readFileSync(
+      join(root, "apps/mobile/app/(tempo)/session-player.tsx"),
+      "utf8",
+    );
 
     expect(screen).toContain("movementRoutineSections");
-    expect(screen).toContain("getMovementRoutineById");
+    expect(screen).toContain("guidedMovementRoutines");
+    expect(screen).toContain("/session-player?routine=");
     expect(routines).toContain("BreathworkTimer");
     expect(routines).toContain('href="/movement"');
+    expect(player).toContain("guidedMovementToSession");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the unique leftover from #221: three guided movement loops (Morning reset, Desk unlock, Shutdown stretch) with per-step guidance and minute durations. They open in the landed pause-freeze `/session-player?routine=` instead of adding `routines/[id].tsx` beside `routines.tsx`.

The five-category #384 catalog stays as string-step library rows. This PR only adds the guided set.

## Linked task(s)

Leftover from #221. `docs/brain/` is empty in this cloud clone — no invented `T-XXXX` IDs.

## Screenshots / screen recording

N/A in this draft — unit coverage for duration mapping + route wiring.

## Test plan

- [x] Local `bun test ./tests/unit/movement_routines.test.ts ./tests/unit/session_player.test.ts ./tests/unit/mobile_route_smoke.test.ts` (27 pass)
- [x] Local `biome lint` on edited mobile files
- [ ] CI lint / typecheck / test

## Acceptance criteria

- Guided ids `morning-reset`, `desk-unlock`, `shutdown-stretch` map `durationMinutes` to `durationMs` without inventing times
- Unknown guided ids stay empty
- `/movement` links a guided session to `/session-player?routine=`
- `routines.tsx` is not overwritten; BreathworkTimer stays
- Pause-freeze session player is reused (no wall-clock #218 model)

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI-originated state changes N/A
- [x] Schema changes N/A
- [x] Styling uses existing NativeWind tokens
- [x] Accessibility: buttons/links use roles; missing-id copy is not shame
- [x] No secrets committed
- [x] Voice rules honored

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`) by default.

## Skipped from #221

- `routines/[id].tsx` (file-vs-folder)
- Overwrite of `routines.tsx`
- Playwright + lockfile
- Static-only player (replaced by landed timed SessionPlayer)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

