### PR TITLE
feat(auth): gated e2e test sign-in leftover from #336 [DO NOT MERGE]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,11 @@ RESEND_API_KEY=
 # Use a verified Resend domain in production, e.g. "Tempo Flow <no-reply@yourdomain.com>".
 RESEND_FROM_EMAIL=
 
+# E2E-only email OTP provider leftover from #336. Set exactly one email on
+# dev/preview Convex deployments. Unset or empty means the provider is not
+# registered. Never set this on production.
+E2E_TEST_AUTH_EMAIL=
+
 # ----------------------------------------------------------------------------
 # Beta gating (set in Convex dashboard env vars; NOT in Vercel / Next.js)
 # scope: [convex dashboard]

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,9 +1,16 @@
+import { ConvexCredentials } from "@convex-dev/auth/providers/ConvexCredentials";
 import { Email } from "@convex-dev/auth/providers/Email";
 import { Password } from "@convex-dev/auth/providers/Password";
-import { convexAuth } from "@convex-dev/auth/server";
+import { convexAuth, createAccount } from "@convex-dev/auth/server";
 import type { GenericMutationCtx } from "convex/server";
 import type { DataModel, Id } from "./_generated/dataModel";
 import { isInactiveAccount } from "./lib/accountDeletion";
+import {
+  E2E_TEST_AUTH_PROVIDER_ID,
+  isE2eTestAuthAuthorized,
+  readE2eTestAuthEmail,
+  shouldRegisterE2eTestAuthProvider,
+} from "./lib/e2eTestAuth";
 import {
   buildReturningUserPatch,
   GRANTED_SUBSCRIPTION,
@@ -15,6 +22,31 @@ type AppDb = GenericMutationCtx<DataModel>["db"];
 
 function normalizeEmail(email: string | undefined | null): string {
   return (email ?? "").trim().toLowerCase();
+}
+
+function getE2eTestAuthProvider() {
+  const e2eTestAuthEmail = readE2eTestAuthEmail();
+  if (!shouldRegisterE2eTestAuthProvider(e2eTestAuthEmail)) {
+    return [];
+  }
+
+  return [
+    ConvexCredentials({
+      id: E2E_TEST_AUTH_PROVIDER_ID,
+      authorize: async (params, ctx) => {
+        if (!isE2eTestAuthAuthorized(params, e2eTestAuthEmail)) {
+          return null;
+        }
+
+        const { user } = await createAccount(ctx, {
+          provider: E2E_TEST_AUTH_PROVIDER_ID,
+          account: { id: e2eTestAuthEmail },
+          profile: { email: e2eTestAuthEmail, emailVerified: true },
+        });
+        return { userId: user._id };
+      },
+    }),
+  ];
 }
 
 async function sendMagicLinkEmail({
@@ -101,6 +133,7 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
       maxAge: 60 * 30,
       sendVerificationRequest: sendMagicLinkEmail,
     }),
+    ...getE2eTestAuthProvider(),
   ],
   session: {
     totalDurationMs: 30 * 24 * 60 * 60 * 1000,

--- a/convex/lib/e2eTestAuth.test.ts
+++ b/convex/lib/e2eTestAuth.test.ts
@@ -21,7 +21,9 @@ describe("e2eTestAuth", () => {
 
   test("readE2eTestAuthEmail trims and lowercases a configured address", () => {
     expect(
-      readE2eTestAuthEmail({ E2E_TEST_AUTH_EMAIL: " Tester@Example.com " }),
+      readE2eTestAuthEmail({
+        E2E_TEST_AUTH_EMAIL: " Tester@Example.com ",
+      } satisfies { [key: string]: string | undefined }),
     ).toBe("tester@example.com");
     expect(shouldRegisterE2eTestAuthProvider("tester@example.com")).toBe(true);
   });

--- a/convex/lib/e2eTestAuth.test.ts
+++ b/convex/lib/e2eTestAuth.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import {
+  E2E_TEST_AUTH_CODE,
+  E2E_TEST_AUTH_PROVIDER_ID,
+  isE2eTestAuthAuthorized,
+  normalizeE2eTestAuthEmail,
+  readE2eTestAuthEmail,
+  shouldRegisterE2eTestAuthProvider,
+} from "./e2eTestAuth";
+
+describe("e2eTestAuth", () => {
+  test("provider id stays stable for Playwright sign-in", () => {
+    expect(E2E_TEST_AUTH_PROVIDER_ID).toBe("e2e-test-email");
+  });
+
+  test("readE2eTestAuthEmail treats missing or blank env as unset", () => {
+    expect(readE2eTestAuthEmail({})).toBe("");
+    expect(readE2eTestAuthEmail({ E2E_TEST_AUTH_EMAIL: "   " })).toBe("");
+    expect(shouldRegisterE2eTestAuthProvider("")).toBe(false);
+  });
+
+  test("readE2eTestAuthEmail trims and lowercases a configured address", () => {
+    expect(
+      readE2eTestAuthEmail({ E2E_TEST_AUTH_EMAIL: " Tester@Example.com " }),
+    ).toBe("tester@example.com");
+    expect(shouldRegisterE2eTestAuthProvider("tester@example.com")).toBe(true);
+  });
+
+  test("authorize requires the exact configured email and fixed code", () => {
+    const expected = normalizeE2eTestAuthEmail("tester@example.com");
+
+    expect(
+      isE2eTestAuthAuthorized(
+        { email: "tester@example.com", code: E2E_TEST_AUTH_CODE },
+        expected,
+      ),
+    ).toBe(true);
+    expect(
+      isE2eTestAuthAuthorized(
+        { email: "other@example.com", code: E2E_TEST_AUTH_CODE },
+        expected,
+      ),
+    ).toBe(false);
+    expect(
+      isE2eTestAuthAuthorized(
+        { email: "tester@example.com", code: "000000" },
+        expected,
+      ),
+    ).toBe(false);
+    expect(
+      isE2eTestAuthAuthorized(
+        { email: "tester@example.com", code: E2E_TEST_AUTH_CODE },
+        "",
+      ),
+    ).toBe(false);
+  });
+});

--- a/convex/lib/e2eTestAuth.ts
+++ b/convex/lib/e2eTestAuth.ts
@@ -1,0 +1,35 @@
+/** Convex Auth provider id for the gated e2e sign-in path leftover from #336. */
+export const E2E_TEST_AUTH_PROVIDER_ID = "e2e-test-email";
+
+/** Fixed verification code accepted only when the provider is registered. */
+export const E2E_TEST_AUTH_CODE = "123456";
+
+export function normalizeE2eTestAuthEmail(
+  email: string | undefined | null,
+): string {
+  return (email ?? "").trim().toLowerCase();
+}
+
+export function readE2eTestAuthEmail(
+  env: { E2E_TEST_AUTH_EMAIL?: string } = process.env,
+): string {
+  return normalizeE2eTestAuthEmail(env.E2E_TEST_AUTH_EMAIL);
+}
+
+export function shouldRegisterE2eTestAuthProvider(email: string): boolean {
+  return email.length > 0;
+}
+
+export function isE2eTestAuthAuthorized(
+  params: { email?: unknown; code?: unknown },
+  expectedEmail: string,
+): boolean {
+  if (!shouldRegisterE2eTestAuthProvider(expectedEmail)) {
+    return false;
+  }
+  const email =
+    typeof params.email === "string"
+      ? normalizeE2eTestAuthEmail(params.email)
+      : "";
+  return email === expectedEmail && params.code === E2E_TEST_AUTH_CODE;
+}

--- a/convex/lib/e2eTestAuth.ts
+++ b/convex/lib/e2eTestAuth.ts
@@ -10,9 +10,9 @@ export function normalizeE2eTestAuthEmail(
   return (email ?? "").trim().toLowerCase();
 }
 
-export function readE2eTestAuthEmail(
-  env: { E2E_TEST_AUTH_EMAIL?: string } = process.env,
-): string {
+type PublicEnv = { [key: string]: string | undefined };
+
+export function readE2eTestAuthEmail(env: PublicEnv = process.env): string {
   return normalizeE2eTestAuthEmail(env.E2E_TEST_AUTH_EMAIL);
 }
 

--- a/tests/e2e/auth.ts
+++ b/tests/e2e/auth.ts
@@ -1,0 +1,38 @@
+import type { Page } from "@playwright/test";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../../convex/_generated/api";
+import { E2E_TEST_AUTH_CODE, E2E_TEST_AUTH_PROVIDER_ID } from "../../convex/lib/e2eTestAuth";
+
+const e2eTestAuthEmail = process.env.E2E_TEST_AUTH_EMAIL?.trim().toLowerCase();
+const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+
+export async function signInWithE2eTestEmail(page: Page) {
+  if (!e2eTestAuthEmail || !convexUrl) {
+    throw new Error("E2E test auth is not configured.");
+  }
+
+  const client = new ConvexHttpClient(convexUrl);
+  const result = await client.action(api.auth.signIn, {
+    provider: E2E_TEST_AUTH_PROVIDER_ID,
+    params: { email: e2eTestAuthEmail, code: E2E_TEST_AUTH_CODE },
+  });
+  const tokens = result.tokens;
+  if (!tokens?.token || !tokens.refreshToken) {
+    throw new Error("E2E test sign-in did not return tokens.");
+  }
+
+  const namespace = convexUrl.replace(/[^a-z0-9]/gi, "");
+  await page.addInitScript(
+    ({ jwt, namespace: authNamespace, refreshToken }) => {
+      window.localStorage.setItem(`__convexAuthJWT_${authNamespace}`, jwt);
+      window.localStorage.setItem(
+        `__convexAuthRefreshToken_${authNamespace}`,
+        refreshToken,
+      );
+    },
+    { jwt: tokens.token, namespace, refreshToken: tokens.refreshToken },
+  );
+
+  await page.goto("/today");
+  await page.waitForURL(/\/today(?:\?|$)/);
+}

--- a/tests/e2e/test-auth.spec.ts
+++ b/tests/e2e/test-auth.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+import { signInWithE2eTestEmail } from "./auth";
+
+test.skip(
+  !process.env.E2E_TEST_AUTH_EMAIL || !process.env.NEXT_PUBLIC_CONVEX_URL,
+  "E2E test auth requires E2E_TEST_AUTH_EMAIL and NEXT_PUBLIC_CONVEX_URL.",
+);
+
+test("E2E test email completes sign-in", async ({ page }) => {
+  await signInWithE2eTestEmail(page);
+
+  await expect(page.getByRole("main").getByRole("heading", { name: "Today" })).toBeVisible();
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the unique leftover from #336 onto current `integration` auth: a ConvexCredentials provider that exists only when `E2E_TEST_AUTH_EMAIL` is non-empty, accepts that exact address plus a fixed verification code, and returns a real Convex Auth session.

**STOP — AUTH.** Draft. MERGEABLE/CLEAN. Required CI green on `1180567`. Auto-arm skipped. I will not merge this.

Skipped from #336:
- Beta allowlist / seat cap (would undo #348 open signup)
- Rebase of the original #336 (it is not draft; rebasing would let auto-arm merge an auth backdoor)

Existing Playwright `TEMPO_E2E_AUTH_BYPASS` is unchanged. The live-Convex sign-in spec skips unless both env vars are set.

## Linked task(s)

Leftover from #336. `docs/brain/TASKS.md` is not readable in this clone (private submodule).

## Screenshots / screen recording

N/A — no user-visible surface. Provider is env-gated and off unless configured.

## Test plan

- [x] `bun test ./convex/lib/e2eTestAuth.test.ts` — 4 pass
- [x] `apps/mobile` and `apps/web` `tsc --noEmit` clean locally after env-bag fix
- [x] CI Typecheck, Lint, Test, Scans, notices, gitleaks, trufflehog, E2E, Vercel on `1180567`
- [ ] Authenticated live-Convex sign-in not verified here (env must stay unset in this workspace)

## Acceptance criteria

- Provider is not registered when `E2E_TEST_AUTH_EMAIL` is missing or blank
- Authorize requires the configured email and the fixed code
- Open signup / max-tier entitlements on `createOrUpdateUser` stay as landed
- Draft until Amit reviews

## HARD_RULES compliance checklist

- [x] No forbidden tech added
- [x] No AI-originated user-state writes
- [x] No schema change
- [x] No styling
- [x] No a11y surface
- [x] No secrets committed; empty `E2E_TEST_AUTH_EMAIL=` documented in `.env.example`
- [x] No shame copy

## Owner tag (§14)

- [x] `cursor-cloud-3`

## Reviewer

Amit (`human-amit`). Do not merge. Do not mark ready.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

