### PR TITLE
feat(settings): BYOK provider keys leftover from #213 [DO NOT MERGE]

### DIFF
--- a/apps/web/app/(tempo)/settings/integrations/page.tsx
+++ b/apps/web/app/(tempo)/settings/integrations/page.tsx
@@ -1,23 +1,211 @@
-/**
- * @generated-by: T-F004 scaffold — replace with T-F005* port.
- * @screen: settings-integrations
- * @category: Settings
- * @source: docs/design/claude-export/design-system/screens-6.jsx
- * @summary: Google Calendar & other integrations.
- * @queries: integrations.list
- * @mutations: integrations.connect, integrations.disconnect
- * @auth: required
- * @notes: Copy placeholder from Claude export; copy pass in a later ticket.
- */
-import { ScaffoldScreen } from "@/components/tempo/ScaffoldScreen";
+"use client";
+
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { KeyRound, PlugZap } from "lucide-react";
+import Link from "next/link";
+import type React from "react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { api } from "@/convex/_generated/api";
+import {
+  buildByokProviderRequest,
+  maskProviderKey,
+  type ByokProvider,
+} from "@/lib/byok";
+
+const provider: ByokProvider = "mistral";
+const defaultPrompt = "Please answer with one calm sentence.";
 
 export default function Page() {
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const savedKey = useQuery(
+    api.users.getProviderKey,
+    isAuthenticated ? { provider } : "skip",
+  );
+  const saveProviderKey = useMutation(api.users.saveProviderKey);
+  const [apiKey, setApiKey] = useState("");
+  const [testPrompt, setTestPrompt] = useState(defaultPrompt);
+  const [saveStatus, setSaveStatus] = useState("");
+  const [testStatus, setTestStatus] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [isTesting, setIsTesting] = useState(false);
+
+  useEffect(() => {
+    if (savedKey?.apiKey) {
+      setApiKey(savedKey.apiKey);
+    }
+  }, [savedKey?.apiKey]);
+
+  async function handleSave(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSaving(true);
+    setSaveStatus("");
+    try {
+      const saved = await saveProviderKey({ provider, apiKey });
+      setApiKey(saved?.apiKey ?? apiKey.trim());
+      setSaveStatus("Provider key saved to Convex.");
+    } catch (error) {
+      setSaveStatus(error instanceof Error ? error.message : "We could not save that key yet.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleMockedProviderCall() {
+    const keyFromConvex = savedKey?.apiKey;
+    if (!keyFromConvex) {
+      setTestStatus("Save a provider key first, then send the test call.");
+      return;
+    }
+
+    setIsTesting(true);
+    setTestStatus("");
+    try {
+      const request = buildByokProviderRequest({
+        apiKey: keyFromConvex,
+        message: testPrompt.trim() || defaultPrompt,
+        provider,
+      });
+      const response = await fetch(request.url, request.init);
+      if (!response.ok) {
+        throw new Error("The mocked provider did not accept the request.");
+      }
+      const json = (await response.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+      };
+      setTestStatus(json.choices?.[0]?.message?.content ?? "Mock provider call completed.");
+    } catch (error) {
+      setTestStatus(
+        error instanceof Error
+          ? error.message
+          : "We could not send the mocked provider call yet.",
+      );
+    } finally {
+      setIsTesting(false);
+    }
+  }
+
+  if (isAuthLoading || (isAuthenticated && savedKey === undefined)) {
+    return (
+      <main className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-8">
+        <div className="h-10 w-64 animate-pulse rounded-xl bg-muted" />
+        <div className="h-80 animate-pulse rounded-2xl bg-muted" />
+      </main>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <main className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-8">
+        <Card>
+          <CardHeader>
+            <CardTitle>Sign in to manage provider keys</CardTitle>
+            <CardDescription>
+              Your keys are saved to your account so model calls can use the provider you choose.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild>
+              <Link href="/sign-in?next=/settings/integrations">Sign in</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
   return (
-    <ScaffoldScreen
-      title="Integrations"
-      category="Settings"
-      source="screens-6.jsx"
-      summary="Google Calendar & other integrations."
-    />
+    <main className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-8">
+      <header className="flex flex-col gap-3">
+        <div className="flex items-center gap-2 text-muted-foreground text-sm">
+          <PlugZap className="h-4 w-4" aria-hidden="true" />
+          Settings / Integrations
+        </div>
+        <div>
+          <h1 className="font-heading text-4xl font-semibold tracking-tight">
+            Provider keys
+          </h1>
+          <p className="mt-2 max-w-2xl text-muted-foreground">
+            Bring your own model key and keep Tempo connected to the provider
+            you already trust. This saves the key to Convex for your account and
+            uses it for the test request below.
+          </p>
+        </div>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <KeyRound className="h-5 w-5 text-primary" aria-hidden="true" />
+            Mistral-compatible key
+          </CardTitle>
+          <CardDescription>
+            Paste a test or production key from your provider. The field reloads
+            from Convex after refresh so you can verify it persisted.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <form className="space-y-4" onSubmit={handleSave}>
+            <div className="space-y-2">
+              <Label htmlFor="mistral-api-key">Mistral-compatible API key</Label>
+              <Input
+                id="mistral-api-key"
+                autoComplete="off"
+                value={apiKey}
+                onChange={(event) => setApiKey(event.target.value)}
+                placeholder="Paste your provider key"
+                type="password"
+              />
+              {savedKey ? (
+                <p className="text-muted-foreground text-sm">
+                  Saved key: {maskProviderKey(savedKey.apiKey)}
+                </p>
+              ) : (
+                <p className="text-muted-foreground text-sm">
+                  No provider key saved yet. Add one when you are ready.
+                </p>
+              )}
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <Button type="submit" disabled={isSaving}>
+                {isSaving ? "Saving..." : "Save provider key"}
+              </Button>
+              {saveStatus ? <output className="text-sm">{saveStatus}</output> : null}
+            </div>
+          </form>
+
+          <div className="rounded-2xl border border-border bg-surface-sunken/60 p-4">
+            <div className="space-y-2">
+              <Label htmlFor="byok-test-prompt">Test prompt</Label>
+              <Input
+                id="byok-test-prompt"
+                value={testPrompt}
+                onChange={(event) => setTestPrompt(event.target.value)}
+              />
+            </div>
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={handleMockedProviderCall}
+                disabled={isTesting || !savedKey?.apiKey}
+              >
+                {isTesting ? "Sending..." : "Send mocked provider call"}
+              </Button>
+              {testStatus ? <output className="text-sm">{testStatus}</output> : null}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </main>
   );
 }

--- a/apps/web/app/api/byok/mock-provider/route.ts
+++ b/apps/web/app/api/byok/mock-provider/route.ts
@@ -1,0 +1,24 @@
+export async function POST(request: Request) {
+  const authorization = request.headers.get("authorization");
+  const body = (await request.json().catch(() => null)) as {
+    messages?: Array<{ content?: string; role?: string }>;
+  } | null;
+
+  if (!authorization?.startsWith("Bearer ")) {
+    return Response.json({ error: "Missing provider authorization header." }, { status: 401 });
+  }
+
+  const prompt = body?.messages?.[0]?.content?.trim();
+
+  return Response.json({
+    choices: [
+      {
+        message: {
+          content: prompt
+            ? "Mock provider heard the saved key."
+            : "Mock provider received the saved key.",
+        },
+      },
+    ],
+  });
+}

--- a/apps/web/lib/byok.test.ts
+++ b/apps/web/lib/byok.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { buildByokProviderRequest, maskProviderKey } from "./byok";
+
+describe("BYOK provider helpers", () => {
+  test("masks provider keys without exposing the secret", () => {
+    expect(maskProviderKey("tfk_live_1234567890abcdef")).toBe("tfk_...cdef");
+    expect(maskProviderKey("short")).toBe("Saved");
+  });
+
+  test("builds a provider request with the saved key in the auth header", () => {
+    const request = buildByokProviderRequest({
+      apiKey: "tfk_test_saved_key_123",
+      message: "Can you hear me?",
+      provider: "mistral",
+    });
+
+    expect(request.url).toBe("/api/byok/mock-provider");
+    expect(request.init.method).toBe("POST");
+    expect(request.init.headers).toEqual({
+      Authorization: "Bearer tfk_test_saved_key_123",
+      "Content-Type": "application/json",
+    });
+    expect(JSON.parse(String(request.init.body))).toEqual({
+      messages: [{ content: "Can you hear me?", role: "user" }],
+      model: "mistral-small-latest",
+      provider: "mistral",
+    });
+  });
+});

--- a/apps/web/lib/byok.ts
+++ b/apps/web/lib/byok.ts
@@ -1,0 +1,38 @@
+export type ByokProvider = "mistral";
+
+export type BuildByokProviderRequestArgs = {
+  apiKey: string;
+  message: string;
+  provider: ByokProvider;
+};
+
+export function maskProviderKey(apiKey: string): string {
+  const trimmed = apiKey.trim();
+  if (trimmed.length < 12) {
+    return "Saved";
+  }
+
+  return `${trimmed.slice(0, 4)}...${trimmed.slice(-4)}`;
+}
+
+export function buildByokProviderRequest({
+  apiKey,
+  message,
+  provider,
+}: BuildByokProviderRequestArgs): { url: string; init: RequestInit } {
+  return {
+    url: "/api/byok/mock-provider",
+    init: {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        messages: [{ content: message, role: "user" }],
+        model: "mistral-small-latest",
+        provider,
+      }),
+    },
+  };
+}

--- a/apps/web/lib/byokWiring.test.ts
+++ b/apps/web/lib/byokWiring.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+
+describe("BYOK integrations wiring", () => {
+  test("uses api.users provider-key functions, not a byok module", () => {
+    const page = readFileSync("apps/web/app/(tempo)/settings/integrations/page.tsx", "utf8");
+    expect(page).toContain("api.users.getProviderKey");
+    expect(page).toContain("api.users.saveProviderKey");
+    expect(page).not.toContain("api.byok.");
+  });
+});

--- a/convex/lib/accountDeletion.test.ts
+++ b/convex/lib/accountDeletion.test.ts
@@ -22,6 +22,7 @@ describe("USER_OWNED_TABLES", () => {
         "habits",
         "memories",
         "notes",
+        "providerKeys",
         "taskRepeatCfgs",
         "tasks",
       ].sort(),

--- a/convex/lib/accountDeletion.ts
+++ b/convex/lib/accountDeletion.ts
@@ -10,6 +10,7 @@ export const USER_OWNED_TABLES = [
   "memories",
   "calendarEvents",
   "taskRepeatCfgs",
+  "providerKeys",
 ] as const;
 
 type UserOwnedTable = (typeof USER_OWNED_TABLES)[number];

--- a/convex/lib/providerKeys.test.ts
+++ b/convex/lib/providerKeys.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeProviderKeyInput } from "./providerKeys";
+
+describe("normalizeProviderKeyInput", () => {
+  test("trims a saved provider key before storage", () => {
+    expect(normalizeProviderKeyInput("  tfk_test_saved_key  ")).toBe("tfk_test_saved_key");
+  });
+
+  test("rejects short provider keys", () => {
+    expect(() => normalizeProviderKeyInput(" short ")).toThrow(/at least 8 characters/i);
+  });
+});

--- a/convex/lib/providerKeys.ts
+++ b/convex/lib/providerKeys.ts
@@ -1,0 +1,82 @@
+import { v } from "convex/values";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { requireUser } from "./requireUser";
+
+export const providerValidator = v.union(v.literal("mistral"));
+export type ProviderId = "mistral";
+
+export const providerKeyReturnValidator = v.union(
+  v.object({
+    provider: providerValidator,
+    apiKey: v.string(),
+    updatedAt: v.number(),
+  }),
+  v.null(),
+);
+
+export function normalizeProviderKeyInput(apiKey: string): string {
+  const trimmed = apiKey.trim();
+  if (trimmed.length < 8) {
+    throw new Error("Provider key should be at least 8 characters.");
+  }
+  return trimmed;
+}
+
+export async function getProviderKeyForUser(
+  ctx: QueryCtx,
+  provider: ProviderId,
+): Promise<{ provider: ProviderId; apiKey: string; updatedAt: number } | null> {
+  const user = await requireUser(ctx);
+  const key = await ctx.db
+    .query("providerKeys")
+    .withIndex("by_userId_provider", (q) => q.eq("userId", user._id).eq("provider", provider))
+    .unique();
+
+  if (!key || key.deletedAt !== undefined) {
+    return null;
+  }
+
+  return {
+    provider: key.provider,
+    apiKey: key.apiKey,
+    updatedAt: key.updatedAt,
+  };
+}
+
+export async function saveProviderKeyForUser(
+  ctx: MutationCtx,
+  args: { provider: ProviderId; apiKey: string },
+): Promise<{ provider: ProviderId; apiKey: string; updatedAt: number }> {
+  const user = await requireUser(ctx);
+  const apiKey = normalizeProviderKeyInput(args.apiKey);
+  const now = Date.now();
+
+  const existing = await ctx.db
+    .query("providerKeys")
+    .withIndex("by_userId_provider", (q) =>
+      q.eq("userId", user._id).eq("provider", args.provider),
+    )
+    .unique();
+
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      apiKey,
+      deletedAt: undefined,
+      updatedAt: now,
+    });
+  } else {
+    await ctx.db.insert("providerKeys", {
+      userId: user._id,
+      provider: args.provider,
+      apiKey,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  return {
+    provider: args.provider,
+    apiKey,
+    updatedAt: now,
+  };
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -272,4 +272,16 @@ export default defineSchema({
     .index("by_userId", ["userId"])
     .index("by_userId_status", ["userId", "status"])
     .index("by_userId_deletedAt", ["userId", "deletedAt"]),
+
+  providerKeys: defineTable({
+    userId: v.id("users"),
+    provider: v.union(v.literal("mistral")),
+    apiKey: v.string(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+    deletedAt: v.optional(v.number()),
+  })
+    .index("by_userId", ["userId"])
+    .index("by_userId_provider", ["userId", "provider"])
+    .index("by_userId_deletedAt", ["userId", "deletedAt"]),
 });

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -4,6 +4,12 @@ import type { QueryCtx } from "./_generated/server";
 import { internalMutation, mutation, query } from "./_generated/server";
 import { isInactiveAccount, softDeleteUserAccount } from "./lib/accountDeletion";
 import { buildReturningUserPatch, newUserFields } from "./lib/entitlements";
+import {
+  getProviderKeyForUser,
+  providerKeyReturnValidator,
+  providerValidator,
+  saveProviderKeyForUser,
+} from "./lib/providerKeys";
 import { requireUser, resolveUserFromIdentity } from "./lib/requireUser";
 import { assertClientMaySetUserType } from "./lib/subscriptionGuards";
 
@@ -196,5 +202,24 @@ export const deleteMyAccount = mutation({
     const user = await requireUser(ctx);
     const { deletedCount } = await softDeleteUserAccount(ctx, user._id);
     return { success: true, deletedCount };
+  },
+});
+
+export const getProviderKey = query({
+  args: { provider: providerValidator },
+  returns: providerKeyReturnValidator,
+  handler: async (ctx, args) => {
+    return await getProviderKeyForUser(ctx, args.provider);
+  },
+});
+
+export const saveProviderKey = mutation({
+  args: {
+    provider: providerValidator,
+    apiKey: v.string(),
+  },
+  returns: providerKeyReturnValidator,
+  handler: async (ctx, args) => {
+    return await saveProviderKeyForUser(ctx, args);
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the unique leftover from #213 onto current `integration` (`6ed4fd4`). Integrations settings saves a Mistral-compatible provider key on a new `providerKeys` table. Public API is `api.users.getProviderKey` / `api.users.saveProviderKey` because committed `api.d.ts` has no `byok` module. `USER_OWNED_TABLES` includes `providerKeys` so account deletion soft-deletes stored keys.

**Secrets + account-deletion STOP.** Required CI is green. Auto-arm skipped. **Leave draft. Do not merge.**

Skipped from #213: `bun.lock`, `package.json`, `playwright.config.ts`, `tests/e2e/byok-settings.spec.ts`, `convex/_generated/api.d.ts`.

## Linked task(s)

Leftover from #213. `docs/brain/TASKS.md` is a private submodule in this clone — no invented T-XXXX.

## Screenshots / screen recording

N/A — authenticated save/test not exercised (no live Convex). Unauthenticated route is auth-gated.

## Test plan

- [x] Local unit tests for normalize / mask / wiring / USER_OWNED_TABLES
- [x] `apps/web` typecheck clean for the new page
- [x] CI Typecheck / Lint / Test / Scans / secret scans / E2E green
- [x] Stayed draft after green; auto-arm skipped

## Acceptance criteria

- Keys trim and reject inputs shorter than 8 characters
- UI masks saved keys (`abcd...wxyz`) and does not print them
- Mock provider route returns 401 without a Bearer header
- Soft-deleted keys are omitted from `getProviderKey`
- Account deletion covers `providerKeys`
- No secrets committed

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] AI-originated state changes: N/A — user pastes their own key
- [x] Schema: `providerKeys` has userId, timestamps, deletedAt, indexes
- [x] Styling: existing shadcn + tokens
- [x] Accessibility: labeled password field, sign-in link
- [x] No secrets committed; tests use dummy placeholders only
- [x] Voice: calm copy, no shame

## Owner tag (§14)

- [x] `cursor-cloud-2`

## Reviewer

Amit (`human-amit`). **Do not merge.**

## STOP

Do not mark ready. Do not enable auto-merge. Leave #213 open until this lands by Amit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

