### PR TITLE
test(today): Monday week start and half-open week windows leftover from #53

### DIFF
--- a/apps/web/lib/localDay.test.ts
+++ b/apps/web/lib/localDay.test.ts
@@ -15,10 +15,12 @@ describe("startOfLocalDayMs / endOfLocalDayMs", () => {
   });
 
   test("start aligns to local midnight", () => {
-    const sample = new Date(2026, 5, 18, 23, 59, 59);
+    const sample = new Date(2026, 5, 18, 23, 59, 59, 999);
     const start = new Date(startOfLocalDayMs(sample));
     expect(start.getHours()).toBe(0);
     expect(start.getMinutes()).toBe(0);
+    expect(start.getSeconds()).toBe(0);
+    expect(start.getMilliseconds()).toBe(0);
     expect(start.getDate()).toBe(18);
   });
 });
@@ -38,6 +40,14 @@ describe("startOfLocalWeekMondayMs", () => {
     expect(monday.getDay()).toBe(1);
     expect(monday.getDate()).toBe(15);
   });
+
+  test("Monday stays on the same calendar Monday", () => {
+    const monday = new Date(2026, 5, 15, 9, 30, 0);
+    const mondayStart = new Date(startOfLocalWeekMondayMs(monday));
+    expect(mondayStart.getDay()).toBe(1);
+    expect(mondayStart.getDate()).toBe(15);
+    expect(mondayStart.getHours()).toBe(0);
+  });
 });
 
 describe("endOfLocalWeekMondayMs", () => {
@@ -46,5 +56,11 @@ describe("endOfLocalWeekMondayMs", () => {
     expect(endOfLocalWeekMondayMs(sample) - startOfLocalWeekMondayMs(sample)).toBe(
       7 * 24 * 60 * 60 * 1000,
     );
+  });
+
+  test("consecutive weeks do not overlap", () => {
+    const week1End = endOfLocalWeekMondayMs(new Date(2026, 5, 17, 12, 0, 0));
+    const week2Start = startOfLocalWeekMondayMs(new Date(2026, 5, 22, 12, 0, 0));
+    expect(week1End).toBe(week2Start);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports the unique `localDay` week-window tests from #53 / #110 that are not on `integration`: Monday stays on the same calendar Monday, consecutive weeks meet at a half-open `[start, end)` boundary, and local midnight zeros seconds/milliseconds.

SKIPPED from #53 / #110: `betaAccess` allowlist (would undo #348 open signup / max tier). RevenueCat mapping is already `revenuecat_events.ts`.

## Linked task(s)

No in-repo `T-XXXX` (`docs/brain/` is a private empty submodule in this cloud clone). Leftover from open FIX #53 / #110.

## Screenshots / screen recording

N/A — no user-visible surface.

## Test plan

- [x] Local `bun test ./apps/web/lib/localDay.test.ts` — 7 pass
- [ ] CI Typecheck / Lint / Test

## Acceptance criteria

- Monday local-week start stays on that Monday.
- Adjacent weeks share the exclusive end / inclusive start boundary.
- `betaAccess` is not reintroduced.

## HARD_RULES compliance checklist

- [x] No forbidden tech added (§2)
- [x] No AI-originated state changes
- [x] No schema changes
- [x] No styling
- [x] No a11y surface
- [x] No secrets
- [x] Voice rules N/A (tests only)

## Owner tag (§14)

- [x] `cursor-cloud-3`

## Reviewer

Amit (`human-amit`). Low-risk test leftover; merge once CI is green.

## Graph vs task

`docs/brain/TASKS.md` is unreadable here. Landed `localDay` already had day/week helpers; this only adds the missing assertions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c50130cf-02fd-4838-b7fb-2e663a4d0e14&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

