### PR TITLE
feat(routines): bundle habits and tasks leftover from #174 [DO NOT MERGE]

### DIFF
--- a/apps/web/app/(tempo)/routines/[id]/page.tsx
+++ b/apps/web/app/(tempo)/routines/[id]/page.tsx
@@ -1,30 +1,8 @@
-/**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
- * @screen: routine-detail
- * @category: Library
- * @source: docs/design/claude-export/design-system/screens-3.jsx
- * @summary: Guided run of a routine.
- * @queries: routines.get
- * @mutations: routines.logRun
- * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
- */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { RoutineDetailClient } from "@/components/routines/RoutineDetailClient";
 
 type Params = { id: string };
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<Params>;
-}) {
+export default async function Page({ params }: { params: Promise<Params> }) {
   const { id } = await params;
-  return (
-    <ScaffoldScreen
-      title="Routine guided"
-      category="Library"
-      source="screens-3.jsx"
-      summary={`Guided run of a routine. (id: ${id})`}
-    />
-  );
+  return <RoutineDetailClient routineId={id} />;
 }

--- a/apps/web/app/(tempo)/routines/page.tsx
+++ b/apps/web/app/(tempo)/routines/page.tsx
@@ -1,23 +1,5 @@
-/**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
- * @screen: routines
- * @category: Library
- * @source: docs/design/claude-export/design-system/screens-3.jsx
- * @summary: Routine library.
- * @queries: routines.list
- * @mutations: routines.create
- * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
- */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+import { RoutinesPageClient } from "@/components/routines/RoutinesPageClient";
 
 export default function Page() {
-  return (
-    <ScaffoldScreen
-      title="Routines"
-      category="Library"
-      source="screens-3.jsx"
-      summary="Routine library."
-    />
-  );
+  return <RoutinesPageClient />;
 }

--- a/apps/web/components/routines/RoutineDetailClient.tsx
+++ b/apps/web/components/routines/RoutineDetailClient.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import Link from "next/link";
+import { useState } from "react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { isWithinToday } from "@/lib/routineRun";
+import { useLocalDayBounds } from "@/lib/useLocalDayBounds";
+
+type RoutineDetailClientProps = {
+  routineId: string;
+};
+
+export function RoutineDetailClient({ routineId }: RoutineDetailClientProps) {
+  const bounds = useLocalDayBounds();
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const routine = useQuery(
+    api.habits.getRoutineWithItems,
+    isAuthenticated ? { routineId } : "skip",
+  );
+  const completeItem = useMutation(api.habits.completeRoutineItem);
+  const [pendingItemId, setPendingItemId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLoading = isAuthLoading || (isAuthenticated && routine === undefined);
+
+  async function handleComplete(routineItemId: Id<"routineItems">) {
+    setPendingItemId(routineItemId);
+    setError(null);
+    try {
+      await completeItem({ routineItemId });
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "We couldn't complete that item yet.");
+    } finally {
+      setPendingItemId(null);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-8">
+        <div className="h-10 w-64 animate-pulse rounded-xl bg-muted" />
+        <div className="h-72 animate-pulse rounded-3xl bg-muted" />
+      </main>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-8">
+        <SoftCard padding="lg" className="text-center">
+          <h1 className="text-h2 font-serif">Sign in to run this routine</h1>
+          <p className="mt-3 text-body text-muted-foreground">
+            Your routine items are private, so sign in to continue.
+          </p>
+          <Link
+            href={`/sign-in?next=/routines/${routineId}`}
+            className="mt-6 inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 font-medium text-primary-foreground"
+          >
+            Sign in
+          </Link>
+        </SoftCard>
+      </main>
+    );
+  }
+
+  if (routine === null) {
+    return (
+      <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-8">
+        <SoftCard padding="lg" className="text-center">
+          <h1 className="text-h2 font-serif">Routine not found</h1>
+          <p className="mt-3 text-body text-muted-foreground">
+            It may have been moved or removed. Your routine library is still available.
+          </p>
+          <Link
+            href="/routines"
+            className="mt-6 inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 font-medium text-primary-foreground"
+          >
+            Back to routines
+          </Link>
+        </SoftCard>
+      </main>
+    );
+  }
+
+  if (routine === undefined) {
+    return null;
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 p-8">
+      <header className="space-y-4">
+        <Link href="/routines" className="text-small font-medium text-primary hover:underline">
+          Back to routines
+        </Link>
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-3">
+            <Pill tone="orange">Routine run</Pill>
+            <Pill tone="moss">Completable items</Pill>
+          </div>
+          <h1 className="text-h1 font-serif">{routine.name}</h1>
+          <p className="max-w-2xl text-body leading-relaxed text-muted-foreground">
+            Move through the habit and task together. Completing either one here updates its source
+            record too.
+          </p>
+        </div>
+      </header>
+
+      {error ? (
+        <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-small text-destructive">
+          {error}
+        </p>
+      ) : null}
+
+      <section className="grid gap-4" aria-label="Routine items">
+        {routine.items.map((item) => {
+          if (item.itemType === "habit") {
+            const doneToday = isWithinToday(
+              item.habit.lastCompletedAt,
+              bounds.startMs,
+              bounds.endMs,
+            );
+            return (
+              <SoftCard key={item._id} as="article" padding="lg" className="space-y-4">
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div className="space-y-2">
+                    <Pill tone="moss">Habit</Pill>
+                    <div>
+                      <h2 className="text-h2 font-serif">{item.habit.name}</h2>
+                      <p className="text-small text-muted-foreground">
+                        Daily cadence · current streak {item.habit.currentStreak}
+                      </p>
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    variant={doneToday ? "subtle" : "primary"}
+                    disabled={doneToday || pendingItemId === item._id}
+                    onClick={() => {
+                      void handleComplete(item._id);
+                    }}
+                  >
+                    {doneToday
+                      ? "Habit complete today"
+                      : pendingItemId === item._id
+                        ? "Completing..."
+                        : "Complete habit"}
+                  </Button>
+                </div>
+                <Link
+                  href={`/habits/${item.habit._id}`}
+                  className="inline-flex text-small font-medium text-primary hover:underline"
+                >
+                  Open habit detail
+                </Link>
+              </SoftCard>
+            );
+          }
+
+          const taskDone = item.task.status === "done";
+          return (
+            <SoftCard key={item._id} as="article" padding="lg" className="space-y-4">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="space-y-2">
+                  <Pill tone="slate">Task</Pill>
+                  <div>
+                    <h2 className="text-h2 font-serif">{item.task.title}</h2>
+                    <p className="text-small text-muted-foreground">
+                      Priority {item.task.priority} · status {item.task.status.replace("_", " ")}
+                    </p>
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  variant={taskDone ? "subtle" : "primary"}
+                  disabled={taskDone || pendingItemId === item._id}
+                  onClick={() => {
+                    void handleComplete(item._id);
+                  }}
+                >
+                  {taskDone
+                    ? "Task complete"
+                    : pendingItemId === item._id
+                      ? "Completing..."
+                      : "Complete task"}
+                </Button>
+              </div>
+              <Link
+                href="/tasks"
+                className="inline-flex text-small font-medium text-primary hover:underline"
+              >
+                Open tasks
+              </Link>
+            </SoftCard>
+          );
+        })}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/components/routines/RoutinesPageClient.tsx
+++ b/apps/web/components/routines/RoutinesPageClient.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { Button, Pill, SoftCard } from "@tempo/ui/primitives";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { type FormEvent, useState } from "react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+
+type RoutineFormState = {
+  name: string;
+  habitName: string;
+  taskTitle: string;
+};
+
+const initialFormState: RoutineFormState = {
+  name: "",
+  habitName: "",
+  taskTitle: "",
+};
+
+export function RoutinesPageClient() {
+  const router = useRouter();
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const routines = useQuery(api.habits.listRoutines, isAuthenticated ? {} : "skip");
+  const createRoutine = useMutation(api.habits.createRoutineWithItems);
+  const [form, setForm] = useState<RoutineFormState>(initialFormState);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isLoading = isAuthLoading || (isAuthenticated && routines === undefined);
+  const canSubmit =
+    form.name.trim().length > 0 &&
+    form.habitName.trim().length > 0 &&
+    form.taskTitle.trim().length > 0 &&
+    !isSubmitting;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const routineId: Id<"routines"> = await createRoutine({
+        name: form.name,
+        habitName: form.habitName,
+        taskTitle: form.taskTitle,
+      });
+      setForm(initialFormState);
+      router.push(`/routines/${routineId}`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "We couldn't create that routine yet.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-8">
+        <div className="h-10 w-56 animate-pulse rounded-xl bg-muted" />
+        <div className="h-64 animate-pulse rounded-3xl bg-muted" />
+        <div className="h-40 animate-pulse rounded-3xl bg-muted" />
+      </main>
+    );
+  }
+
+  if (!isAuthenticated || !routines) {
+    return (
+      <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-8">
+        <SoftCard padding="lg" className="text-center">
+          <h1 className="text-h2 font-serif">Sign in to build routines</h1>
+          <p className="mt-3 text-body text-muted-foreground">
+            Your routine library lives with your tasks and habits, so sign in to keep it together.
+          </p>
+          <Link
+            href="/sign-in?next=/routines"
+            className="mt-6 inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 font-medium text-primary-foreground"
+          >
+            Sign in
+          </Link>
+        </SoftCard>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-8 p-8">
+      <header className="space-y-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <Pill tone="orange">Library</Pill>
+          <Pill tone="moss">Habits + tasks</Pill>
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-h1 font-serif">Routines</h1>
+          <p className="max-w-2xl text-body leading-relaxed text-muted-foreground">
+            Bundle a small repeating habit with a concrete task, then run both from one calm view.
+          </p>
+        </div>
+      </header>
+
+      <SoftCard as="section" padding="lg" aria-labelledby="create-routine-heading">
+        <div className="grid gap-6 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+          <div className="space-y-3">
+            <h2 id="create-routine-heading" className="text-h2 font-serif">
+              Create a starter routine
+            </h2>
+            <p className="text-small leading-relaxed text-muted-foreground">
+              Add one habit and one task. You can complete both from the routine view after it is
+              created.
+            </p>
+          </div>
+
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <label htmlFor="routine-name" className="text-small font-medium">
+                Routine name
+              </label>
+              <input
+                id="routine-name"
+                name="routineName"
+                value={form.name}
+                onChange={(event) =>
+                  setForm((current) => ({ ...current, name: event.target.value }))
+                }
+                className="h-11 w-full rounded-xl border border-border bg-background px-4 text-body text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-primary"
+                placeholder="Morning reset"
+                autoComplete="off"
+              />
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <label htmlFor="routine-habit" className="text-small font-medium">
+                  Habit
+                </label>
+                <input
+                  id="routine-habit"
+                  name="habitName"
+                  value={form.habitName}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, habitName: event.target.value }))
+                  }
+                  className="h-11 w-full rounded-xl border border-border bg-background px-4 text-body text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-primary"
+                  placeholder="Drink water"
+                  autoComplete="off"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="routine-task" className="text-small font-medium">
+                  Task
+                </label>
+                <input
+                  id="routine-task"
+                  name="taskTitle"
+                  value={form.taskTitle}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, taskTitle: event.target.value }))
+                  }
+                  className="h-11 w-full rounded-xl border border-border bg-background px-4 text-body text-foreground outline-none transition focus-visible:ring-2 focus-visible:ring-primary"
+                  placeholder="Pack tomorrow's bag"
+                  autoComplete="off"
+                />
+              </div>
+            </div>
+
+            {error ? (
+              <p className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-small text-destructive">
+                {error}
+              </p>
+            ) : null}
+
+            <Button type="submit" disabled={!canSubmit}>
+              {isSubmitting ? "Creating routine..." : "Create routine"}
+            </Button>
+          </form>
+        </div>
+      </SoftCard>
+
+      <section className="space-y-4" aria-labelledby="routine-library-heading">
+        <div className="flex items-end justify-between gap-4">
+          <div>
+            <h2 id="routine-library-heading" className="text-h2 font-serif">
+              Routine library
+            </h2>
+            <p className="text-small text-muted-foreground">
+              {routines.length === 0
+                ? "No routines yet. One gentle starter is enough."
+                : `${routines.length} ${routines.length === 1 ? "routine" : "routines"} ready.`}
+            </p>
+          </div>
+        </div>
+
+        {routines.length === 0 ? (
+          <SoftCard tone="sunken" padding="lg" className="text-center">
+            <p className="text-body text-foreground">Your first routine can be tiny.</p>
+            <p className="mt-2 text-small text-muted-foreground">
+              Try pairing one body cue with one task you want to make easier to start.
+            </p>
+          </SoftCard>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            {routines.map((routine) => (
+              <SoftCard key={routine._id} as="article" padding="md" className="flex flex-col gap-4">
+                <div className="space-y-2">
+                  <h3 className="text-h3 font-serif">{routine.name}</h3>
+                  <div className="flex flex-wrap gap-2">
+                    <Pill tone="moss">{routine.habitCount} habit</Pill>
+                    <Pill tone="slate">{routine.taskCount} task</Pill>
+                  </div>
+                </div>
+                <Link
+                  href={`/routines/${routine._id}`}
+                  className="mt-auto inline-flex h-10 items-center justify-center rounded-lg border border-border bg-card px-4 text-small font-medium transition hover:bg-surface-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                >
+                  Open routine
+                </Link>
+              </SoftCard>
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/lib/routineLibrary.test.ts
+++ b/apps/web/lib/routineLibrary.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { isWithinToday } from "./routineRun";
+
+describe("isWithinToday", () => {
+  test("uses the landed half-open local-day window", () => {
+    expect(isWithinToday(undefined, 0, 10)).toBe(false);
+    expect(isWithinToday(0, 0, 10)).toBe(true);
+    expect(isWithinToday(9, 0, 10)).toBe(true);
+    expect(isWithinToday(10, 0, 10)).toBe(false);
+  });
+});
+
+describe("routines leftover wiring", () => {
+  test("list and create call generated habits APIs, not api.routines", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../components/routines/RoutinesPageClient.tsx"),
+      "utf8",
+    );
+    expect(source).toContain("api.habits.listRoutines");
+    expect(source).toContain("api.habits.createRoutineWithItems");
+    expect(source).not.toContain("api.routines.");
+  });
+
+  test("detail complete calls generated habits APIs", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../components/routines/RoutineDetailClient.tsx"),
+      "utf8",
+    );
+    expect(source).toContain("api.habits.getRoutineWithItems");
+    expect(source).toContain("api.habits.completeRoutineItem");
+    expect(source).toContain("isWithinToday");
+    expect(source).not.toContain("api.routines.");
+  });
+});

--- a/apps/web/lib/routineRun.ts
+++ b/apps/web/lib/routineRun.ts
@@ -1,0 +1,8 @@
+/** Half-open local-day window [startMs, endMs) — same as Today filters. */
+export function isWithinToday(
+  timestamp: number | undefined,
+  startMs: number,
+  endMs: number,
+): boolean {
+  return timestamp !== undefined && timestamp >= startMs && timestamp < endMs;
+}

--- a/convex/habits.ts
+++ b/convex/habits.ts
@@ -2,6 +2,15 @@ import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { computeHabitStreakUpdate } from "./lib/habitStreak";
 import { requireUser } from "./lib/requireUser";
+import {
+	completeRoutineItem as completeRoutineItemHandler,
+	completionResultValidator,
+	createRoutineWithItems as createRoutineWithItemsHandler,
+	getRoutineWithItems as getRoutineWithItemsHandler,
+	listRoutineSummaries,
+	routineDetailValidator,
+	routineSummaryValidator,
+} from "./lib/routineBundles";
 
 export const list = query({
 	args: {},
@@ -102,4 +111,33 @@ export const remove = mutation({
 		await ctx.db.delete(args.habitId);
 		return { success: true };
 	},
+});
+
+/** Leftover from #174 — public API stays on `habits` because `api.routines` is not generated. */
+export const listRoutines = query({
+	args: {},
+	returns: v.array(routineSummaryValidator),
+	handler: listRoutineSummaries,
+});
+
+export const getRoutineWithItems = query({
+	args: { routineId: v.string() },
+	returns: v.union(routineDetailValidator, v.null()),
+	handler: getRoutineWithItemsHandler,
+});
+
+export const createRoutineWithItems = mutation({
+	args: {
+		name: v.string(),
+		habitName: v.string(),
+		taskTitle: v.string(),
+	},
+	returns: v.id("routines"),
+	handler: createRoutineWithItemsHandler,
+});
+
+export const completeRoutineItem = mutation({
+	args: { routineItemId: v.id("routineItems") },
+	returns: completionResultValidator,
+	handler: completeRoutineItemHandler,
 });

--- a/convex/lib/accountDeletion.test.ts
+++ b/convex/lib/accountDeletion.test.ts
@@ -22,6 +22,8 @@ describe("USER_OWNED_TABLES", () => {
         "habits",
         "memories",
         "notes",
+        "routineItems",
+        "routines",
         "taskRepeatCfgs",
         "tasks",
       ].sort(),

--- a/convex/lib/accountDeletion.ts
+++ b/convex/lib/accountDeletion.ts
@@ -10,6 +10,8 @@ export const USER_OWNED_TABLES = [
   "memories",
   "calendarEvents",
   "taskRepeatCfgs",
+  "routines",
+  "routineItems",
 ] as const;
 
 type UserOwnedTable = (typeof USER_OWNED_TABLES)[number];

--- a/convex/lib/routineBundles.test.ts
+++ b/convex/lib/routineBundles.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { countRoutineItems, trimmedRequiredString } from "./routineBundles";
+
+describe("trimmedRequiredString", () => {
+  test("returns trimmed text", () => {
+    expect(trimmedRequiredString("  Morning reset  ", "Routine name")).toBe("Morning reset");
+  });
+
+  test("rejects blank labels with a calm error", () => {
+    expect(() => trimmedRequiredString("   ", "Routine name")).toThrow(
+      "Routine name cannot be empty.",
+    );
+  });
+});
+
+describe("countRoutineItems", () => {
+  test("counts habit and task rows separately", () => {
+    expect(
+      countRoutineItems([
+        { itemType: "habit" },
+        { itemType: "task" },
+        { itemType: "habit" },
+      ]),
+    ).toEqual({ habitCount: 2, taskCount: 1 });
+  });
+
+  test("empty bundle stays at zero", () => {
+    expect(countRoutineItems([])).toEqual({ habitCount: 0, taskCount: 0 });
+  });
+});

--- a/convex/lib/routineBundles.ts
+++ b/convex/lib/routineBundles.ts
@@ -1,0 +1,336 @@
+import { v } from "convex/values";
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { computeHabitStreakUpdate } from "./habitStreak";
+import { requireUser } from "./requireUser";
+
+type ConvexCtx = QueryCtx | MutationCtx;
+
+export type RoutineItemCounts = { habitCount: number; taskCount: number };
+
+export function trimmedRequiredString(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${label} cannot be empty.`);
+  }
+  return trimmed;
+}
+
+export function countRoutineItems(
+  items: ReadonlyArray<{ itemType: "habit" | "task" }>,
+): RoutineItemCounts {
+  let habitCount = 0;
+  let taskCount = 0;
+  for (const item of items) {
+    if (item.itemType === "habit") {
+      habitCount += 1;
+    } else {
+      taskCount += 1;
+    }
+  }
+  return { habitCount, taskCount };
+}
+
+export const routineSummaryValidator = v.object({
+  _id: v.id("routines"),
+  name: v.string(),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+  habitCount: v.number(),
+  taskCount: v.number(),
+});
+
+const habitItemValidator = v.object({
+  _id: v.id("routineItems"),
+  itemType: v.literal("habit"),
+  position: v.number(),
+  habit: v.object({
+    _id: v.id("habits"),
+    name: v.string(),
+    cadence: v.union(v.literal("daily"), v.literal("weekly")),
+    currentStreak: v.number(),
+    longestStreak: v.number(),
+    lastCompletedAt: v.optional(v.number()),
+  }),
+});
+
+const taskItemValidator = v.object({
+  _id: v.id("routineItems"),
+  itemType: v.literal("task"),
+  position: v.number(),
+  task: v.object({
+    _id: v.id("tasks"),
+    title: v.string(),
+    description: v.optional(v.string()),
+    status: v.union(
+      v.literal("todo"),
+      v.literal("in_progress"),
+      v.literal("done"),
+      v.literal("cancelled"),
+    ),
+    priority: v.union(v.literal("low"), v.literal("medium"), v.literal("high")),
+    dueAt: v.optional(v.number()),
+  }),
+});
+
+export const routineDetailValidator = v.object({
+  _id: v.id("routines"),
+  name: v.string(),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+  items: v.array(v.union(habitItemValidator, taskItemValidator)),
+});
+
+export const completionResultValidator = v.object({
+  routineItemId: v.id("routineItems"),
+  itemType: v.union(v.literal("habit"), v.literal("task")),
+  completed: v.boolean(),
+});
+
+async function getOwnedRoutine(
+  ctx: ConvexCtx,
+  routineId: Id<"routines">,
+  userId: Id<"users">,
+): Promise<Doc<"routines">> {
+  const routine = await ctx.db.get("routines", routineId);
+  if (!routine || routine.userId !== userId || routine.deletedAt !== undefined) {
+    throw new Error("Routine not found");
+  }
+  return routine;
+}
+
+export async function listRoutineSummaries(ctx: QueryCtx) {
+  const user = await requireUser(ctx);
+  const routines = await ctx.db
+    .query("routines")
+    .withIndex("by_userId_deletedAt", (q) => q.eq("userId", user._id).eq("deletedAt", undefined))
+    .collect();
+  const items = await ctx.db
+    .query("routineItems")
+    .withIndex("by_userId_deletedAt", (q) => q.eq("userId", user._id).eq("deletedAt", undefined))
+    .collect();
+
+  const itemCounts = new Map<Id<"routines">, RoutineItemCounts>();
+  const itemsByRoutine = new Map<Id<"routines">, Array<{ itemType: "habit" | "task" }>>();
+  for (const item of items) {
+    const bucket = itemsByRoutine.get(item.routineId) ?? [];
+    bucket.push({ itemType: item.itemType });
+    itemsByRoutine.set(item.routineId, bucket);
+  }
+  for (const [routineId, bucket] of itemsByRoutine) {
+    itemCounts.set(routineId, countRoutineItems(bucket));
+  }
+
+  return routines
+    .map((routine) => {
+      const counts = itemCounts.get(routine._id) ?? { habitCount: 0, taskCount: 0 };
+      return {
+        _id: routine._id,
+        name: routine.name,
+        createdAt: routine.createdAt,
+        updatedAt: routine.updatedAt,
+        habitCount: counts.habitCount,
+        taskCount: counts.taskCount,
+      };
+    })
+    .slice()
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+export async function getRoutineWithItems(ctx: QueryCtx, args: { routineId: string }) {
+  const user = await requireUser(ctx);
+  const routineId = ctx.db.normalizeId("routines", args.routineId);
+  if (!routineId) {
+    return null;
+  }
+  const routine = await ctx.db.get("routines", routineId);
+  if (!routine || routine.userId !== user._id || routine.deletedAt !== undefined) {
+    return null;
+  }
+
+  const items = await ctx.db
+    .query("routineItems")
+    .withIndex("by_routineId_deletedAt", (q) =>
+      q.eq("routineId", routine._id).eq("deletedAt", undefined),
+    )
+    .collect();
+
+  const resolvedItems: Array<
+    | {
+        _id: Id<"routineItems">;
+        itemType: "habit";
+        position: number;
+        habit: {
+          _id: Id<"habits">;
+          name: string;
+          cadence: "daily" | "weekly";
+          currentStreak: number;
+          longestStreak: number;
+          lastCompletedAt?: number;
+        };
+      }
+    | {
+        _id: Id<"routineItems">;
+        itemType: "task";
+        position: number;
+        task: {
+          _id: Id<"tasks">;
+          title: string;
+          description?: string;
+          status: "todo" | "in_progress" | "done" | "cancelled";
+          priority: "low" | "medium" | "high";
+          dueAt?: number;
+        };
+      }
+  > = [];
+
+  const orderedItems = items.slice().sort((a, b) => a.position - b.position);
+  for (const item of orderedItems) {
+    if (item.itemType === "habit" && item.habitId) {
+      const habit = await ctx.db.get("habits", item.habitId);
+      if (habit && habit.userId === user._id && habit.deletedAt === undefined) {
+        resolvedItems.push({
+          _id: item._id,
+          itemType: "habit",
+          position: item.position,
+          habit: {
+            _id: habit._id,
+            name: habit.name,
+            cadence: habit.cadence,
+            currentStreak: habit.currentStreak,
+            longestStreak: habit.longestStreak,
+            lastCompletedAt: habit.lastCompletedAt,
+          },
+        });
+      }
+    }
+
+    if (item.itemType === "task" && item.taskId) {
+      const task = await ctx.db.get("tasks", item.taskId);
+      if (task && task.userId === user._id && task.deletedAt === undefined) {
+        resolvedItems.push({
+          _id: item._id,
+          itemType: "task",
+          position: item.position,
+          task: {
+            _id: task._id,
+            title: task.title,
+            description: task.description,
+            status: task.status,
+            priority: task.priority,
+            dueAt: task.dueAt,
+          },
+        });
+      }
+    }
+  }
+
+  return {
+    _id: routine._id,
+    name: routine.name,
+    createdAt: routine.createdAt,
+    updatedAt: routine.updatedAt,
+    items: resolvedItems,
+  };
+}
+
+export async function createRoutineWithItems(
+  ctx: MutationCtx,
+  args: { name: string; habitName: string; taskTitle: string },
+) {
+  const user = await requireUser(ctx);
+  const now = Date.now();
+  const routineId = await ctx.db.insert("routines", {
+    userId: user._id,
+    name: trimmedRequiredString(args.name, "Routine name"),
+    createdAt: now,
+    updatedAt: now,
+  });
+  const habitId = await ctx.db.insert("habits", {
+    userId: user._id,
+    name: trimmedRequiredString(args.habitName, "Habit name"),
+    cadence: "daily",
+    currentStreak: 0,
+    longestStreak: 0,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const taskId = await ctx.db.insert("tasks", {
+    userId: user._id,
+    title: trimmedRequiredString(args.taskTitle, "Task title"),
+    status: "todo",
+    priority: "medium",
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  await ctx.db.insert("routineItems", {
+    userId: user._id,
+    routineId,
+    itemType: "habit",
+    habitId,
+    position: 0,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await ctx.db.insert("routineItems", {
+    userId: user._id,
+    routineId,
+    itemType: "task",
+    taskId,
+    position: 1,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  return routineId;
+}
+
+export async function completeRoutineItem(
+  ctx: MutationCtx,
+  args: { routineItemId: Id<"routineItems"> },
+) {
+  const user = await requireUser(ctx);
+  const item = await ctx.db.get("routineItems", args.routineItemId);
+  if (!item || item.userId !== user._id || item.deletedAt !== undefined) {
+    throw new Error("Routine item not found");
+  }
+  await getOwnedRoutine(ctx, item.routineId, user._id);
+
+  if (item.itemType === "habit") {
+    if (!item.habitId) {
+      throw new Error("Routine habit not found");
+    }
+    const habit = await ctx.db.get("habits", item.habitId);
+    if (!habit || habit.userId !== user._id || habit.deletedAt !== undefined) {
+      throw new Error("Habit not found");
+    }
+    const now = Date.now();
+    const update = computeHabitStreakUpdate(
+      now,
+      habit.lastCompletedAt,
+      habit.currentStreak,
+      habit.longestStreak,
+    );
+    if (!update.alreadyDone) {
+      await ctx.db.patch(habit._id, {
+        currentStreak: update.currentStreak,
+        longestStreak: update.longestStreak,
+        lastCompletedAt: now,
+        updatedAt: now,
+      });
+    }
+  } else {
+    if (!item.taskId) {
+      throw new Error("Routine task not found");
+    }
+    const task = await ctx.db.get("tasks", item.taskId);
+    if (!task || task.userId !== user._id || task.deletedAt !== undefined) {
+      throw new Error("Task not found");
+    }
+    await ctx.db.patch(task._id, { status: "done", updatedAt: Date.now() });
+  }
+
+  await ctx.db.patch(item._id, { updatedAt: Date.now() });
+  return { routineItemId: item._id, itemType: item.itemType, completed: true };
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -258,6 +258,35 @@ export default defineSchema({
     .index("by_userId", ["userId"])
     .index("by_userId_deletedAt", ["userId", "deletedAt"]),
 
+  /**
+   * Leftover from #174 — bundle one habit with one task. New tables must
+   * stay on USER_OWNED_TABLES so account deletion covers them.
+   */
+  routines: defineTable({
+    userId: v.id("users"),
+    name: v.string(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    deletedAt: v.optional(v.number()),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_userId_deletedAt", ["userId", "deletedAt"]),
+
+  routineItems: defineTable({
+    userId: v.id("users"),
+    routineId: v.id("routines"),
+    itemType: v.union(v.literal("habit"), v.literal("task")),
+    habitId: v.optional(v.id("habits")),
+    taskId: v.optional(v.id("tasks")),
+    position: v.number(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    deletedAt: v.optional(v.number()),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_routineId_deletedAt", ["routineId", "deletedAt"])
+    .index("by_userId_deletedAt", ["userId", "deletedAt"]),
+
   goals: defineTable({
     userId: v.id("users"),
     title: v.string(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the unique leftover from **#174** (habit+task routine bundles) onto current `integration`. The original PR added `convex/routines.ts` and edited `api.d.ts`; committed `api.d.ts` does not list a `routines` module, so this leftover exposes `listRoutines` / `getRoutineWithItems` / `createRoutineWithItems` / `completeRoutineItem` on the existing generated `habits` module.

New `routines` and `routineItems` tables are added to `USER_OWNED_TABLES`. That is **account-deletion adjacent**. This PR stays **draft**. Do not merge. Do not mark ready. Auto-arm skipped (draft).

Required CI is green (Typecheck, Lint, Test, Scans, secret scans, E2E). `docs/brain/TASKS.md` is a private submodule and is empty in this clone — no invented T-XXXX.

## Linked task(s)

Leftover from open **#174**. Public board: `docs/TASKS.md` (brain board unreadable here).

## Screenshots / screen recording

Unauthenticated `/routines` is gated by existing auth middleware to `/sign-in?next=/routines`. Authenticated create/complete needs a live Convex deployment (not available in this agent).

[Unauthenticated /routines redirects to sign-in with next=/routines](https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froutines-signin-next.png)

## Test plan

- [x] `bunx tsc --noEmit` in `apps/web` passes
- [x] Biome lint on edited files passes
- [x] Unit tests: `routineBundles.test.ts`, `accountDeletion.test.ts`, `routineLibrary.test.ts`
- [x] Required CI green (Typecheck / Lint / Test / Scans / E2E / secret scans)
- [x] Manual: `/routines` redirects to sign-in with `next=/routines`

Skipped from #174: `bun.lock`, `package.json`, `playwright.config.ts`, `tests/e2e/routines.spec.ts`, `scripts/start-convex-e2e.sh`, `convex/_generated/api.d.ts`.

## Acceptance criteria

- Web `/routines` is no longer a scaffold: create a starter routine (one habit + one task) and open `/routines/[id]`.
- Completing a habit item uses landed `computeHabitStreakUpdate` (same UTC-day window as `habits.completeToday`).
- Completing a task item sets `status: "done"` on the source task.
- Soft-deleted routines/items/habits/tasks are skipped.
- Account deletion covers the new tables (`USER_OWNED_TABLES` includes `routines` and `routineItems`).
- No new Convex module; no `api.d.ts` edit.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] No AI-originated silent writes
- [x] Schema: `userId`, `createdAt`, `updatedAt`, `deletedAt`, indexes (`by_userId`, `by_userId_deletedAt`, `by_routineId_deletedAt`)
- [x] Styling uses `@tempo/ui` primitives (Button / Pill / SoftCard)
- [x] Keyboard-focusable inputs and `focus-visible` rings
- [x] No secrets
- [x] Anti-shame empty / error copy

## Owner tag (§14)

- [x] `cursor-cloud-1`

## Reviewer

Amit (`human-amit`). **Do not merge.** Same STOP rule as #366 / #373.

## Why this stays draft

Adding user-owned tables without `USER_OWNED_TABLES` would leak routine rows on account deletion. Adding them *to* `USER_OWNED_TABLES` is a deletion-path change. Amit reviews that.

Do not close **#174** until this lands.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

