### PR TITLE
feat(tasks): add optional checklists leftover from #206

### DIFF
--- a/apps/web/app/(tempo)/tasks/checklists/page.tsx
+++ b/apps/web/app/(tempo)/tasks/checklists/page.tsx
@@ -1,0 +1,5 @@
+import { TaskViewsScreen } from "@/components/tasks/TaskViewsScreen";
+
+export default function ChecklistTasksPage() {
+  return <TaskViewsScreen view="checklists" />;
+}

--- a/apps/web/components/tasks/TaskViewsScreen.tsx
+++ b/apps/web/components/tasks/TaskViewsScreen.tsx
@@ -7,6 +7,11 @@ import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { api } from "@/convex/_generated/api";
 import {
+  getChecklistProgress,
+  parseChecklistText,
+  toggleChecklistItem,
+} from "@/convex/lib/taskChecklists";
+import {
   filterTasksForView,
   groupTasksByEnergy,
   groupTasksByPriority,
@@ -44,6 +49,7 @@ type Draft = {
   energy: TaskEnergy;
   dueToday: boolean;
   repeat: RepeatDraft;
+  checklistText: string;
 };
 
 const localStorageKey = "tempo:task-views-core:v1";
@@ -54,6 +60,7 @@ const viewLinks = [
   { href: "/projects/home-reset", label: "Project" },
   { href: "/tasks/priority", label: "Priority" },
   { href: "/tasks/energy", label: "Energy" },
+  { href: "/tasks/checklists", label: "Checklists" },
 ] as const;
 
 const defaultDraft: Draft = {
@@ -63,6 +70,7 @@ const defaultDraft: Draft = {
   energy: "medium",
   dueToday: false,
   repeat: "none",
+  checklistText: "",
 };
 
 const allowLocalTaskViews =
@@ -106,6 +114,7 @@ function getViewTitle(view: TaskView, projectSlug?: string): string {
   if (view === "inbox") return "Inbox";
   if (view === "priority") return "Priority";
   if (view === "energy") return "Energy";
+  if (view === "checklists") return "Checklists";
   return titleFromProjectSlug(projectSlug ?? "project");
 }
 
@@ -120,6 +129,7 @@ function toViewRecord(task: ConvexTaskRecord): TaskViewRecord {
     projectId: task.projectId,
     projectName: task.projectName,
     dueAt: task.dueAt,
+    checklist: task.checklist,
     updatedAt: task.updatedAt,
   };
 }
@@ -214,6 +224,7 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
         ? projectId
         : slugifyProjectName(normalizedProjectName);
     const dueAt = draft.dueToday ? bounds.endMs - 1 : undefined;
+    const checklist = parseChecklistText(draft.checklistText);
 
     if (usesConvex) {
       const taskId = await createTask({
@@ -223,6 +234,7 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
         dueAt,
         projectId: normalizedProjectId,
         projectName: normalizedProjectName,
+        checklist,
       });
       if (draft.repeat === "daily" || draft.repeat === "weekly") {
         const cfgId = await createRepeatCfg({
@@ -245,6 +257,7 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
           projectId: normalizedProjectId,
           projectName: normalizedProjectName,
           dueAt,
+          checklist,
           createdAt: now,
           updatedAt: now,
         },
@@ -254,7 +267,7 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
       return;
     }
 
-    setDraft((current) => ({ ...current, title: "" }));
+    setDraft((current) => ({ ...current, title: "", checklistText: "" }));
   };
 
   const handleToggle = async (task: TaskViewRecord) => {
@@ -301,6 +314,28 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
 
     setEditingId(null);
     setEditingTitle("");
+  };
+
+  const handleChecklistToggle = async (task: TaskViewRecord, itemId: string) => {
+    if (!task.checklist || !taskStoreReady) {
+      return;
+    }
+    const checklist = toggleChecklistItem(task.checklist, itemId);
+
+    if (usesConvex) {
+      await updateTask({ taskId: task.id as Id<"tasks">, checklist });
+      return;
+    }
+
+    if (!usesLocalStore) {
+      return;
+    }
+
+    persistLocal((tasks) =>
+      tasks.map((item) =>
+        item.id === task.id ? { ...item, checklist, updatedAt: Date.now() } : item,
+      ),
+    );
   };
 
   return (
@@ -434,6 +469,20 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
             />
             Show on Today
           </label>
+          <label className="mt-4 block space-y-2">
+            <span className="text-sm font-medium text-foreground">Checklist (one step per line)</span>
+            <textarea
+              aria-label="Checklist steps"
+              value={draft.checklistText}
+              disabled={!taskStoreReady}
+              onChange={(event) =>
+                setDraft((current) => ({ ...current, checklistText: event.target.value }))
+              }
+              rows={3}
+              className="w-full rounded-xl border border-border bg-background px-3 py-2 text-foreground outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-70"
+              placeholder="Unpack the bag&#10;Put the kettle on"
+            />
+          </label>
         </section>
 
         {view === "priority" ? (
@@ -447,6 +496,7 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
             onEdit={startEditing}
             onSave={(task) => void saveEdit(task)}
             onToggle={(task) => void handleToggle(task)}
+            onChecklistToggle={(task, itemId) => void handleChecklistToggle(task, itemId)}
           />
         ) : view === "energy" ? (
           <GroupedTaskList
@@ -459,6 +509,7 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
             onEdit={startEditing}
             onSave={(task) => void saveEdit(task)}
             onToggle={(task) => void handleToggle(task)}
+            onChecklistToggle={(task, itemId) => void handleChecklistToggle(task, itemId)}
           />
         ) : (
           <TaskList
@@ -470,6 +521,7 @@ export function TaskViewsScreen({ view, projectSlug }: TaskViewsScreenProps) {
             onEdit={startEditing}
             onSave={(task) => void saveEdit(task)}
             onToggle={(task) => void handleToggle(task)}
+            onChecklistToggle={(task, itemId) => void handleChecklistToggle(task, itemId)}
           />
         )}
       </div>
@@ -486,6 +538,7 @@ type TaskListProps = {
   onEdit: (task: TaskViewRecord) => void;
   onSave: (task: TaskViewRecord) => void;
   onToggle: (task: TaskViewRecord) => void;
+  onChecklistToggle: (task: TaskViewRecord, itemId: string) => void;
 };
 
 function TaskList({
@@ -497,6 +550,7 @@ function TaskList({
   onEdit,
   onSave,
   onToggle,
+  onChecklistToggle,
 }: TaskListProps) {
   if (tasks.length === 0) {
     return (
@@ -520,6 +574,7 @@ function TaskList({
           onEdit={onEdit}
           onSave={onSave}
           onToggle={onToggle}
+          onChecklistToggle={onChecklistToggle}
         />
       ))}
     </ul>
@@ -541,6 +596,7 @@ function GroupedTaskList<TGroup extends string>({
   onEdit,
   onSave,
   onToggle,
+  onChecklistToggle,
 }: GroupedTaskListProps<TGroup>) {
   return (
     <div className="space-y-6">
@@ -558,6 +614,7 @@ function GroupedTaskList<TGroup extends string>({
             onEdit={onEdit}
             onSave={onSave}
             onToggle={onToggle}
+            onChecklistToggle={onChecklistToggle}
           />
         </section>
       ))}
@@ -574,6 +631,7 @@ type TaskRowProps = {
   onEdit: (task: TaskViewRecord) => void;
   onSave: (task: TaskViewRecord) => void;
   onToggle: (task: TaskViewRecord) => void;
+  onChecklistToggle: (task: TaskViewRecord, itemId: string) => void;
 };
 
 function TaskRow({
@@ -585,8 +643,10 @@ function TaskRow({
   onEdit,
   onSave,
   onToggle,
+  onChecklistToggle,
 }: TaskRowProps) {
   const isDone = task.status === "done";
+  const checklistProgress = getChecklistProgress(task.checklist);
 
   return (
     <li
@@ -643,7 +703,32 @@ function TaskRow({
             <span className="rounded-pill bg-surface-sunken px-3 py-1">{task.projectName ?? "Inbox"}</span>
             <span className="rounded-pill bg-surface-sunken px-3 py-1">{task.priority} priority</span>
             <span className="rounded-pill bg-surface-sunken px-3 py-1">{task.energy} energy</span>
+            {checklistProgress.total > 0 ? (
+              <span className="rounded-pill bg-surface-sunken px-3 py-1">
+                {checklistProgress.completed}/{checklistProgress.total} steps
+              </span>
+            ) : null}
           </div>
+          {task.checklist && task.checklist.length > 0 ? (
+            <ul className="space-y-2 pt-1" aria-label={`${task.title} checklist`}>
+              {task.checklist.map((item) => (
+                <li key={item.id}>
+                  <label className="flex min-h-11 items-center gap-2 text-sm text-foreground">
+                    <input
+                      type="checkbox"
+                      checked={item.completed}
+                      disabled={actionsDisabled}
+                      onChange={() => onChecklistToggle(task, item.id)}
+                      className="h-4 w-4 rounded border-border text-primary"
+                    />
+                    <span className={cn(item.completed && "text-muted-foreground line-through")}>
+                      {item.text}
+                    </span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          ) : null}
         </div>
         {!editing ? (
           <Button

--- a/apps/web/lib/task-view-filters.ts
+++ b/apps/web/lib/task-view-filters.ts
@@ -1,7 +1,13 @@
 export type TaskStatus = "todo" | "in_progress" | "done" | "cancelled";
 export type TaskPriority = "low" | "medium" | "high";
 export type TaskEnergy = "low" | "medium" | "high";
-export type TaskView = "today" | "inbox" | "project" | "priority" | "energy";
+export type TaskView = "today" | "inbox" | "project" | "priority" | "energy" | "checklists";
+
+export type TaskChecklistItem = {
+  id: string;
+  text: string;
+  completed: boolean;
+};
 
 export type TaskViewRecord = {
   id: string;
@@ -13,13 +19,14 @@ export type TaskViewRecord = {
   projectId?: string;
   projectName?: string;
   dueAt?: number;
+  checklist?: TaskChecklistItem[];
   updatedAt: number;
 };
 
 export type TaskViewFilter =
   | { view: "today"; todayStart: number; todayEnd: number }
   | { view: "project"; projectId: string }
-  | { view: "inbox" | "priority" | "energy" };
+  | { view: "inbox" | "priority" | "energy" | "checklists" };
 
 export type TaskGroups = Record<TaskPriority, TaskViewRecord[]>;
 export type EnergyGroups = Record<TaskEnergy, TaskViewRecord[]>;
@@ -59,6 +66,10 @@ export function filterTasksForView(tasks: TaskViewRecord[], filter: TaskViewFilt
 
     if (filter.view === "project") {
       return task.projectId === filter.projectId;
+    }
+
+    if (filter.view === "checklists") {
+      return (task.checklist?.length ?? 0) > 0;
     }
 
     return true;

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -20,6 +20,7 @@ const isCoreTaskViewRoute = createRouteMatcher([
   "/tasks",
   "/tasks/priority",
   "/tasks/energy",
+  "/tasks/checklists",
   "/projects",
   "/projects/(.*)",
 ]);

--- a/convex/lib/taskChecklists.ts
+++ b/convex/lib/taskChecklists.ts
@@ -1,0 +1,106 @@
+/** Checklist leftover from #206 — stored on landed `tasks`, not a new table. */
+
+export const MAX_CHECKLIST_ITEMS = 20;
+
+export type ChecklistItem = {
+  id: string;
+  text: string;
+  completed: boolean;
+};
+
+export type ChecklistProgress = {
+  completed: number;
+  total: number;
+  percent: number;
+};
+
+function slugForChecklistId(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 24);
+}
+
+export function checklistItemId(text: string, index: number): string {
+  const slug = slugForChecklistId(text);
+  return `check-${index}-${slug || "item"}`;
+}
+
+/** One checklist line per newline. Empty lines drop. Caps at `MAX_CHECKLIST_ITEMS`. */
+export function parseChecklistText(text: string): ChecklistItem[] | undefined {
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, MAX_CHECKLIST_ITEMS);
+
+  if (lines.length === 0) {
+    return undefined;
+  }
+
+  return lines.map((line, index) => ({
+    id: checklistItemId(line, index),
+    text: line,
+    completed: false,
+  }));
+}
+
+/** Drop empty text, clamp length, keep only `{id,text,completed}`. */
+export function normalizeChecklist(
+  items: readonly ChecklistItem[] | undefined,
+): ChecklistItem[] | undefined {
+  if (items === undefined) {
+    return undefined;
+  }
+
+  const next: ChecklistItem[] = [];
+  for (const item of items) {
+    const text = item.text.trim();
+    if (!text) {
+      continue;
+    }
+    const id = item.id.trim() || checklistItemId(text, next.length);
+    next.push({
+      id,
+      text,
+      completed: item.completed === true,
+    });
+    if (next.length >= MAX_CHECKLIST_ITEMS) {
+      break;
+    }
+  }
+
+  return next.length === 0 ? undefined : next;
+}
+
+export function taskHasChecklist(
+  task: { checklist?: readonly ChecklistItem[] | undefined },
+): boolean {
+  return (task.checklist?.length ?? 0) > 0;
+}
+
+export function getChecklistProgress(
+  items: readonly ChecklistItem[] | undefined,
+): ChecklistProgress {
+  const total = items?.length ?? 0;
+  if (total === 0) {
+    return { completed: 0, total: 0, percent: 0 };
+  }
+
+  const completed = items?.filter((item) => item.completed).length ?? 0;
+  return {
+    completed,
+    total,
+    percent: Math.round((completed / total) * 100),
+  };
+}
+
+export function toggleChecklistItem(
+  items: readonly ChecklistItem[],
+  itemId: string,
+): ChecklistItem[] {
+  return items.map((item) =>
+    item.id === itemId ? { ...item, completed: !item.completed } : item,
+  );
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -147,6 +147,16 @@ export default defineSchema({
     projectId: v.optional(v.string()),
     projectName: v.optional(v.string()),
     dueAt: v.optional(v.number()),
+    // Leftover from #206 — optional steps on a task, not a new table.
+    checklist: v.optional(
+      v.array(
+        v.object({
+          id: v.string(),
+          text: v.string(),
+          completed: v.boolean(),
+        }),
+      ),
+    ),
     createdAt: v.number(),
     updatedAt: v.number(),
     deletedAt: v.optional(v.number()),

--- a/convex/tasks.ts
+++ b/convex/tasks.ts
@@ -2,8 +2,15 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { requireUser } from "./lib/requireUser";
 import { filterTasksDueInRange } from "./lib/task_filters";
+import { normalizeChecklist } from "./lib/taskChecklists";
 import { assertRepeatEvery } from "./lib/taskRepeat";
 import { fetchCurrentUser } from "./users";
+
+const checklistItemValidator = v.object({
+  id: v.string(),
+  text: v.string(),
+  completed: v.boolean(),
+});
 
 const taskStatusValidator = v.union(
   v.literal("todo"),
@@ -31,6 +38,7 @@ const taskReturnValidator = v.object({
   projectId: v.optional(v.string()),
   projectName: v.optional(v.string()),
   dueAt: v.optional(v.number()),
+  checklist: v.optional(v.array(checklistItemValidator)),
   createdAt: v.number(),
   updatedAt: v.number(),
   deletedAt: v.optional(v.number()),
@@ -122,6 +130,7 @@ export const create = mutation({
     projectId: v.optional(v.string()),
     projectName: v.optional(v.string()),
     dueAt: v.optional(v.number()),
+    checklist: v.optional(v.array(checklistItemValidator)),
   },
   returns: v.id("tasks"),
   handler: async (ctx, args) => {
@@ -137,6 +146,7 @@ export const create = mutation({
       projectId: args.projectId?.trim(),
       projectName: args.projectName?.trim(),
       dueAt: args.dueAt,
+      checklist: normalizeChecklist(args.checklist),
       createdAt: now,
       updatedAt: now,
     });
@@ -156,6 +166,7 @@ export const update = mutation({
     projectId: v.optional(v.union(v.string(), v.null())),
     projectName: v.optional(v.union(v.string(), v.null())),
     dueAt: v.optional(v.union(v.number(), v.null())),
+    checklist: v.optional(v.union(v.array(checklistItemValidator), v.null())),
   },
   returns: v.id("tasks"),
   handler: async (ctx, args) => {
@@ -181,6 +192,9 @@ export const update = mutation({
     }
     if (args.dueAt !== undefined) {
       patch.dueAt = args.dueAt === null ? undefined : args.dueAt;
+    }
+    if (args.checklist !== undefined) {
+      patch.checklist = args.checklist === null ? undefined : normalizeChecklist(args.checklist);
     }
     await ctx.db.patch(args.taskId, patch as typeof task);
     return args.taskId;

--- a/tests/unit/task_checklists.test.ts
+++ b/tests/unit/task_checklists.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  MAX_CHECKLIST_ITEMS,
+  getChecklistProgress,
+  normalizeChecklist,
+  parseChecklistText,
+  taskHasChecklist,
+  toggleChecklistItem,
+} from "../../convex/lib/taskChecklists";
+import { filterTasksForView, type TaskViewRecord } from "../../apps/web/lib/task-view-filters";
+
+const baseTask = (id: string, checklist?: TaskViewRecord["checklist"]): TaskViewRecord => ({
+  id,
+  title: id,
+  status: "todo",
+  priority: "medium",
+  energy: "medium",
+  updatedAt: 1,
+  checklist,
+});
+
+describe("task checklist leftover from #206", () => {
+  test("parseChecklistText drops empty lines and caps at 20", () => {
+    const parsed = parseChecklistText("  unpack  \n\nput kettle on\n");
+    expect(parsed).toEqual([
+      { id: "check-0-unpack", text: "unpack", completed: false },
+      { id: "check-1-put-kettle-on", text: "put kettle on", completed: false },
+    ]);
+
+    const overflowing = Array.from({ length: MAX_CHECKLIST_ITEMS + 5 }, (_, index) => `step ${index}`).join(
+      "\n",
+    );
+    expect(parseChecklistText(overflowing)?.length).toBe(MAX_CHECKLIST_ITEMS);
+    expect(parseChecklistText("   \n\n")).toBeUndefined();
+  });
+
+  test("normalizeChecklist trims, drops blanks, and treats only true as completed", () => {
+    expect(
+      normalizeChecklist([
+        { id: " keep ", text: "  first  ", completed: true },
+        { id: "", text: "second", completed: false },
+        { id: "gone", text: "   ", completed: true },
+      ]),
+    ).toEqual([
+      { id: "keep", text: "first", completed: true },
+      { id: "check-1-second", text: "second", completed: false },
+    ]);
+    expect(normalizeChecklist([])).toBeUndefined();
+  });
+
+  test("progress stays honest for empty, partial, and complete lists", () => {
+    expect(getChecklistProgress(undefined)).toEqual({ completed: 0, total: 0, percent: 0 });
+    expect(
+      getChecklistProgress([
+        { id: "a", text: "one", completed: true },
+        { id: "b", text: "two", completed: false },
+      ]),
+    ).toEqual({ completed: 1, total: 2, percent: 50 });
+    expect(
+      getChecklistProgress([
+        { id: "a", text: "one", completed: true },
+        { id: "b", text: "two", completed: true },
+      ]),
+    ).toEqual({ completed: 2, total: 2, percent: 100 });
+  });
+
+  test("toggleChecklistItem flips only the named step", () => {
+    const items = [
+      { id: "a", text: "one", completed: false },
+      { id: "b", text: "two", completed: true },
+    ];
+    expect(toggleChecklistItem(items, "a")).toEqual([
+      { id: "a", text: "one", completed: true },
+      { id: "b", text: "two", completed: true },
+    ]);
+    expect(toggleChecklistItem(items, "missing")).toEqual(items);
+  });
+
+  test("checklists view keeps only live tasks that have steps", () => {
+    const visible = filterTasksForView(
+      [
+        baseTask("plain"),
+        baseTask("with-steps", [{ id: "a", text: "one", completed: false }]),
+        { ...baseTask("cancelled-steps", [{ id: "a", text: "one", completed: false }]), status: "cancelled" },
+      ],
+      { view: "checklists" },
+    );
+    expect(visible.map((task) => task.id)).toEqual(["with-steps"]);
+    const onlyVisible = visible[0];
+    expect(onlyVisible).toBeDefined();
+    if (onlyVisible) {
+      expect(taskHasChecklist(onlyVisible)).toBe(true);
+    }
+    expect(taskHasChecklist(baseTask("plain"))).toBe(false);
+  });
+});
+
+describe("TaskViews checklist leftover wiring", () => {
+  test("create form and checklists route sit on landed TaskViews, not a second TasksScreen", () => {
+    const screen = readFileSync(
+      join(import.meta.dir, "../../apps/web/components/tasks/TaskViewsScreen.tsx"),
+      "utf8",
+    );
+    const page = readFileSync(
+      join(import.meta.dir, "../../apps/web/app/(tempo)/tasks/checklists/page.tsx"),
+      "utf8",
+    );
+    const tasks = readFileSync(join(import.meta.dir, "../../convex/tasks.ts"), "utf8");
+
+    expect(page).toContain('view="checklists"');
+    expect(screen).toContain("/tasks/checklists");
+    expect(screen).toContain("parseChecklistText");
+    expect(screen).toContain("Checklist steps");
+    expect(screen).not.toContain("recurrenceFrequency");
+    expect(screen).not.toContain("{frequency,interval");
+    expect(tasks).toContain("normalizeChecklist");
+    expect(tasks).toContain("checklist: v.optional");
+  });
+});

--- a/tests/unit/task_filters.test.ts
+++ b/tests/unit/task_filters.test.ts
@@ -68,6 +68,22 @@ describe("task view filters", () => {
     expect(result.map((task) => task.id)).toEqual(["task-done", "task-today"]);
   });
 
+  test("checklists view keeps only non-cancelled tasks that have steps", () => {
+    const inboxSeed = records[2];
+    if (!inboxSeed) {
+      throw new Error("expected inbox seed record");
+    }
+    const withChecklist: TaskViewRecord = {
+      ...inboxSeed,
+      id: "task-checklist",
+      checklist: [{ id: "a", text: "one step", completed: false }],
+      updatedAt: 50,
+    };
+    const result = filterTasksForView([...records, withChecklist], { view: "checklists" });
+
+    expect(result.map((task) => task.id)).toEqual(["task-checklist"]);
+  });
+
   test("inbox view includes all non-cancelled task records", () => {
     const result = filterTasksForView(records, { view: "inbox" });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#206’s unique leftover after landed TaskViews + `taskRepeatCfgs` is optional checklists — not a second TasksScreen and not `{frequency,interval}` recurrence. This ports that leftover onto the current APIs: `tasks.checklist` is optional, create/update accept it, TaskViews gets a Checklists view, and the create form takes one step per line.

## Linked task(s)

Leftover from open PR #206 (`feat(tasks): add task variant views`). `docs/brain/TASKS.md` is a private submodule in this clone — no invented `T-XXXX`.

## Screenshots / screen recording

N/A at open — unit coverage + route wiring. UI walkthrough after CI.

## Test plan

- [x] `bun test ./tests/unit/task_checklists.test.ts ./tests/unit/task_filters.test.ts` (12 pass)
- [x] `apps/web` `tsc --noEmit`
- [x] Biome lint on touched files
- [ ] CI green on this head
- [ ] Does not reintroduce #206 TasksScreen rewrite or `{frequency,interval}` recurrence

## Acceptance criteria

- Optional `tasks.checklist` array `{id,text,completed}` (cap 20) does not break existing rows
- `tasks.create` / `tasks.update` accept checklist; `null` on update clears the field
- `/tasks/checklists` shows only live tasks that have steps
- Create form textarea parses one step per line
- Original #206 TasksScreen rewrite and recurrence shape are not landed

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] No AI-originated silent state changes
- [x] Schema change is `v.optional` + validators; no new table; no RAM-only leak
- [x] Styling uses existing TaskViews tokens
- [x] Checklist toggles are keyboard-reachable checkboxes
- [x] No secrets
- [x] Empty Checklists view stays kind (“This view is clear.”)

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`)

## What this skips

- #206 `TasksScreen.tsx` rewrite
- `{frequency,interval,nextDueAt}` on the task row (landed recurrence is `taskRepeatCfgs` via #378)
- Playwright e2e + lockfile from #206
- Closing #206 until this leftover is the only remaining unique piece and this PR has merged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

